### PR TITLE
feat(runtime): bypass tool approval for headless runs via MOSOO_DRIVER_AUTO_APPROVE_TOOLS

### DIFF
--- a/src/runtimes/auto-approve-tools.ts
+++ b/src/runtimes/auto-approve-tools.ts
@@ -1,0 +1,14 @@
+import type { DriverStartInput } from "../protocol/start";
+
+// Headless consumers (Public Thread API, web apps) cannot answer interactive
+// tool-confirmation prompts: the public event stream does not carry the
+// requestId needed to approve, so a tool-heavy agent would otherwise stall
+// waiting for an approval that can never arrive. An Agent whose Environment sets
+// MOSOO_DRIVER_AUTO_APPROVE_TOOLS=1 opts every tool call into auto-approval so it
+// can run unattended. The Sandbox is already the isolation boundary, so this is
+// a per-Agent trust decision, not a global one.
+export const AUTO_APPROVE_TOOLS_ENV = "MOSOO_DRIVER_AUTO_APPROVE_TOOLS";
+
+export function shouldAutoApproveTools(payload: DriverStartInput): boolean {
+  return payload.execution.environment.variables[AUTO_APPROVE_TOOLS_ENV] === "1";
+}

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -12,13 +12,19 @@ import type { DriverBootMcpServer } from "../../protocol/boot";
 import type { JsonObject } from "../../protocol/json";
 import type { DriverStartInput } from "../../protocol/start";
 import type { AgentDriverContext } from "../agent-driver-backend";
+import { shouldAutoApproveTools } from "../auto-approve-tools";
 import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import { mergeProviderOptions } from "../provider-options";
 import { buildNativeRuntimeSystemPrompt } from "../skill-bootstrap";
 import { readProcessEnvString, stringifyForDisplay } from "./agent-sdk-json";
 export const CLAUDE_CODE_EXECUTABLE_ENV = "MOSOO_CLAUDE_CODE_EXECUTABLE";
 
-function createCanUseTool(context: AgentDriverContext): CanUseTool {
+function createCanUseTool(
+  context: AgentDriverContext,
+  payload: DriverStartInput,
+): CanUseTool {
+  const autoApproveTools = shouldAutoApproveTools(payload);
+
   return async (toolName, input, options): Promise<PermissionResult> => {
     if (options.signal.aborted) {
       return {
@@ -26,6 +32,14 @@ function createCanUseTool(context: AgentDriverContext): CanUseTool {
         interrupt: true,
         message: "Permission request was aborted.",
         toolUseID: options.toolUseID,
+      };
+    }
+
+    if (autoApproveTools) {
+      return {
+        behavior: "allow",
+        toolUseID: options.toolUseID,
+        updatedInput: input,
       };
     }
 
@@ -123,7 +137,7 @@ export async function createClaudeQueryOptions(input: {
   const options: ClaudeQueryOptions = {
     abortController: input.abortController,
     additionalDirectories: input.payload.execution.session.additionalDirectories,
-    canUseTool: createCanUseTool(input.context),
+    canUseTool: createCanUseTool(input.context, input.payload),
     cwd: input.payload.execution.session.cwd,
     env: toClaudeEnv(input.payload, claudeConfigDir),
     includePartialMessages: true,

--- a/src/runtimes/openai/app-server-driver-backend.ts
+++ b/src/runtimes/openai/app-server-driver-backend.ts
@@ -16,6 +16,7 @@ import type { DriverRuntime } from "../../protocol/runtime";
 import type { DriverStartInput } from "../../protocol/start";
 import type { McpExecuteCommand, RuntimeCommandInput } from "../../runtime-command";
 import type { AgentDriverBackend, AgentDriverContext } from "../agent-driver-backend";
+import { shouldAutoApproveTools } from "../auto-approve-tools";
 import { DriverEventPublisher } from "../driver-event-publisher";
 import {
   buildNativeRuntimeSystemPrompt,
@@ -36,7 +37,12 @@ import type {
 
 const OPENAI_RUNTIME_APPROVAL_POLICY = "on-request" satisfies ApprovalPolicy;
 
+function resolveOpenAiApprovalPolicy(payload: DriverStartInput): ApprovalPolicy {
+  return shouldAutoApproveTools(payload) ? "never" : OPENAI_RUNTIME_APPROVAL_POLICY;
+}
+
 interface OpenAiTurnStartInput {
+  readonly approvalPolicy: ApprovalPolicy;
   readonly cwd: string;
   readonly model: string;
   readonly text: string;
@@ -70,7 +76,7 @@ function isTerminalOpenAiTurnStatus(status: TurnStatus | undefined): boolean {
 
 export function createOpenAiTurnStartParams(input: OpenAiTurnStartInput): TurnStartParams {
   return {
-    approvalPolicy: OPENAI_RUNTIME_APPROVAL_POLICY,
+    approvalPolicy: input.approvalPolicy,
     cwd: input.cwd,
     input: [
       {
@@ -177,7 +183,7 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
     const developerInstructions = buildNativeRuntimeSystemPrompt(this.#payload.execution);
     const nativeResumeThreadId = readOpenAiNativeResumeThreadId(this.#payload);
     const baseThreadParams = {
-      approvalPolicy: OPENAI_RUNTIME_APPROVAL_POLICY,
+      approvalPolicy: resolveOpenAiApprovalPolicy(this.#payload),
       cwd: this.#payload.execution.session.cwd,
       model: this.#payload.execution.model,
       modelProvider: this.#payload.execution.provider,
@@ -274,6 +280,7 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
       turnResult = await client.request(
         "turn/start",
         createOpenAiTurnStartParams({
+          approvalPolicy: resolveOpenAiApprovalPolicy(this.#payload),
           cwd: this.#payload.execution.session.cwd,
           model: this.#payload.execution.model,
           text: input.text,

--- a/tests/openai-app-server-turn-start.test.ts
+++ b/tests/openai-app-server-turn-start.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, test } from "bun:test";
 import { createOpenAiTurnStartParams } from "../src/runtimes/openai/app-server-driver-backend";
 
 describe("OpenAI app-server turn start params", () => {
-  test("carries runtime policy with every user turn", () => {
+  test("carries the provided approval policy with every user turn", () => {
     expect(
       createOpenAiTurnStartParams({
+        approvalPolicy: "on-request",
         cwd: "/workspace",
         model: "gpt-5.4",
         text: "Run pwd",
@@ -24,5 +25,17 @@ describe("OpenAI app-server turn start params", () => {
       model: "gpt-5.4",
       threadId: "thread-1",
     });
+  });
+
+  test("forwards the auto-approve (never) policy for headless turns", () => {
+    expect(
+      createOpenAiTurnStartParams({
+        approvalPolicy: "never",
+        cwd: "/workspace",
+        model: "gpt-5.4",
+        text: "Run pwd",
+        threadId: "thread-1",
+      }).approvalPolicy,
+    ).toBe("never");
   });
 });


### PR DESCRIPTION
## What

Adds an opt-in environment switch — `MOSOO_DRIVER_AUTO_APPROVE_TOOLS` — that lets an Agent run tool calls without the interactive approval prompt, in **both** the Claude and OpenAI/Codex runtimes.

## Why

Headless callers (the Public Thread API, web apps) cannot answer the interactive tool-confirmation prompt: the public event stream does not carry the `requestId` needed to approve a tool call. A tool-using agent therefore stalls, waiting for an approval that can never arrive.

## How

A shared helper (`src/runtimes/auto-approve-tools.ts`) reads `MOSOO_DRIVER_AUTO_APPROVE_TOOLS` from the Agent's execution environment. When it is `1`:

- **Claude runtime** — `createCanUseTool` returns `behavior: "allow"` for every tool call (the abort guard still runs first).
- **OpenAI/Codex runtime** — the thread-start and turn-start approval policy resolves to `"never"` instead of `"on-request"`.

The Sandbox remains the isolation boundary, so this is a per-Agent trust decision rather than a global one. Default behavior is unchanged when the variable is unset.

## Test plan

- `bun run tc` — passes.
- `bun test` — 151 pass / 0 fail. Updated `createOpenAiTurnStartParams` coverage to the new contract and added a case asserting the `never` policy forwards through for headless turns.
