### PR TITLE
refactor(driver)!: drop Cloudflare naming/coupling from the boot contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM cloudflare/sandbox:0.10.3
+# Sandbox base image. Defaults to Cloudflare's sandbox (what Mosoo runs on),
+# but the Driver Kernel itself is sandbox-neutral — override at build time with
+# `--build-arg SANDBOX_BASE_IMAGE=...` to run the driver on a different base.
+ARG SANDBOX_BASE_IMAGE=cloudflare/sandbox:0.10.3
+FROM ${SANDBOX_BASE_IMAGE}
 
-# Keep this image version in sync with apps/api/package.json -> @cloudflare/sandbox.
+# Keep the default base image version in sync with apps/api/package.json -> @cloudflare/sandbox.
 ARG CLAUDE_AGENT_SDK_VERSION=0.3.158
 ARG ANTHROPIC_SDK_VERSION=0.100.1
 ARG OPENAI_RUNTIME_VERSION=0.135.0

--- a/src/protocol/boot/host-snapshot.ts
+++ b/src/protocol/boot/host-snapshot.ts
@@ -36,12 +36,12 @@ export interface DriverSpaceAliasBinding {
 }
 
 export interface DriverExecutionSessionContext {
-  readonly cloudflareSessionId: SandboxSessionId;
   readonly homePath: string;
   readonly organizationAccessSnapshot: DriverOrganizationAccessSnapshotOutput;
   readonly origin: DriverOrigin;
   readonly sandboxId: SandboxId;
   readonly sandboxKind: string;
+  readonly sandboxSessionId: SandboxSessionId;
   readonly sandboxSubjectId: DriverId;
   readonly sandboxSubjectKind: string;
   readonly sessionOrganizationPath: string;
@@ -157,10 +157,6 @@ export function readExecutionSessionContext(value: unknown): DriverExecutionSess
   const record = readRecord(value, "execution.session.context");
 
   return {
-    cloudflareSessionId: parseId(
-      record["cloudflareSessionId"],
-      "Driver execution Cloudflare session ID",
-    ) as SandboxSessionId,
     homePath: readNonEmptyString(record, "homePath", "execution.session.context"),
     organizationAccessSnapshot: readOrganizationAccessSnapshot(
       record["organizationAccessSnapshot"],
@@ -168,6 +164,10 @@ export function readExecutionSessionContext(value: unknown): DriverExecutionSess
     origin: readOrigin(record["origin"]),
     sandboxId: parseId(record["sandboxId"], "Driver execution sandbox ID") as SandboxId,
     sandboxKind: readNonEmptyString(record, "sandboxKind", "execution.session.context"),
+    sandboxSessionId: parseId(
+      record["sandboxSessionId"],
+      "Driver execution sandbox session ID",
+    ) as SandboxSessionId,
     sandboxSubjectId: parseId(record["sandboxSubjectId"], "Driver execution sandbox subject ID"),
     sandboxSubjectKind: readNonEmptyString(
       record,

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -7,12 +7,12 @@ import { DRIVER_CONTROL_PORT_MIN } from "../src/protocol/boot";
 export const DRIVER_TEST_IDS = {
   agentId: "01J00000000000000000000009",
   callerAccountId: "01J00000000000000000000001",
-  cloudflareSessionId: "01J0000000000000000000000E",
   driverInstanceId: "01J0000000000000000000000F",
   environmentId: "01J00000000000000000000010",
   environmentRevisionId: "01J00000000000000000000011",
   runId: "01J00000000000000000000012",
   sandboxId: "01J0000000000000000000000D",
+  sandboxSessionId: "01J0000000000000000000000E",
   secondRunId: "01J00000000000000000000013",
   sessionId: "01J00000000000000000000008",
   spaceId: "01J00000000000000000000014",
@@ -43,7 +43,6 @@ export const driverBootPayload = {
     session: {
       additionalDirectories: [],
       context: {
-        cloudflareSessionId: DRIVER_TEST_IDS.cloudflareSessionId,
         homePath: "/tmp/home",
         organizationAccessSnapshot: {
           entries: [],
@@ -56,6 +55,7 @@ export const driverBootPayload = {
         },
         sandboxId: DRIVER_TEST_IDS.sandboxId,
         sandboxKind: "cattle",
+        sandboxSessionId: DRIVER_TEST_IDS.sandboxSessionId,
         sandboxSubjectId: DRIVER_TEST_IDS.sessionId,
         sandboxSubjectKind: "session",
         sessionOrganizationPath: "/tmp/organization",


### PR DESCRIPTION
## What

Removes the two Cloudflare couplings in the otherwise sandbox-neutral Driver Kernel:

1. **Rename `cloudflareSessionId` → `sandboxSessionId`** in the boot contract (`DriverExecutionSessionContext`, parser, and the boot-payload test fixture). The field type was already the neutral `SandboxSessionId`, and the boot context already carries a `sandboxKind` discriminator — only the field *name* leaked the origin. A non-Cloudflare host no longer has to populate a Cloudflare-named field.
2. **Make the Docker base image overridable** via `ARG SANDBOX_BASE_IMAGE` (default unchanged: `cloudflare/sandbox:0.10.3`). Build on a different base with `--build-arg SANDBOX_BASE_IMAGE=...`.

## Breaking change

Boot payload `execution.session.context` now requires `sandboxSessionId` instead of `cloudflareSessionId`. The host (Mosoo) must emit the new key. Safe to land now since the contract isn't published/stable yet.

## Verification

- `bun run tc` ✅  · `bun run lint` ✅ (0 errors) · `bun run build` ✅ (types emit `sandboxSessionId`)
- `bun test`: this change adds **no** new failures.

## ⚠️ Pre-existing red tests (not from this PR)

`main` already has **2 failing assertions** in `tests/driver-artifact-contract.test.ts`, from earlier commits that weren't synced with this contract test:
- `license` assertion expects `"UNLICENSED"` but `package.json` is now `"Apache-2.0"` (from `chore(driver): set package license to Apache-2.0`).
- README assertions (`"The core product is the Driver Kernel"`, `"CMA is a compatibility surface"`) no longer match the rewritten README.

I left these for the maintainers since reconciling the README-content contract is a judgment call — happy to fix in a follow-up if you want main green.
