### PR TITLE
fix(openai): order mcp config import

### DIFF
--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -23,7 +23,6 @@ import {
   materializeOpenAiApiKeyAuthState,
   materializeOpenAiModelProviderConfig,
 } from "./auth-state";
-import { buildOpenAiMcpServerConfig } from "./mcp-config";
 import type {
   ClientRequestMethod,
   ClientRequestParams,
@@ -42,6 +41,7 @@ import {
   isServerRequestMethod,
   parseServerNotificationParams,
 } from "./generated/app-server-protocol";
+import { buildOpenAiMcpServerConfig } from "./mcp-config";
 
 interface PendingJsonRpcRequest {
   method: ClientRequestMethod;


### PR DESCRIPTION
### What's changed?

- Reordered the buildOpenAiMcpServerConfig import in app-server-client.ts so runtime imports stay grouped after type imports.

### Why

- Keeps the OpenAI runtime file aligned with lint import ordering without changing behavior.

### Verification

- bun run lint
- bun run tc