### PR TITLE
feat(runtime): use capability access snapshots

### DIFF
--- a/src/infrastructure/logging/driver-debug-paths.ts
+++ b/src/infrastructure/logging/driver-debug-paths.ts
@@ -143,18 +143,17 @@ export function summarizePathCollection(
 export function summarizeAppAccessSnapshot(
   snapshot: DriverAppAccessSnapshotOutput,
 ): Record<string, unknown> {
-  const roleCounts = {
-    admin: 0,
-    edit: 0,
-    read: 0,
-  };
   const typeCounts = {
     root: 0,
     space: 0,
   };
+  let writableEntryCount = 0;
 
   for (const entry of snapshot.entries) {
-    roleCounts[entry.role] += 1;
+    if (entry.canWrite) {
+      writableEntryCount += 1;
+    }
+
     typeCounts[entry.type] += 1;
   }
 
@@ -166,8 +165,8 @@ export function summarizeAppAccessSnapshot(
             JSON.stringify(
               snapshot.entries
                 .map((entry) => ({
+                  canWrite: entry.canWrite,
                   mountPath: entry.mountPath,
-                  role: entry.role,
                   spaceId: entry.spaceId,
                   type: entry.type,
                 }))
@@ -175,8 +174,8 @@ export function summarizeAppAccessSnapshot(
             ),
           )
         : null,
-    roleCounts,
     typeCounts,
+    writableEntryCount,
   };
 }
 

--- a/src/protocol/boot/host-snapshot.ts
+++ b/src/protocol/boot/host-snapshot.ts
@@ -14,6 +14,7 @@ import {
   parseId,
   parseNullableId,
   readArray,
+  readBoolean,
   readNonEmptyString,
   readNumber,
   readRecord,
@@ -104,20 +105,15 @@ export function readAppAccessSnapshot(value: unknown): DriverAppAccessSnapshotOu
     ).map((entry, index) => {
       const label = `execution.session.context.appAccessSnapshot.entries[${index}]`;
       const entryRecord = readRecord(entry, label);
-      const role = readNonEmptyString(entryRecord, "role", label);
       const type = readNonEmptyString(entryRecord, "type", label);
-
-      if (role !== "admin" && role !== "edit" && role !== "read") {
-        throw new TypeError(`${label}.role must be admin, edit, or read.`);
-      }
 
       if (type !== "space") {
         throw new TypeError(`${label}.type must be space.`);
       }
 
       return {
+        canWrite: readBoolean(entryRecord, "canWrite", label),
         mountPath: readNonEmptyString(entryRecord, "mountPath", label),
-        role,
         spaceId: parseId(entryRecord["spaceId"], `${label}.spaceId`) as SpaceId,
         type,
       };

--- a/src/protocol/boot/readers.ts
+++ b/src/protocol/boot/readers.ts
@@ -65,6 +65,20 @@ export function readNumber(record: Record<string, unknown>, field: string, label
   return value;
 }
 
+export function readBoolean(
+  record: Record<string, unknown>,
+  field: string,
+  label: string,
+): boolean {
+  const value = record[field];
+
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${label}.${field} must be a boolean.`);
+  }
+
+  return value;
+}
+
 export function readInteger(record: Record<string, unknown>, field: string, label: string): number {
   const value = readNumber(record, field, label);
 

--- a/src/runtime-command/index.ts
+++ b/src/runtime-command/index.ts
@@ -23,8 +23,8 @@ export interface RuntimeCommandInput {
 }
 
 export interface DriverAppAccessSnapshotEntry {
+  readonly canWrite: boolean;
   readonly mountPath: string;
-  readonly role: "admin" | "edit" | "read";
   readonly spaceId: string;
   readonly type: "space";
 }
@@ -173,6 +173,16 @@ function readOptionalString(record: Record<string, unknown>, field: string): str
   return value;
 }
 
+function readBoolean(record: Record<string, unknown>, field: string): boolean {
+  const value = record[field];
+
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${field} must be a boolean.`);
+  }
+
+  return value;
+}
+
 function readStringArray(record: Record<string, unknown>, field: string): string[] | undefined {
   const value = record[field];
 
@@ -197,14 +207,6 @@ function readRuntimeCommandInput(value: unknown): RuntimeCommandInput {
   };
 }
 
-function readAccessRole(value: unknown): DriverAppAccessSnapshotEntry["role"] {
-  if (value === "admin" || value === "edit" || value === "read") {
-    return value;
-  }
-
-  throw new TypeError("appAccessSnapshot.entries[].role must be admin, edit, or read.");
-}
-
 function readAppAccessSnapshotEntry(value: unknown): DriverAppAccessSnapshotEntry {
   const record = readRecord(value, "appAccessSnapshot.entries[]");
   const type = readNonEmptyString(record, "type");
@@ -214,8 +216,8 @@ function readAppAccessSnapshotEntry(value: unknown): DriverAppAccessSnapshotEntr
   }
 
   return {
+    canWrite: readBoolean(record, "canWrite"),
     mountPath: readNonEmptyString(record, "mountPath"),
-    role: readAccessRole(record["role"]),
     spaceId: readNonEmptyString(record, "spaceId"),
     type,
   };

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -77,8 +77,8 @@ export const driverBootPayload = {
 export const driverTestAccessSnapshot = {
   entries: [
     {
+      canWrite: true,
       mountPath: "/workspace/docs",
-      role: "read",
       spaceId: DRIVER_TEST_IDS.spaceId,
       type: "space",
     },

--- a/tests/fixtures/driver/commands/access-refresh.json
+++ b/tests/fixtures/driver/commands/access-refresh.json
@@ -4,8 +4,8 @@
   "appAccessSnapshot": {
     "entries": [
       {
+        "canWrite": true,
         "mountPath": "/workspace",
-        "role": "read",
         "spaceId": "space-1",
         "type": "space"
       }


### PR DESCRIPTION
## Summary

- replace `appAccessSnapshot.entries[].role` with fail-closed `canWrite: boolean` parsing
- update boot payload parsing and debug snapshot summaries to use capability payloads
- update driver test fixtures and access refresh command fixture

## Verification

- `bun run tc`
- `bun run lint`
- `git diff --check`
- `bun test tests/driver-golden-fixtures.test.ts tests/read-driver-boot-payload.test.ts tests/driver-runtime-boundary.test.ts tests/agent-driver-kernel.test.ts`

## Parent Mosoo PR

- Root stacked PR: https://github.com/langgenius/mosoo/pull/24
