### PR TITLE
fix(driver): emit claude tool results after output

### DIFF
--- a/src/runtimes/claude/agent-sdk-event-writer.ts
+++ b/src/runtimes/claude/agent-sdk-event-writer.ts
@@ -93,31 +93,6 @@ export class ClaudeAgentSdkEventWriter {
     ]);
   }
 
-  async endTool(context: AgentDriverContext, toolCallId: string): Promise<void> {
-    if (this.#toolEnded.has(toolCallId)) {
-      return;
-    }
-
-    this.#toolEnded.add(toolCallId);
-    await this.#push(context, "driver.claude.tool.ended", [
-      {
-        kind: "tool.call.updated",
-        payload: {
-          status: "completed",
-          toolCallId,
-        },
-      },
-      {
-        kind: "item.completed",
-        payload: {
-          itemId: toolCallId,
-          itemType: "tool_call",
-          status: "completed",
-        },
-      },
-    ]);
-  }
-
   async ensureMessageStarted(context: AgentDriverContext, messageId: string): Promise<void> {
     if (this.#messageStarted.has(messageId)) {
       return;
@@ -316,7 +291,7 @@ export class ClaudeAgentSdkEventWriter {
     messageId,
     toolCallId,
   }: ClaudeToolResultEvent): Promise<void> {
-    await this.#push(context, "driver.claude.tool.result", [
+    const events: DriverEventInput[] = [
       {
         kind: "tool.call.updated",
         payload: {
@@ -327,7 +302,21 @@ export class ClaudeAgentSdkEventWriter {
           toolCallId,
         },
       },
-    ]);
+    ];
+
+    if (!this.#toolEnded.has(toolCallId)) {
+      this.#toolEnded.add(toolCallId);
+      events.push({
+        kind: "item.completed",
+        payload: {
+          itemId: toolCallId,
+          itemType: "tool_call",
+          status: "completed",
+        },
+      });
+    }
+
+    await this.#push(context, "driver.claude.tool.result", events);
   }
 
   async pushUsage(

--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -164,7 +164,6 @@ export class ClaudeAgentSdkMessageTranslator {
             toolCallId,
           });
         }
-        await this.#events.endTool(context, toolCallId);
       }
     }
 
@@ -197,10 +196,8 @@ export class ClaudeAgentSdkMessageTranslator {
 
     if (eventType === "content_block_stop") {
       const index = readNumber(event, "index");
-      const toolCallId = index === null ? null : this.#blockIndexToToolCallId.get(index);
 
-      if (isTruthy(toolCallId) && index !== null) {
-        await this.#events.endTool(context, toolCallId);
+      if (index !== null) {
         this.#blockIndexToToolCallId.delete(index);
       }
       return;

--- a/tests/fixtures/providers/claude-agent-sdk/cases/assistant-final-message.json
+++ b/tests/fixtures/providers/claude-agent-sdk/cases/assistant-final-message.json
@@ -67,21 +67,6 @@
       }
     },
     {
-      "kind": "tool.call.updated",
-      "payload": {
-        "status": "completed",
-        "toolCallId": "tool-2"
-      }
-    },
-    {
-      "kind": "item.completed",
-      "payload": {
-        "itemId": "tool-2",
-        "itemType": "tool_call",
-        "status": "completed"
-      }
-    },
-    {
       "kind": "message.completed",
       "payload": {
         "messageId": "<driver-id>",

--- a/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
+++ b/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
@@ -160,6 +160,9 @@
     {
       "kind": "tool.call.updated",
       "payload": {
+        "content": "[{\"text\":\"/workspace\",\"type\":\"text\"}]",
+        "messageId": "<driver-id>",
+        "rawOutput": "[{\"text\":\"/workspace\",\"type\":\"text\"}]",
         "status": "completed",
         "toolCallId": "tool-1"
       }
@@ -170,16 +173,6 @@
         "itemId": "tool-1",
         "itemType": "tool_call",
         "status": "completed"
-      }
-    },
-    {
-      "kind": "tool.call.updated",
-      "payload": {
-        "content": "[{\"text\":\"/workspace\",\"type\":\"text\"}]",
-        "messageId": "<driver-id>",
-        "rawOutput": "[{\"text\":\"/workspace\",\"type\":\"text\"}]",
-        "status": "completed",
-        "toolCallId": "tool-1"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Keep Claude Agent SDK tool calls running until an actual tool_result arrives.
- Emit result content through tool.call.updated before completing the tool item.
- Refresh Claude provider fixtures for the corrected event sequence.

## Tests
- just test-file apps/driver/tests/claude-agent-sdk-provider-fixtures.test.ts
- just tc-package agent-driver