### PR TITLE
test(openai): add live app-server smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Copy this file to .env and fill only the values you need.
+# Do not commit real API keys.
+
+# OpenAI live smoke test.
+# just live-openai uses AGENT_DRIVER_LIVE_OPENAI_API_KEY first, then OPENAI_API_KEY.
+AGENT_DRIVER_LIVE_OPENAI_API_KEY=
+AGENT_DRIVER_LIVE_OPENAI_MODEL=gpt-5.4
+OPENAI_API_KEY=
+
+# OpenAI-compatible provider support.
+OPENAI_COMPATIBLE_API_KEY=
+OPENAI_COMPATIBLE_BASE_URL=
+
+# Optional OpenAI runtime executable override. Uncomment only when needed.
+# MOSOO_OPENAI_RUNTIME_EXECUTABLE=/path/to/codex
+
+# Anthropic live smoke test.
+# just live-anthropic uses AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY first, then ANTHROPIC_API_KEY.
+AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY=
+AGENT_DRIVER_LIVE_ANTHROPIC_MODEL=claude-sonnet-4-5
+ANTHROPIC_API_KEY=
+
+# Optional Claude executable override. Uncomment only when needed.
+# MOSOO_CLAUDE_CODE_EXECUTABLE=/path/to/mosoo-claude-code
+
+# ACP fallback runtime.
+# MOSOO_ACP_FALLBACK_COMMAND=/path/to/acp-agent
+# MOSOO_ACP_FALLBACK_ARGS=["--stdio"]
+# MOSOO_ACP_AUTH_METHOD_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+bun.lock
 dist/
 coverage/
 .env

--- a/justfile
+++ b/justfile
@@ -22,6 +22,9 @@ docker-build:
 live-anthropic:
     bun run test:live:anthropic
 
+live-openai:
+    bun run test:live:openai
+
 clean:
     fd -u -t d -F node_modules . -X rm -rf
     fd -u -t d -F dist . -X rm -rf

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "lint": "vp lint src tests",
     "tc": "vp exec tsc --noEmit",
     "test": "vp exec bun test tests",
-    "test:live:anthropic": "vp exec bun test tests/claude-agent-sdk-live.test.ts"
+    "test:live:anthropic": "vp exec bun test tests/claude-agent-sdk-live.test.ts",
+    "test:live:openai": "vp exec bun test tests/openai-app-server-live.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.158",

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -128,6 +128,11 @@ function summarizeJsonRpcErrorData(value: unknown): JsonObject | null {
 const OPENAI_RUNTIME_HOME_ENV_NAME = ["CODE", "X_HOME"].join("");
 const DEFAULT_OPENAI_RUNTIME_EXECUTABLE = ["co", "dex"].join("");
 
+function readOpenAiRuntimeExecutable(): string {
+  const executable = process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"]?.trim();
+  return executable && executable.length > 0 ? executable : DEFAULT_OPENAI_RUNTIME_EXECUTABLE;
+}
+
 export class OpenAiAppServerClient {
   readonly #context: OpenAiClientContext;
   readonly #pendingRequests = new Map<RequestId, PendingJsonRpcRequest>();
@@ -197,8 +202,7 @@ export class OpenAiAppServerClient {
     });
 
     await measure("app_server.spawn", async () => {
-      const executable =
-        process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] ?? DEFAULT_OPENAI_RUNTIME_EXECUTABLE;
+      const executable = readOpenAiRuntimeExecutable();
       const child = spawn(executable, ["app-server"], {
         cwd: this.#payload.execution.session.cwd,
         env,

--- a/tests/openai-app-server-live.test.ts
+++ b/tests/openai-app-server-live.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
+import { OPENAI_DEFAULT_MODEL_ID } from "../src/models";
+import type { DriverEventInput } from "../src/protocol/events";
+import type { DriverStartInput } from "../src/protocol/start";
+import { AGENT_DRIVER_PROVIDER_REGISTRY } from "../src/runtimes/provider-registry";
+import { DRIVER_TEST_IDS, bootPayload } from "./driver-runtime-boundary-fixtures";
+
+const LIVE_API_KEY_ENV = "AGENT_DRIVER_LIVE_OPENAI_API_KEY";
+const PROVIDER_API_KEY_ENV = "OPENAI_API_KEY";
+const LIVE_MODEL_ENV = "AGENT_DRIVER_LIVE_OPENAI_MODEL";
+const LIVE_TURN_TIMEOUT_MS = 120_000;
+
+const tempRoots: string[] = [];
+
+function logLiveStatus(message: string, details: Record<string, string | number | boolean> = {}): void {
+  const suffix =
+    Object.keys(details).length === 0
+      ? ""
+      : ` ${JSON.stringify(Object.fromEntries(Object.entries(details).toSorted()))}`;
+  console.info(`[live-openai] ${message}${suffix}`);
+}
+
+afterEach(async () => {
+  for (const root of tempRoots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+function readEnvString(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value && value.length > 0 ? value : null;
+}
+
+function readLiveApiKey(): string | null {
+  return readEnvString(LIVE_API_KEY_ENV) ?? readEnvString(PROVIDER_API_KEY_ENV);
+}
+
+function readLiveModel(): string {
+  return readEnvString(LIVE_MODEL_ENV) ?? OPENAI_DEFAULT_MODEL_ID;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function eventPayload(event: DriverEventInput): Record<string, unknown> | null {
+  return isRecord(event.payload) ? event.payload : null;
+}
+
+function textDeltaFrom(event: DriverEventInput): string {
+  if (event.kind !== "message.delta") {
+    return "";
+  }
+
+  const contentDelta = eventPayload(event)?.["contentDelta"];
+  return typeof contentDelta === "string" ? contentDelta : "";
+}
+
+function errorMessageFrom(event: DriverEventInput): string {
+  const error = eventPayload(event)?.["error"];
+
+  if (!isRecord(error)) {
+    return "unknown provider error";
+  }
+
+  const code = typeof error["code"] === "string" ? error["code"] : "unknown";
+  const message = typeof error["message"] === "string" ? error["message"] : "unknown";
+  return `${code}: ${message}`;
+}
+
+function describeCollectedKinds(events: readonly DriverEventInput[]): string {
+  return events.map((event) => event.kind).join(", ");
+}
+
+async function waitForTerminalTurnEvent(input: {
+  events: AsyncIterable<DriverEventInput>;
+  timeoutMs: number;
+}): Promise<DriverEventInput[]> {
+  const collected: DriverEventInput[] = [];
+  const iterator = input.events[Symbol.asyncIterator]();
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let progressId: ReturnType<typeof setInterval> | null = null;
+  let messageDeltaCount = 0;
+  let messageDeltaChars = 0;
+  const startedAtMs = Date.now();
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => resolve("timeout"), input.timeoutMs);
+  });
+  progressId = setInterval(() => {
+    logLiveStatus("still waiting for terminal event", {
+      elapsedMs: Date.now() - startedAtMs,
+      events: collected.length,
+      messageDeltaChars,
+    });
+  }, 10_000);
+
+  try {
+    while (true) {
+      const result = await Promise.race([iterator.next(), timeout]);
+
+      if (result === "timeout") {
+        throw new Error(
+          `Timed out waiting for live driver turn. Collected events: ${describeCollectedKinds(
+            collected,
+          )}`,
+        );
+      }
+
+      if (result.done) {
+        throw new Error(
+          `Driver event stream closed before live turn completed. Collected events: ${describeCollectedKinds(
+            collected,
+          )}`,
+        );
+      }
+
+      collected.push(result.value);
+
+      if (result.value.kind === "message.delta") {
+        const deltaLength = textDeltaFrom(result.value).length;
+        messageDeltaCount += 1;
+        messageDeltaChars += deltaLength;
+
+        if (messageDeltaCount === 1 || messageDeltaCount % 20 === 0) {
+          logLiveStatus("received message delta", {
+            chars: messageDeltaChars,
+            count: messageDeltaCount,
+          });
+        }
+      } else {
+        logLiveStatus("received event", {
+          count: collected.length,
+          kind: result.value.kind,
+        });
+      }
+
+      if (result.value.kind === "run.failed") {
+        throw new Error(`Live driver turn failed: ${errorMessageFrom(result.value)}`);
+      }
+
+      if (result.value.kind === "run.completed") {
+        logLiveStatus("terminal event received", {
+          elapsedMs: Date.now() - startedAtMs,
+          events: collected.length,
+          messageDeltaChars,
+        });
+        return collected;
+      }
+    }
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    if (progressId) {
+      clearInterval(progressId);
+    }
+  }
+}
+
+async function createLiveDriverPaths(): Promise<{
+  cwd: string;
+  homePath: string;
+  sharedRootPath: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "agent-driver-openai-live-"));
+  const homePath = join(root, "home");
+  const sharedRootPath = join(root, "workspace");
+  await Promise.all([
+    mkdir(homePath, { recursive: true }),
+    mkdir(sharedRootPath, { recursive: true }),
+  ]);
+  tempRoots.push(root);
+
+  return {
+    cwd: sharedRootPath,
+    homePath,
+    sharedRootPath,
+  };
+}
+
+function createLiveStartInput(input: {
+  apiKey: string;
+  cwd: string;
+  homePath: string;
+  sharedRootPath: string;
+}): DriverStartInput {
+  return {
+    ...bootPayload,
+    execution: {
+      ...bootPayload.execution,
+      environment: {
+        variables: {
+          ...bootPayload.execution.environment.variables,
+          [PROVIDER_API_KEY_ENV]: input.apiKey,
+        },
+      },
+      model: readLiveModel(),
+      provider: "openai",
+      session: {
+        ...bootPayload.execution.session,
+        additionalDirectories: [],
+        cwd: input.cwd,
+        homePath: input.homePath,
+        mcpServers: [],
+        mountAliases: [],
+        nativeResumeRef: null,
+        sharedRootPath: input.sharedRootPath,
+      },
+      skillCatalog: [],
+      skills: [],
+      systemPrompt: "Reply to the user with exactly one lowercase word: pong. Do not call tools.",
+    },
+    runtime: "openai-runtime",
+    runtimeTransport: "openai-app-server",
+  };
+}
+
+const liveApiKey = readLiveApiKey();
+const liveTest = liveApiKey ? test : test.skip;
+
+describe("OpenAI app-server live provider", () => {
+  liveTest(
+    "sends ping through the driver and receives pong from OpenAI",
+    async () => {
+      expect(liveApiKey).toBeString();
+      logLiveStatus("starting live smoke", {
+        executableOverride: Boolean(readEnvString("MOSOO_OPENAI_RUNTIME_EXECUTABLE")),
+        model: readLiveModel(),
+      });
+      const paths = await createLiveDriverPaths();
+      logLiveStatus("workspace prepared");
+      const kernel = new AgentDriverKernelCore({
+        backendFactory: (input) => AGENT_DRIVER_PROVIDER_REGISTRY.createBackend(input),
+        hostPorts: {
+          skill: {
+            materialize: async () => [],
+          },
+        },
+      });
+      const events = kernel.events();
+      let kernelStarted = false;
+
+      try {
+        logLiveStatus("starting driver kernel");
+        await kernel.start(
+          createLiveStartInput({
+            apiKey: liveApiKey,
+            cwd: paths.cwd,
+            homePath: paths.homePath,
+            sharedRootPath: paths.sharedRootPath,
+          }),
+        );
+        kernelStarted = true;
+        logLiveStatus("driver kernel started");
+
+        const inputText = "ping";
+        logLiveStatus("sending input", {
+          text: inputText,
+        });
+        const dispatch = kernel.dispatch({
+          commandId: "live-openai-input-1",
+          input: {
+            text: inputText,
+          },
+          kind: "input.start",
+          requestId: "live-openai-request-1",
+          runId: DRIVER_TEST_IDS.runId,
+        });
+        logLiveStatus("waiting for terminal event");
+        const turnEvents = await waitForTerminalTurnEvent({
+          events,
+          timeoutMs: LIVE_TURN_TIMEOUT_MS,
+        });
+        const outputText = turnEvents.map(textDeltaFrom).join("").trim().toLowerCase();
+        logLiveStatus("received output", {
+          text: outputText,
+        });
+
+        await expect(dispatch).resolves.toEqual({
+          requestId: "live-openai-request-1",
+        });
+        logLiveStatus("dispatch completed", {
+          outputChars: outputText.length,
+        });
+        expect(outputText).toContain("pong");
+      } finally {
+        if (kernelStarted) {
+          logLiveStatus("stopping driver kernel");
+          await kernel.stop("test.stop").catch(() => {});
+          logLiveStatus("driver kernel stopped");
+        } else {
+          logLiveStatus("driver kernel was not started; skipping stop");
+        }
+      }
+    },
+    LIVE_TURN_TIMEOUT_MS + 5_000,
+  );
+});


### PR DESCRIPTION
### What's changed?

- Add OpenAI app-server live smoke test (`tests/openai-app-server-live.test.ts`)
- Add `test:live:openai` script and `just live-openai` recipe
- Add `.env.example` with live test and provider env vars
- Trim empty `MOSOO_OPENAI_RUNTIME_EXECUTABLE` before falling back to default codex

### Why

- Mirror the existing Anthropic live smoke path so OpenAI/Codex runtime can be validated end-to-end locally

### Test plan

- [x] `bun run tc`
- [x] `just live-openai` with `AGENT_DRIVER_LIVE_OPENAI_API_KEY` or `OPENAI_API_KEY` set