### PR TITLE
style(driver): format imports and unions to satisfy repository fmt check

### DIFF
--- a/src/infrastructure/logging/driver-debug-paths.ts
+++ b/src/infrastructure/logging/driver-debug-paths.ts
@@ -1,10 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type { DriverBootPayload } from "../../protocol/boot";
-import {
-  isSandboxOrganizationPath,
-  isSandboxSessionPath,
-} from "../../protocol/paths";
+import { isSandboxOrganizationPath, isSandboxSessionPath } from "../../protocol/paths";
 
 type PathKind =
   | "other_absolute"

--- a/src/protocol/boot/host-snapshot.ts
+++ b/src/protocol/boot/host-snapshot.ts
@@ -8,13 +8,7 @@ import type {
   SandboxId,
   SandboxSessionId,
 } from "./host-ids";
-import {
-  parseId,
-  parseNullableId,
-  readNonEmptyString,
-  readNumber,
-  readRecord,
-} from "./readers";
+import { parseId, parseNullableId, readNonEmptyString, readNumber, readRecord } from "./readers";
 
 export interface DriverOrigin {
   readonly callerUserId: AccountId;

--- a/src/runtime-command/index.ts
+++ b/src/runtime-command/index.ts
@@ -76,10 +76,7 @@ export interface McpExecuteCommandResult {
   readonly toolName: string;
 }
 
-export type RuntimeCommandResult =
-  | InputStartCommandResult
-  | McpExecuteCommandResult
-  | null;
+export type RuntimeCommandResult = InputStartCommandResult | McpExecuteCommandResult | null;
 
 export type DriverCapabilityId =
   | "custom_tool_execute"

--- a/tests/agent-driver-kernel.test.ts
+++ b/tests/agent-driver-kernel.test.ts
@@ -5,11 +5,7 @@ import type { DriverEventInput } from "../src/protocol/events";
 import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
 import type { AgentDriverContext } from "../src/runtimes/agent-driver-backend";
 import { driverBootPayload } from "./driver-boot-payload-fixture";
-import {
-  DRIVER_TEST_IDS,
-  bootPayload,
-  createBackend,
-} from "./driver-runtime-boundary-fixtures";
+import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
 describe("AgentDriverKernelCore", () => {
   test("starts from a driver start input without boot transport fields", async () => {

--- a/tests/driver-runtime-boundary-fixtures.ts
+++ b/tests/driver-runtime-boundary-fixtures.ts
@@ -7,10 +7,7 @@ import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
 import type { RuntimeCommand } from "../src/runtime-command";
 import type { AgentDriverBackend, AgentDriverContext } from "../src/runtimes/agent-driver-backend";
 import { createAgentDriverContext } from "../src/runtimes/agent-driver-backend";
-import {
-  DRIVER_TEST_IDS,
-  driverBootPayload,
-} from "./driver-boot-payload-fixture";
+import { DRIVER_TEST_IDS, driverBootPayload } from "./driver-boot-payload-fixture";
 
 export { DRIVER_TEST_IDS };
 


### PR DESCRIPTION
## Summary

Reformat five files so they satisfy the repository formatter (`vp fmt --check`). Pure formatting: collapse import statements and a union type onto single lines per the default print width. No behavior change.

## Why

`langgenius/mosoo` pins this repo as the `apps/driver` submodule and runs `vp fmt --check` over `apps/` in its `Repository check` CI job. The current driver `main` tip has formatting drift in these files, which fails that check on every downstream mosoo PR (e.g. mosoo#66). This mirrors the earlier mosoo fix (#61, "bump agent driver submodule to fix repository lint").

## Verification

- `vp fmt --check` — clean (verified from the mosoo monorepo over `apps/driver`)
- `vp lint src tests` — pass
- `vp exec tsc --noEmit` — pass

## Risk And Blast Radius

- Affected packages: agent-driver (formatting only)
- Affected user flows or APIs: none
- Rollback: revert this commit

## Required Checks

- [x] Commits: `type(scope): subject`, English only
- [x] Diff scoped; no unrelated cleanup
