### PR TITLE
feat(runtime): merge advanced provider options at session start

### DIFF
--- a/src/protocol/boot/index.ts
+++ b/src/protocol/boot/index.ts
@@ -1,4 +1,6 @@
 import type { DriverInstanceId } from "../id";
+import type { JsonObject } from "../json";
+import { readJsonObject } from "../json";
 import type { DriverNativeRuntimeRef, DriverRuntime, DriverRuntimeTransport } from "../runtime";
 import {
   isSupportedDriverRuntime,
@@ -136,6 +138,7 @@ export interface DriverExecutionSpec {
   readonly model: string;
   readonly profilePrompt: string;
   readonly provider: string;
+  readonly providerOptions: JsonObject;
   readonly session: DriverExecutionSessionSpec;
   readonly skillCatalog: DriverSkillCatalogEntry[];
   readonly skills: DriverResolvedSkill[];
@@ -338,6 +341,10 @@ function readExecution(value: unknown): DriverExecutionSpec {
     model: readNonEmptyString(record, "model", "execution"),
     profilePrompt: readString(record, "profilePrompt", "execution"),
     provider: readNonEmptyString(record, "provider", "execution"),
+    providerOptions:
+      record["providerOptions"] === undefined
+        ? {}
+        : readJsonObject(record["providerOptions"], "execution.providerOptions"),
     session: readExecutionSession(record["session"]),
     skillCatalog: readArray(record["skillCatalog"], "execution.skillCatalog").map(
       readSkillCatalogEntry,

--- a/src/protocol/execution.ts
+++ b/src/protocol/execution.ts
@@ -33,6 +33,7 @@ export interface DriverExecutionInput {
   readonly environment: DriverExecutionEnvironment;
   readonly model: string;
   readonly provider: string;
+  readonly providerOptions: DriverExecutionSpec["providerOptions"];
   readonly run: DriverExecutionRunInput;
   readonly session: DriverExecutionSessionInput;
   readonly skillCatalog: DriverSkillCatalogEntry[];
@@ -47,6 +48,7 @@ export function createDriverExecutionInputFromBootExecution(
     environment: execution.environment,
     model: execution.model,
     provider: execution.provider,
+    providerOptions: execution.providerOptions,
     run: {
       runId: execution.configRevision.runId,
       sessionId: execution.configRevision.sessionId,

--- a/src/protocol/json.ts
+++ b/src/protocol/json.ts
@@ -1,0 +1,59 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertJsonValue(value: unknown, label: string): asserts value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => {
+      assertJsonValue(entry, `${label}[${index}]`);
+    });
+    return;
+  }
+
+  if (isJsonObject(value)) {
+    for (const [key, entry] of Object.entries(value)) {
+      assertJsonValue(entry, `${label}.${key}`);
+    }
+    return;
+  }
+
+  throw new TypeError(`${label} must be JSON-serializable.`);
+}
+
+function cloneJsonValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(cloneJsonValue);
+  }
+
+  if (isJsonObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneJsonValue(entry)]),
+    );
+  }
+
+  return value;
+}
+
+export function readJsonObject(value: unknown, label: string): JsonObject {
+  if (!isJsonObject(value)) {
+    throw new TypeError(`${label} must be a JSON object.`);
+  }
+
+  assertJsonValue(value, label);
+  return cloneJsonValue(value) as JsonObject;
+}

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -9,9 +9,11 @@ import type {
 
 import { isTruthy } from "../../core/truthiness";
 import type { DriverBootMcpServer } from "../../protocol/boot";
+import type { JsonObject } from "../../protocol/json";
 import type { DriverStartInput } from "../../protocol/start";
 import type { AgentDriverContext } from "../agent-driver-backend";
 import { buildRuntimeChildProcessEnv } from "../child-process-env";
+import { mergeProviderOptions } from "../provider-options";
 import { buildNativeRuntimeSystemPrompt } from "../skill-bootstrap";
 import { readProcessEnvString, stringifyForDisplay } from "./agent-sdk-json";
 export const CLAUDE_CODE_EXECUTABLE_ENV = "MOSOO_CLAUDE_CODE_EXECUTABLE";
@@ -100,6 +102,13 @@ export function resolveClaudeConfigDir(payload: DriverStartInput): string {
   return payload.execution.session.homePath;
 }
 
+export function mergeClaudeQueryOptions<T extends object>(
+  options: T,
+  providerOptions: JsonObject,
+): T {
+  return mergeProviderOptions(options, providerOptions);
+}
+
 export async function createClaudeQueryOptions(input: {
   abortController: AbortController;
   context: AgentDriverContext;
@@ -150,5 +159,5 @@ export async function createClaudeQueryOptions(input: {
     options.resume = input.nativeSessionId;
   }
 
-  return options;
+  return mergeClaudeQueryOptions(options, input.payload.execution.providerOptions);
 }

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -174,6 +174,7 @@ export class OpenAiAppServerClient {
       materializeOpenAiModelProviderConfig({
         env,
         provider: this.#payload.execution.provider,
+        providerOptions: this.#payload.execution.providerOptions,
         runtimeHome,
       }),
     );

--- a/src/runtimes/openai/auth-state.ts
+++ b/src/runtimes/openai/auth-state.ts
@@ -2,6 +2,9 @@ import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { isTruthy } from "../../core/truthiness";
+import type { JsonObject, JsonValue } from "../../protocol/json";
+import { isJsonObject } from "../../protocol/json";
+import { mergeProviderOptions } from "../provider-options";
 interface OpenAiApiKeyAuthStateInput {
   env: NodeJS.ProcessEnv;
   runtimeHome: string;
@@ -16,6 +19,7 @@ interface OpenAiApiKeyAuthStateResult {
 interface OpenAiModelProviderConfigInput {
   env: NodeJS.ProcessEnv;
   provider: string;
+  providerOptions?: JsonObject;
   runtimeHome: string;
 }
 
@@ -42,6 +46,74 @@ function readEnvVar(env: NodeJS.ProcessEnv, key: string): string | null {
 
 function toTomlString(value: string): string {
   return JSON.stringify(value);
+}
+
+function toTomlKeySegment(value: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(value) ? value : toTomlString(value);
+}
+
+function toTomlInlineValue(value: JsonValue, path: string): string {
+  if (value === null) {
+    throw new Error(`OpenAI provider option ${path} cannot be null in config.toml.`);
+  }
+
+  if (typeof value === "string") {
+    return toTomlString(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry, index) => toTomlInlineValue(entry, `${path}[${index}]`)).join(", ")}]`;
+  }
+
+  return `{ ${Object.entries(value)
+    .map(
+      ([key, entry]) => `${toTomlKeySegment(key)} = ${toTomlInlineValue(entry, `${path}.${key}`)}`,
+    )
+    .join(", ")} }`;
+}
+
+function isTomlTable(value: unknown): value is JsonObject {
+  return isJsonObject(value);
+}
+
+function appendTomlObject(
+  lines: string[],
+  object: Record<string, JsonValue>,
+  path: string[] = [],
+): void {
+  if (path.length > 0) {
+    if (lines.length > 0 && lines.at(-1) !== "") {
+      lines.push("");
+    }
+
+    lines.push(`[${path.map(toTomlKeySegment).join(".")}]`);
+  }
+
+  const nestedEntries: [string, JsonObject][] = [];
+
+  for (const [key, value] of Object.entries(object)) {
+    if (isTomlTable(value)) {
+      nestedEntries.push([key, value]);
+    } else {
+      lines.push(
+        `${toTomlKeySegment(key)} = ${toTomlInlineValue(value, [...path, key].join("."))}`,
+      );
+    }
+  }
+
+  for (const [key, value] of nestedEntries) {
+    appendTomlObject(lines, value, [...path, key]);
+  }
+}
+
+function stringifyToml(object: Record<string, JsonValue>): string {
+  const lines: string[] = [];
+  appendTomlObject(lines, object);
+  return `${lines.join("\n")}\n`;
 }
 
 async function writeFileIfChanged(
@@ -114,12 +186,9 @@ export async function materializeOpenAiModelProviderConfig(
   input: OpenAiModelProviderConfigInput,
 ): Promise<OpenAiModelProviderConfigResult> {
   const configTomlPath = join(input.runtimeHome, "config.toml");
-
-  const lines = [
-    "[features]",
-    ...DISABLED_RUNTIME_FEATURES.map((feature) => `${feature} = false`),
-    "",
-  ];
+  const generatedConfig: Record<string, JsonValue> = {
+    features: Object.fromEntries(DISABLED_RUNTIME_FEATURES.map((feature) => [feature, false])),
+  };
 
   if (input.provider === OPENAI_COMPATIBLE_PROVIDER_ID) {
     const apiKey = readEnvVar(input.env, OPENAI_COMPATIBLE_API_KEY_ENV_NAME);
@@ -131,20 +200,21 @@ export async function materializeOpenAiModelProviderConfig(
       );
     }
 
-    lines.unshift(
-      `model_provider = ${toTomlString(input.provider)}`,
-      "",
-      `[model_providers.${toTomlString(input.provider)}]`,
-      'name = "Mosoo OpenAI-Compatible"',
-      `base_url = ${toTomlString(baseUrl)}`,
-      `env_key = ${toTomlString(OPENAI_COMPATIBLE_API_KEY_ENV_NAME)}`,
-      'wire_api = "responses"',
-      "",
-    );
+    generatedConfig["model_provider"] = input.provider;
+    generatedConfig["model_providers"] = {
+      [input.provider]: {
+        base_url: baseUrl,
+        env_key: OPENAI_COMPATIBLE_API_KEY_ENV_NAME,
+        name: "Mosoo OpenAI-Compatible",
+        wire_api: "responses",
+      },
+    };
   }
 
+  const config = mergeProviderOptions(generatedConfig, input.providerOptions ?? {});
+
   await mkdir(input.runtimeHome, { recursive: true });
-  const written = await writeFileIfChanged(configTomlPath, lines.join("\n"));
+  const written = await writeFileIfChanged(configTomlPath, stringifyToml(config));
 
   return {
     configTomlPath,

--- a/src/runtimes/provider-options.ts
+++ b/src/runtimes/provider-options.ts
@@ -1,0 +1,43 @@
+import type { JsonObject, JsonValue } from "../protocol/json";
+import { isJsonObject } from "../protocol/json";
+
+function cloneJsonValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(cloneJsonValue);
+  }
+
+  if (isJsonObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneJsonValue(entry)]),
+    );
+  }
+
+  return value;
+}
+
+function isMergeableRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepMergeRecords(
+  base: Record<string, unknown>,
+  providerOptions: JsonObject,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+
+  for (const [key, value] of Object.entries(providerOptions)) {
+    const current = result[key];
+
+    if (isMergeableRecord(current) && isJsonObject(value)) {
+      result[key] = deepMergeRecords(current, value);
+    } else {
+      result[key] = cloneJsonValue(value);
+    }
+  }
+
+  return result;
+}
+
+export function mergeProviderOptions<T extends object>(base: T, providerOptions: JsonObject): T {
+  return deepMergeRecords(base as Record<string, unknown>, providerOptions) as T;
+}

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { mergeClaudeQueryOptions } from "../src/runtimes/claude/agent-sdk-query-options";
+
+describe("Claude Agent SDK query options", () => {
+  test("deep-merges advanced provider options into generated query options", () => {
+    const base = {
+      env: {
+        BASE: "1",
+      },
+      mcpServers: {
+        linear: {
+          headers: {
+            Authorization: "Bearer generated",
+          },
+          type: "http",
+          url: "https://mcp-proxy.example/linear",
+        },
+      },
+      model: "claude-sonnet-4",
+      permissionMode: "default",
+      persistSession: true,
+    };
+
+    const merged = mergeClaudeQueryOptions(base, {
+      env: {
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: "4096",
+      },
+      mcpServers: {
+        linear: {
+          headers: {
+            "X-Debug": "enabled",
+          },
+        },
+      },
+      permissionMode: "acceptEdits",
+    });
+
+    expect(merged).toEqual({
+      env: {
+        BASE: "1",
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: "4096",
+      },
+      mcpServers: {
+        linear: {
+          headers: {
+            Authorization: "Bearer generated",
+            "X-Debug": "enabled",
+          },
+          type: "http",
+          url: "https://mcp-proxy.example/linear",
+        },
+      },
+      model: "claude-sonnet-4",
+      permissionMode: "acceptEdits",
+      persistSession: true,
+    });
+    expect(base.env).toEqual({ BASE: "1" });
+  });
+});

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -42,7 +42,7 @@ describe("driver artifact contract", () => {
     expect(packageJson.private).toBe(false);
     expect(packageJson.version).toBe("0.1.0");
     expect(packageJson.description).toContain("Agent Driver");
-    expect(packageJson.license).toBe("UNLICENSED");
+    expect(packageJson.license).toBe("Apache-2.0");
     expect(packageJson.packageManager).toBe("bun@1.3.14");
     expect(packageJson.bin).toEqual({
       "agent-driver": "./dist/driver.mjs",
@@ -200,8 +200,8 @@ describe("driver artifact contract", () => {
   test("documents the standalone release boundary", () => {
     const readme = readText("../README.md");
 
-    expect(readme).toContain("The core product is the Driver Kernel");
-    expect(readme).toContain("CMA is a compatibility surface");
+    expect(readme).toContain("The core product is the **Driver Kernel**");
+    expect(readme).toContain("CMA (the Anthropic Managed Agents compatibility surface)");
     expect(readme).toContain("Every public entry has a matching declaration file");
     expect(readme).toContain("agent-driver/boot");
     expect(readme).toContain("agent-driver/events");

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -40,6 +40,7 @@ export const driverBootPayload = {
     model: "model-1",
     profilePrompt: "",
     provider: "provider-1",
+    providerOptions: {},
     session: {
       additionalDirectories: [],
       context: {

--- a/tests/openai-app-server-auth-state.test.ts
+++ b/tests/openai-app-server-auth-state.test.ts
@@ -72,6 +72,17 @@ describe("OpenAI app-server auth state", () => {
         OPENAI_COMPATIBLE_BASE_URL: "https://compat.example/v1",
       },
       provider: "openai-compatible",
+      providerOptions: {
+        features: {
+          tool_suggest: true,
+        },
+        model_providers: {
+          "openai-compatible": {
+            wire_api: "chat",
+          },
+        },
+        sandbox_workspace_write: true,
+      },
       runtimeHome,
     });
 
@@ -84,9 +95,14 @@ describe("OpenAI app-server auth state", () => {
       base_url: "https://compat.example/v1",
       env_key: "OPENAI_COMPATIBLE_API_KEY",
       name: "Mosoo OpenAI-Compatible",
-      wire_api: "responses",
+      wire_api: "chat",
     });
-    expectDisabledRuntimeFeatures(config);
+    expect(requireRecord(config["features"], "runtime features")).toMatchObject({
+      plugins: false,
+      remote_plugin: false,
+      tool_suggest: true,
+    });
+    expect(config["sandbox_workspace_write"]).toBe(true);
   });
 
   test("writes generated config for built-in OpenAI auth", async () => {


### PR DESCRIPTION
Summary:
- Carries providerOptions through the driver execution input.
- Deep-merges providerOptions into Claude SDK query options and OpenAI config.toml.
- Covers driver merge behavior with tests.

Tests:
- bun test tests