### PR TITLE
feat(openai): wire MCP servers into the Codex runtime via config.toml

### DIFF
--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -23,6 +23,7 @@ import {
   materializeOpenAiApiKeyAuthState,
   materializeOpenAiModelProviderConfig,
 } from "./auth-state";
+import { buildOpenAiMcpServerConfig } from "./mcp-config";
 import type {
   ClientRequestMethod,
   ClientRequestParams,
@@ -159,8 +160,10 @@ export class OpenAiAppServerClient {
     const runtimeHome = homePath;
     await measure("app_server.home.mkdir", () => mkdir(runtimeHome, { recursive: true }));
 
+    const mcpConfig = buildOpenAiMcpServerConfig(this.#payload.execution.session.mcpServers);
     const env = buildRuntimeChildProcessEnv({
       ...this.#payload.execution.environment.variables,
+      ...mcpConfig.env,
       [OPENAI_RUNTIME_HOME_ENV_NAME]: runtimeHome,
       LOG_FORMAT: "json",
     });
@@ -173,6 +176,7 @@ export class OpenAiAppServerClient {
     const modelProviderConfig = await measure("app_server.config", () =>
       materializeOpenAiModelProviderConfig({
         env,
+        mcpServers: mcpConfig.mcpServers,
         provider: this.#payload.execution.provider,
         providerOptions: this.#payload.execution.providerOptions,
         runtimeHome,
@@ -185,6 +189,7 @@ export class OpenAiAppServerClient {
     });
     this.#context.logger.debug("driver.openai.model_provider_config.prepared", {
       configTomlWritten: modelProviderConfig.written,
+      mcpServerCount: Object.keys(mcpConfig.mcpServers).length,
       provider: modelProviderConfig.provider,
     });
     this.#context.logger.debug("driver.openai.env.prepared", {

--- a/src/runtimes/openai/auth-state.ts
+++ b/src/runtimes/openai/auth-state.ts
@@ -18,6 +18,7 @@ interface OpenAiApiKeyAuthStateResult {
 
 interface OpenAiModelProviderConfigInput {
   env: NodeJS.ProcessEnv;
+  mcpServers?: Record<string, JsonValue>;
   provider: string;
   providerOptions?: JsonObject;
   runtimeHome: string;
@@ -209,6 +210,10 @@ export async function materializeOpenAiModelProviderConfig(
         wire_api: "responses",
       },
     };
+  }
+
+  if (input.mcpServers !== undefined && Object.keys(input.mcpServers).length > 0) {
+    generatedConfig["mcp_servers"] = input.mcpServers;
   }
 
   const config = mergeProviderOptions(generatedConfig, input.providerOptions ?? {});

--- a/src/runtimes/openai/mcp-config.ts
+++ b/src/runtimes/openai/mcp-config.ts
@@ -1,0 +1,72 @@
+import type { AuthorizedDriverBootMcpServer, DriverBootMcpServer } from "../../protocol/boot";
+import type { JsonValue } from "../../protocol/json";
+
+export interface OpenAiMcpServerConfig {
+  /**
+   * Bearer-token environment variables to inject into the app-server child
+   * process. Referenced from config.toml via `bearer_token_env_var` so the
+   * short-lived proxy grant never lands on disk.
+   */
+  readonly env: Record<string, string>;
+  /**
+   * `[mcp_servers.<name>]` tables to merge into the generated config.toml. Each
+   * entry points the OpenAI runtime at the host MCP proxy over streamable HTTP.
+   */
+  readonly mcpServers: Record<string, JsonValue>;
+}
+
+function isAuthorized(server: DriverBootMcpServer): server is AuthorizedDriverBootMcpServer {
+  return server.authorizationState === "active";
+}
+
+function toMcpServerKey(server: DriverBootMcpServer, usedNames: Set<string>): string {
+  const baseName = server.name.trim() || server.serverId;
+  let candidate = baseName;
+  let suffix = 2;
+
+  while (usedNames.has(candidate)) {
+    candidate = `${baseName}-${suffix}`;
+    suffix += 1;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
+}
+
+function toBearerTokenEnvName(index: number): string {
+  return `MOSOO_MCP_BEARER_TOKEN_${index}`;
+}
+
+/**
+ * Translate authorized boot MCP servers into the OpenAI runtime (Codex)
+ * `config.toml` shape. Only `authorizationState === "active"` servers are
+ * wired; unavailable servers are skipped, mirroring the Claude and ACP
+ * backends. The proxy grant is passed through a dedicated environment variable
+ * rather than inlined into config.toml.
+ */
+export function buildOpenAiMcpServerConfig(
+  servers: readonly DriverBootMcpServer[],
+): OpenAiMcpServerConfig {
+  const usedNames = new Set<string>();
+  const mcpServers: Record<string, JsonValue> = {};
+  const env: Record<string, string> = {};
+  let index = 0;
+
+  for (const server of servers) {
+    if (!isAuthorized(server)) {
+      continue;
+    }
+
+    const key = toMcpServerKey(server, usedNames);
+    const bearerTokenEnvName = toBearerTokenEnvName(index);
+    index += 1;
+
+    env[bearerTokenEnvName] = server.proxyGrantId;
+    mcpServers[key] = {
+      bearer_token_env_var: bearerTokenEnvName,
+      url: server.proxyUrl,
+    };
+  }
+
+  return { env, mcpServers };
+}

--- a/tests/openai-app-server-auth-state.test.ts
+++ b/tests/openai-app-server-auth-state.test.ts
@@ -124,6 +124,50 @@ describe("OpenAI app-server auth state", () => {
     expectDisabledRuntimeFeatures(config);
   });
 
+  test("writes mcp_servers tables into the generated config", async () => {
+    const runtimeHome = await createRuntimeHome();
+
+    const result = await materializeOpenAiModelProviderConfig({
+      env: {
+        OPENAI_API_KEY: "openai-key",
+      },
+      mcpServers: {
+        Linear: {
+          bearer_token_env_var: "MOSOO_MCP_BEARER_TOKEN_0",
+          url: "https://api.example/driver/mcp/proxy/server-1",
+        },
+      },
+      provider: "openai",
+      runtimeHome,
+    });
+
+    expect(result.written).toBe(true);
+    const config = await readGeneratedConfig(result.configTomlPath);
+    const mcpServers = requireRecord(config["mcp_servers"], "mcp servers");
+
+    expect(mcpServers["Linear"]).toEqual({
+      bearer_token_env_var: "MOSOO_MCP_BEARER_TOKEN_0",
+      url: "https://api.example/driver/mcp/proxy/server-1",
+    });
+    expectDisabledRuntimeFeatures(config);
+  });
+
+  test("omits mcp_servers when no servers are wired", async () => {
+    const runtimeHome = await createRuntimeHome();
+
+    const result = await materializeOpenAiModelProviderConfig({
+      env: {
+        OPENAI_API_KEY: "openai-key",
+      },
+      mcpServers: {},
+      provider: "openai",
+      runtimeHome,
+    });
+
+    const config = await readGeneratedConfig(result.configTomlPath);
+    expect(config["mcp_servers"]).toBeUndefined();
+  });
+
   test("skips unchanged generated config writes", async () => {
     const runtimeHome = await createRuntimeHome();
     const input = {

--- a/tests/openai-app-server-mcp-config.test.ts
+++ b/tests/openai-app-server-mcp-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  AuthorizedDriverBootMcpServer,
+  DriverBootMcpServer,
+  UnavailableDriverBootMcpServer,
+} from "../src/protocol/boot";
+import type { CredentialId, McpServerId } from "../src/protocol/boot/host-ids";
+import { buildOpenAiMcpServerConfig } from "../src/runtimes/openai/mcp-config";
+
+function authorizedServer(
+  overrides: Partial<AuthorizedDriverBootMcpServer> = {},
+): AuthorizedDriverBootMcpServer {
+  return {
+    authType: "oauth",
+    authorizationState: "active",
+    credentialId: "cred-1" as CredentialId,
+    credentialScope: "app",
+    credentialStatus: "active",
+    name: "Linear",
+    proxyGrantId: "grant-token",
+    proxyUrl: "https://api.example/driver/mcp/proxy/server-1",
+    serverId: "server-1" as McpServerId,
+    ...overrides,
+  };
+}
+
+function unavailableServer(): UnavailableDriverBootMcpServer {
+  return {
+    authType: "oauth",
+    authorizationState: "authorization_required",
+    credentialScope: "app",
+    credentialStatus: "expired",
+    name: "Notion",
+    serverId: "server-unavailable" as McpServerId,
+  };
+}
+
+describe("buildOpenAiMcpServerConfig", () => {
+  test("wires authorized servers to the HTTP proxy via a token env var", () => {
+    const config = buildOpenAiMcpServerConfig([authorizedServer()]);
+
+    expect(config.mcpServers).toEqual({
+      Linear: {
+        bearer_token_env_var: "MOSOO_MCP_BEARER_TOKEN_0",
+        url: "https://api.example/driver/mcp/proxy/server-1",
+      },
+    });
+    expect(config.env).toEqual({ MOSOO_MCP_BEARER_TOKEN_0: "grant-token" });
+  });
+
+  test("skips servers that are not active", () => {
+    const servers: DriverBootMcpServer[] = [unavailableServer()];
+    const config = buildOpenAiMcpServerConfig(servers);
+
+    expect(config.mcpServers).toEqual({});
+    expect(config.env).toEqual({});
+  });
+
+  test("dedupes duplicate names and gives each server a distinct token env var", () => {
+    const config = buildOpenAiMcpServerConfig([
+      authorizedServer({
+        name: "Linear",
+        proxyGrantId: "grant-a",
+        proxyUrl: "https://api.example/driver/mcp/proxy/a",
+        serverId: "server-a" as McpServerId,
+      }),
+      authorizedServer({
+        name: "Linear",
+        proxyGrantId: "grant-b",
+        proxyUrl: "https://api.example/driver/mcp/proxy/b",
+        serverId: "server-b" as McpServerId,
+      }),
+    ]);
+
+    expect(Object.keys(config.mcpServers)).toEqual(["Linear", "Linear-2"]);
+    expect(config.mcpServers["Linear"]).toMatchObject({
+      bearer_token_env_var: "MOSOO_MCP_BEARER_TOKEN_0",
+    });
+    expect(config.mcpServers["Linear-2"]).toMatchObject({
+      bearer_token_env_var: "MOSOO_MCP_BEARER_TOKEN_1",
+    });
+    expect(config.env).toEqual({
+      MOSOO_MCP_BEARER_TOKEN_0: "grant-a",
+      MOSOO_MCP_BEARER_TOKEN_1: "grant-b",
+    });
+  });
+
+  test("falls back to the server id when the name is blank", () => {
+    const config = buildOpenAiMcpServerConfig([
+      authorizedServer({ name: "  ", serverId: "server-7" as McpServerId }),
+    ]);
+
+    expect(Object.keys(config.mcpServers)).toEqual(["server-7"]);
+  });
+});


### PR DESCRIPTION
## What & why

The OpenAI/Codex backend never bridged `session.mcpServers` into the runtime. `config.toml` only carried `features` / `model_provider`, and `thread/start` (`ThreadStartParams`) has no MCP field — so authorized MCP servers were silently dropped for Codex, even though the **Claude** (`options.mcpServers`) and **ACP** (`buildAcpMcpServers`) backends both wired them. This was the gap flagged during the YEF-678 investigation.

It was not a Codex limitation: Codex supports streamable HTTP MCP servers through `config.toml` (`[mcp_servers.<name>]` with `url` + `bearer_token_env_var`, see [openai/codex#4317](https://github.com/openai/codex/pull/4317) / [docs](https://developers.openai.com/codex/mcp)). Our HTTP-proxy MCP model maps onto it directly.

## Changes

- **New** `src/runtimes/openai/mcp-config.ts` — `buildOpenAiMcpServerConfig()` translates each `authorizationState === "active"` boot MCP server into a `[mcp_servers.<name>]` table pointing at the existing host MCP proxy (`proxyUrl`). Unavailable servers are skipped; duplicate names are deduped (mirrors the Claude backend's `toMcpServerKey`).
- The short-lived proxy grant (`proxyGrantId`) is passed through a dedicated env var (`bearer_token_env_var = MOSOO_MCP_BEARER_TOKEN_<n>`) injected into the app-server child process, so the token is **not** written to `config.toml` on disk.
- `materializeOpenAiModelProviderConfig()` accepts an optional `mcpServers` map and emits it under `mcp_servers` before the `providerOptions` deep-merge (so user-supplied servers still compose).
- `app-server-client.ts` computes the config at boot, merges the token env vars into the child env, and logs `mcpServerCount`.

After this, Codex connects to the proxy itself and emits tools as `mcpToolCall` items, which the driver's `event-translator` already handles — the only missing piece was telling Codex which servers exist.

## Tests

- New `tests/openai-app-server-mcp-config.test.ts`: active wiring, skipping unavailable servers, name dedup + distinct token env vars, blank-name fallback to `serverId`.
- Extended `tests/openai-app-server-auth-state.test.ts`: `mcp_servers` tables land in `config.toml`; omitted when no servers are wired.

## Checks

`bun run lint`, `bun run tc`, `bun test` (150 pass / 1 skip), `bun run build` — all green.
