### PR TITLE
fix(runtime): retry driver event batches

### DIFF
--- a/src/core/agent-driver-kernel.ts
+++ b/src/core/agent-driver-kernel.ts
@@ -1,6 +1,7 @@
 import { createBufferedSinkLogger } from "../observability";
 import type { Logger } from "../observability";
 import type { DriverEventInput } from "../protocol/events";
+import type { DriverEventBatchOutput } from "../protocol/orpc";
 import type { DriverStartInput } from "../protocol/start";
 import type { RunError, RuntimeCommand, RuntimeCommandResult } from "../runtime-command";
 import type {
@@ -139,6 +140,7 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
   readonly #runtimeState = new DriverRuntimeStateMachine();
   #backend: AgentDriverBackend | null = null;
   #payload: DriverStartInput | null = null;
+  #pushedEventSeq = 0;
   #runTask: Promise<void> | null = null;
   #shuttingDown = false;
   #started = false;
@@ -245,10 +247,21 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
     return result.done ? null : result.value;
   }
 
-  async pushEvents(input: { events: DriverEventInput[] }): Promise<void> {
+  async pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput> {
+    const accepted = input.events.map((event) => {
+      this.#pushedEventSeq += 1;
+
+      return {
+        seq: this.#pushedEventSeq,
+        type: event.kind,
+      };
+    });
+
     for (const event of input.events) {
       this.#events.push(event);
     }
+
+    return { accepted };
   }
 
   async start(input: AgentDriverKernelStartInput): Promise<void> {

--- a/src/core/driver-runtime-io.ts
+++ b/src/core/driver-runtime-io.ts
@@ -1,6 +1,7 @@
 import type { DriverEventInput } from "../protocol/events";
 import type { RunId } from "../protocol/id";
 import type {
+  DriverEventBatchOutput,
   DriverFailureInput,
   DriverHeartbeatInput,
   DriverHeartbeatOutput,
@@ -8,7 +9,7 @@ import type {
 import type { RunError, RuntimeCommand, RuntimeCommandResult } from "../runtime-command";
 
 export interface DriverRuntimeEventPort {
-  pushEvents(input: { events: DriverEventInput[] }): Promise<void>;
+  pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput>;
 }
 
 export interface DriverRuntimeCommandPort {

--- a/src/host-ports/index.ts
+++ b/src/host-ports/index.ts
@@ -2,6 +2,7 @@ import type { Logger } from "../observability";
 import type { DriverEventInput } from "../protocol/events";
 import type { DriverExecutionInput } from "../protocol/execution";
 import type { DriverHostIntegrationSnapshot } from "../protocol/host-integration";
+import type { DriverEventBatchOutput } from "../protocol/orpc";
 import type { McpExecuteCommand, RuntimeCommand, RuntimeCommandResult } from "../runtime-command";
 
 export type AgentDriverHostPortName =
@@ -25,7 +26,7 @@ export interface AgentDriverEventSink {
     result?: RuntimeCommandResult;
     status: "accepted" | "cancelled" | "completed" | "failed";
   }): Promise<void>;
-  pushEvents(input: { events: DriverEventInput[] }): Promise<void>;
+  pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput>;
 }
 
 export interface AgentDriverPermissionPort {

--- a/src/infrastructure/runtime/driver-instance-socket.ts
+++ b/src/infrastructure/runtime/driver-instance-socket.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/websocket";
@@ -9,6 +9,7 @@ import { createDriverId, parseDriverId } from "../../protocol/id";
 import type { DriverInstanceId, EventId, SessionId, RunId } from "../../protocol/id";
 import type {
   DriverFailureInput,
+  DriverEventBatchOutput,
   DriverHeartbeatInput,
   DriverHeartbeatOutput,
   DriverHelloInput,
@@ -123,11 +124,12 @@ export class DriverInstanceSocket {
     });
   }
 
-  async pushEvents(input: { events: DriverEventInput[] }): Promise<void> {
-    await this.#requireClient().driver.pushEvents({
+  async pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput> {
+    const sourceEventIdOccurrences = new Map<string, number>();
+    return this.#requireClient().driver.pushEvents({
       driverInstanceId: this.payload.driverInstanceId,
       events: input.events.flatMap((event) =>
-        toDriverEventEnvelopes(this.payload, event, this.#activeRunId),
+        toDriverEventEnvelopes(this.payload, event, this.#activeRunId, sourceEventIdOccurrences),
       ),
     });
   }
@@ -179,7 +181,38 @@ function readSourceEventId(event: DriverEventInput): string {
     return event.sourceEventId ?? event.id;
   }
 
-  return event.sourceEventId ?? randomUUID();
+  return event.sourceEventId ?? createDeterministicSourceEventId(event);
+}
+
+function addSourceEventIdOccurrence(
+  sourceEventId: string,
+  occurrences: Map<string, number>,
+): string {
+  const nextOccurrence = (occurrences.get(sourceEventId) ?? 0) + 1;
+  occurrences.set(sourceEventId, nextOccurrence);
+
+  return nextOccurrence === 1 ? sourceEventId : `${sourceEventId}:${nextOccurrence}`;
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .toSorted()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function createDeterministicSourceEventId(event: DriverEventInput): string {
+  return `sha256:${createHash("sha256").update(stableJson(event)).digest("hex")}`;
 }
 
 function parseRunId(value: string): RunId {
@@ -200,9 +233,13 @@ export function toDriverEventEnvelopes(
   payload: DriverBootPayload,
   event: DriverEventInput,
   activeRunId: RunId | null,
+  sourceEventIdOccurrences = new Map<string, number>(),
 ): DriverEventEnvelope[] {
   const occurredAtMs = readEventOccurredAt(event);
-  const sourceEventId = readSourceEventId(event);
+  const sourceEventId = addSourceEventIdOccurrence(
+    readSourceEventId(event),
+    sourceEventIdOccurrences,
+  );
   const occurredAt = new Date(occurredAtMs).toISOString();
   const runId = readEventRunId(event, activeRunId);
 

--- a/src/runtimes/driver-event-publisher.ts
+++ b/src/runtimes/driver-event-publisher.ts
@@ -1,5 +1,6 @@
 import { summarizeDriverEventBatch } from "../infrastructure/logging/driver-debug";
 import type { DriverEventInput } from "../protocol/events";
+import type { DriverEventReceipt } from "../protocol/orpc";
 import type { DriverRuntime } from "../protocol/runtime";
 import type { AgentDriverContext } from "./agent-driver-backend";
 
@@ -14,8 +15,9 @@ async function settleSendGate(task: Promise<void>): Promise<void> {
 export class DriverEventPublisher {
   readonly #getSessionRef: () => string | null;
   readonly #runtime: DriverRuntime;
-  #sendError: Error | null = null;
   #sendGate: Promise<void> = Promise.resolve();
+  #lastAcceptedSeq = 0;
+  #pendingEvents: DriverEventInput[] = [];
 
   constructor(runtime: DriverRuntime, getSessionRef: () => string | null) {
     this.#getSessionRef = getSessionRef;
@@ -31,18 +33,13 @@ export class DriverEventPublisher {
       return;
     }
 
-    if (this.#sendError) {
-      throw this.#sendError;
-    }
-
     const task = this.#sendAfterPreviousPush(context, reason, events);
     this.#sendGate = settleSendGate(task);
-    try {
-      await task;
-    } catch (error) {
-      this.#sendError = error instanceof Error ? error : new Error("Driver event send failed.");
-      throw error;
-    }
+    await task;
+  }
+
+  lastAcceptedSeq(): number {
+    return this.#lastAcceptedSeq;
   }
 
   async #sendAfterPreviousPush(
@@ -53,23 +50,42 @@ export class DriverEventPublisher {
     try {
       await this.#sendGate;
     } catch {
-      // Previous failure is recorded in #sendError; this keeps concurrent pushes from spawning unhandled rejections.
+      // Failed batches stay in #pendingEvents; the next push retries them before sending new events.
     }
 
+    const batch = [...this.#pendingEvents, ...events];
+
     context.logger.debug("driver.runtime.events.sending", {
+      pendingEventCount: this.#pendingEvents.length,
       reason,
       runtime: this.#runtime,
       sessionRef: this.#getSessionRef(),
-      ...summarizeDriverEventBatch(events),
+      ...summarizeDriverEventBatch(batch),
     });
 
-    await context.ports.eventSink.pushEvents({ events });
+    try {
+      const result = await context.ports.eventSink.pushEvents({ events: batch });
+      this.#rememberAcceptedReceipts(result.accepted);
+      this.#pendingEvents = batch.slice(Math.min(result.accepted.length, batch.length));
 
-    context.logger.debug("driver.runtime.events.sent", {
-      eventCount: events.length,
-      reason,
-      runtime: this.#runtime,
-      sessionRef: this.#getSessionRef(),
-    });
+      context.logger.debug("driver.runtime.events.sent", {
+        acceptedEventCount: result.accepted.length,
+        eventCount: batch.length,
+        lastAcceptedSeq: this.#lastAcceptedSeq,
+        pendingEventCount: this.#pendingEvents.length,
+        reason,
+        runtime: this.#runtime,
+        sessionRef: this.#getSessionRef(),
+      });
+    } catch (error) {
+      this.#pendingEvents = batch;
+      throw error;
+    }
+  }
+
+  #rememberAcceptedReceipts(receipts: readonly DriverEventReceipt[]): void {
+    for (const receipt of receipts) {
+      this.#lastAcceptedSeq = Math.max(this.#lastAcceptedSeq, receipt.seq);
+    }
   }
 }

--- a/tests/driver-event-publisher.test.ts
+++ b/tests/driver-event-publisher.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { createBufferedSinkLogger } from "../src/observability";
+import type { DriverEventInput } from "../src/protocol/events";
+import type { DriverEventBatchOutput } from "../src/protocol/orpc";
+import { createAgentDriverContext } from "../src/runtimes/agent-driver-backend";
+import { DriverEventPublisher } from "../src/runtimes/driver-event-publisher";
+import { bootPayload } from "./driver-runtime-boundary-fixtures";
+
+function createTestLogger() {
+  return createBufferedSinkLogger({
+    level: "debug",
+    service: "driver-event-publisher-test",
+    sink: async () => {},
+  });
+}
+
+function createEvent(kind: "message.started" | "message.completed"): DriverEventInput {
+  return {
+    kind,
+    payload: {
+      messageId: "message-1",
+      ...(kind === "message.started" ? { role: "agent" } : { stopReason: "end_turn" }),
+    },
+  };
+}
+
+function createContext(input: {
+  pushEvents: (events: DriverEventInput[]) => Promise<DriverEventBatchOutput>;
+}) {
+  return createAgentDriverContext({
+    eventSink: {
+      commandUpdate: async () => {},
+      pushEvents: async ({ events }) => input.pushEvents(events),
+    },
+    logger: createTestLogger(),
+    payload: bootPayload,
+    permission: {
+      request: async () => "reject_once",
+    },
+  });
+}
+
+describe("DriverEventPublisher", () => {
+  test("retries a failed batch and advances the accepted seq cursor", async () => {
+    const attempts: DriverEventInput[][] = [];
+    const context = createContext({
+      pushEvents: async (events) => {
+        attempts.push(events);
+
+        if (attempts.length === 1) {
+          throw new Error("socket send failed");
+        }
+
+        return {
+          accepted: events.map((event, index) => ({
+            seq: 40 + index,
+            type: event.kind,
+          })),
+        };
+      },
+    });
+    const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
+    const started = createEvent("message.started");
+    const completed = createEvent("message.completed");
+
+    await expect(publisher.push(context, "first", [started])).rejects.toThrow("socket send failed");
+    await publisher.push(context, "second", [completed]);
+
+    expect(attempts).toEqual([[started], [started, completed]]);
+    expect(publisher.lastAcceptedSeq()).toBe(41);
+  });
+});

--- a/tests/driver-runtime-boundary-fixtures.ts
+++ b/tests/driver-runtime-boundary-fixtures.ts
@@ -66,8 +66,16 @@ export class FakeDriverRuntimeIo implements DriverRuntimeIo {
     this.failedRuns.push(error);
   }
 
-  async pushEvents(input: Parameters<DriverRuntimeIo["pushEvents"]>[0]): Promise<void> {
+  async pushEvents(
+    input: Parameters<DriverRuntimeIo["pushEvents"]>[0],
+  ): ReturnType<DriverRuntimeIo["pushEvents"]> {
     this.pushedEvents.push(input);
+    return {
+      accepted: input.events.map((event, index) => ({
+        seq: index + 1,
+        type: event.kind,
+      })),
+    };
   }
 }
 

--- a/tests/driver-runtime-boundary.test.ts
+++ b/tests/driver-runtime-boundary.test.ts
@@ -83,6 +83,34 @@ describe("driver runtime boundary", () => {
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.thirdRunId);
   });
 
+  test("driver socket creates deterministic source ids for draft event replay", () => {
+    const draft = {
+      kind: "message.started",
+      payload: {
+        messageId: "message-1",
+        role: "agent",
+      },
+    } as const;
+    const occurrences = new Map<string, number>();
+    const [first] = toDriverEventEnvelopes(
+      driverBootPayload,
+      draft,
+      DRIVER_TEST_IDS.runId,
+      occurrences,
+    );
+    const [second] = toDriverEventEnvelopes(
+      driverBootPayload,
+      draft,
+      DRIVER_TEST_IDS.runId,
+      occurrences,
+    );
+    const [retry] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
+
+    expect(first?.event.sourceEventId).toMatch(/^sha256:/);
+    expect(second?.event.sourceEventId).toBe(`${first?.event.sourceEventId}:2`);
+    expect(retry?.event.sourceEventId).toBe(first?.event.sourceEventId);
+  });
+
   test("runs input commands through the backend and reports completion to API", async () => {
     const backend = createBackend();
     const runtimeState = new DriverRuntimeStateMachine();


### PR DESCRIPTION
## Summary
- return accepted event receipts from driver pushEvents
- retry pending event batches after transient send failures
- make draft event source ids deterministic for replay idempotency

## Verification
- bun test apps/api/tests/driver-finalization-repair.test.ts apps/driver/tests/driver-event-publisher.test.ts apps/driver/tests/driver-runtime-boundary.test.ts
- just tc-package agent-driver
- just e2e deterministic session-log
- just e2e public-api runtime