### PR TITLE
fix(tests): satisfy strict lint for array sort and promise resolve

### DIFF
--- a/tests/openai-app-server-live.test.ts
+++ b/tests/openai-app-server-live.test.ts
@@ -24,7 +24,7 @@ function logLiveStatus(
   const suffix =
     Object.keys(details).length === 0
       ? ""
-      : ` ${JSON.stringify(Object.fromEntries(Object.entries(details).toSorted()))}`;
+      : ` ${JSON.stringify(Object.fromEntries(Object.entries(details).toSorted((a, b) => a[0].localeCompare(b[0]))))}`;
   console.info(`[live-openai] ${message}${suffix}`);
 }
 

--- a/tests/opencode-acp-contract.test.ts
+++ b/tests/opencode-acp-contract.test.ts
@@ -166,13 +166,21 @@ function createOpenCodeAcpClient(input: {
 
       child.kill("SIGTERM");
       await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          resolve();
+        };
         const timeout = setTimeout(() => {
           child.kill("SIGKILL");
-          resolve();
+          finish();
         }, 2_000);
         child.once("exit", () => {
           clearTimeout(timeout);
-          resolve();
+          finish();
         });
       });
     },

--- a/tests/opencode-acp-live.test.ts
+++ b/tests/opencode-acp-live.test.ts
@@ -58,7 +58,7 @@ function logLiveStatus(
   const suffix =
     Object.keys(details).length === 0
       ? ""
-      : ` ${JSON.stringify(Object.fromEntries(Object.entries(details).toSorted()))}`;
+      : ` ${JSON.stringify(Object.fromEntries(Object.entries(details).toSorted((a, b) => a[0].localeCompare(b[0]))))}`;
   console.info(`[live-opencode] ${message}${suffix}`);
 }
 
@@ -200,7 +200,9 @@ async function withTimeout<T>(input: {
     if (result === "timeout") {
       throw new Error(
         `Timed out waiting for ${input.label}. ${JSON.stringify(
-          Object.fromEntries(Object.entries(input.details).toSorted()),
+          Object.fromEntries(
+            Object.entries(input.details).toSorted((a, b) => a[0].localeCompare(b[0])),
+          ),
         )}`,
       );
     }


### PR DESCRIPTION
## What

Fix three lint violations in the driver test files so they pass the
mosoo repository's stricter shared lint config.

- `require-array-sort-compare`: add a key comparator to the three
  `Object.entries(...).toSorted()` calls in `opencode-acp-live.test.ts`
  and `openai-app-server-live.test.ts`.
- `no-multiple-resolved`: guard the OpenCode ACP `stop()` cleanup promise
  with a `settled` flag so `resolve()` runs at most once.

## Why

The `mosoo` repo lints this submodule's `apps/driver` content with its
own shared config (`config/vite-plus.shared.ts`), which enables
`require-array-sort-compare` and `no-multiple-resolved`. The current
submodule commit fails `mosoo`'s **PR Check / Repository check** on `main`,
breaking CI for every new mosoo PR. This driver repo's own CI is unaffected
and stays green.

## Testing

- `vp lint src tests` — clean
- `vp fmt --check src tests` — clean
- `vp lint apps/driver/tests` under the mosoo strict config — clean
