### PR TITLE
feat(runtime): pass advanced settings through driver

### DIFF
--- a/src/infrastructure/logging/driver-debug-paths.ts
+++ b/src/infrastructure/logging/driver-debug-paths.ts
@@ -107,6 +107,7 @@ export function summarizeDriverBootPayload(payload: DriverBootPayload): Record<s
       additionalDirectories: summarizePathCollection(session.additionalDirectories, {
         includeFingerprint: true,
       }),
+      builtInToolCount: payload.execution.builtInTools.length,
       configRevision: payload.execution.configRevision,
       cwd: summarizePath(session.cwd),
       envVarCount: Object.keys(payload.execution.environment.variables).length,

--- a/src/protocol/boot/index.ts
+++ b/src/protocol/boot/index.ts
@@ -68,6 +68,29 @@ export interface DriverExecutionEnvironment {
   readonly variables: Record<string, string>;
 }
 
+export type DriverBuiltInToolName =
+  | "bash"
+  | "edit"
+  | "glob"
+  | "grep"
+  | "read"
+  | "web_fetch"
+  | "web_search"
+  | "write";
+
+export interface DriverBuiltInToolConfig {
+  readonly enabled: boolean;
+  readonly name: DriverBuiltInToolName;
+}
+
+function readBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${label} must be a boolean.`);
+  }
+
+  return value;
+}
+
 export interface DriverSkillCatalogFrontmatterSummary {
   readonly author: string | null;
   readonly description: string | null;
@@ -130,6 +153,7 @@ export interface DriverExecutionSessionSpec {
 }
 
 export interface DriverExecutionSpec {
+  readonly builtInTools: DriverBuiltInToolConfig[];
   readonly configRevision: DriverConfigRevision;
   readonly environment: DriverExecutionEnvironment;
   readonly model: string;
@@ -273,6 +297,33 @@ function readResolvedSkill(value: unknown, index: number): DriverResolvedSkill {
   };
 }
 
+function readBuiltInToolName(value: unknown, label: string): DriverBuiltInToolName {
+  if (
+    value === "bash" ||
+    value === "edit" ||
+    value === "glob" ||
+    value === "grep" ||
+    value === "read" ||
+    value === "web_fetch" ||
+    value === "web_search" ||
+    value === "write"
+  ) {
+    return value;
+  }
+
+  throw new TypeError(`${label} is unsupported.`);
+}
+
+function readBuiltInTool(value: unknown, index: number): DriverBuiltInToolConfig {
+  const label = `execution.builtInTools[${index}]`;
+  const record = readRecord(value, label);
+
+  return {
+    enabled: readBoolean(record["enabled"], `${label}.enabled`),
+    name: readBuiltInToolName(record["name"], `${label}.name`),
+  };
+}
+
 function readBootMcpServer(value: unknown, index: number): DriverBootMcpServer {
   const label = `execution.session.mcpServers[${index}]`;
   const record = readRecord(value, label);
@@ -331,6 +382,7 @@ function readExecution(value: unknown): DriverExecutionSpec {
   const environment = readRecord(record["environment"], "execution.environment");
 
   return {
+    builtInTools: readArray(record["builtInTools"], "execution.builtInTools").map(readBuiltInTool),
     configRevision: readConfigRevision(record["configRevision"]),
     environment: {
       variables: readVariables(environment["variables"]),

--- a/src/protocol/execution.ts
+++ b/src/protocol/execution.ts
@@ -23,6 +23,7 @@ export interface DriverExecutionSessionInput {
 }
 
 export interface DriverExecutionInput {
+  readonly builtInTools: DriverExecutionSpec["builtInTools"];
   readonly environment: DriverExecutionEnvironment;
   readonly model: string;
   readonly provider: string;
@@ -38,6 +39,7 @@ export function createDriverExecutionInputFromBootExecution(
   execution: DriverExecutionSpec,
 ): DriverExecutionInput {
   return {
+    builtInTools: execution.builtInTools,
     environment: execution.environment,
     model: execution.model,
     provider: execution.provider,

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -9,6 +9,7 @@ import type {
 
 import { isTruthy } from "../../core/truthiness";
 import type { DriverBootMcpServer } from "../../protocol/boot";
+import type { DriverBuiltInToolName } from "../../protocol/boot";
 import type { JsonObject } from "../../protocol/json";
 import type { DriverStartInput } from "../../protocol/start";
 import type { AgentDriverContext } from "../agent-driver-backend";
@@ -16,7 +17,19 @@ import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import { mergeProviderOptions } from "../provider-options";
 import { buildNativeRuntimeSystemPrompt } from "../skill-bootstrap";
 import { readProcessEnvString, stringifyForDisplay } from "./agent-sdk-json";
+
 export const CLAUDE_CODE_EXECUTABLE_ENV = "MOSOO_CLAUDE_CODE_EXECUTABLE";
+
+const CLAUDE_BUILT_IN_TOOL_NAMES = {
+  bash: "Bash",
+  edit: "Edit",
+  glob: "Glob",
+  grep: "Grep",
+  read: "Read",
+  web_fetch: "WebFetch",
+  web_search: "WebSearch",
+  write: "Write",
+} as const satisfies Record<DriverBuiltInToolName, string>;
 
 function createCanUseTool(context: AgentDriverContext): CanUseTool {
   return async (toolName, input, options): Promise<PermissionResult> => {
@@ -98,6 +111,12 @@ function toClaudeEnv(payload: DriverStartInput, claudeConfigDir: string): NodeJS
   });
 }
 
+export function toClaudeBuiltInTools(payload: DriverStartInput): string[] {
+  return payload.execution.builtInTools.flatMap((tool) =>
+    tool.enabled ? [CLAUDE_BUILT_IN_TOOL_NAMES[tool.name]] : [],
+  );
+}
+
 export function resolveClaudeConfigDir(payload: DriverStartInput): string {
   return payload.execution.session.homePath;
 }
@@ -136,6 +155,7 @@ export async function createClaudeQueryOptions(input: {
       });
     },
   };
+  options.tools = toClaudeBuiltInTools(input.payload);
 
   const claudeCodeExecutable = readProcessEnvString(CLAUDE_CODE_EXECUTABLE_ENV);
   if (isTruthy(claudeCodeExecutable)) {

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -98,7 +98,9 @@ describe("Claude Agent SDK query options", () => {
       execution: {
         ...driverBootPayload.execution,
         builtInTools: driverBootPayload.execution.builtInTools.map((tool) =>
-          tool.name === "bash" || tool.name === "web_search" ? { ...tool, enabled: false } : tool,
+          tool.name === "bash" || tool.name === "web_search"
+            ? { enabled: false, name: tool.name }
+            : tool,
         ),
       },
     });
@@ -120,7 +122,9 @@ describe("Claude Agent SDK query options", () => {
       execution: {
         ...driverBootPayload.execution,
         builtInTools: driverBootPayload.execution.builtInTools.map((tool) =>
-          tool.name === "bash" || tool.name === "web_search" ? { ...tool, enabled: false } : tool,
+          tool.name === "bash" || tool.name === "web_search"
+            ? { enabled: false, name: tool.name }
+            : tool,
         ),
         model: "claude-sonnet-4-5",
         provider: "anthropic",

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { mergeClaudeQueryOptions } from "../src/runtimes/claude/agent-sdk-query-options";
+import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
+import {
+  mergeClaudeQueryOptions,
+  toClaudeBuiltInTools,
+} from "../src/runtimes/claude/agent-sdk-query-options";
+import { driverBootPayload } from "./driver-boot-payload-fixture";
 
 describe("Claude Agent SDK query options", () => {
   test("deep-merges advanced provider options into generated query options", () => {
@@ -56,5 +61,26 @@ describe("Claude Agent SDK query options", () => {
       persistSession: true,
     });
     expect(base.env).toEqual({ BASE: "1" });
+  });
+
+  test("maps Mosoo built-in tool toggles into Claude SDK tool names", () => {
+    const payload = createDriverStartInputFromBootPayload({
+      ...driverBootPayload,
+      execution: {
+        ...driverBootPayload.execution,
+        builtInTools: driverBootPayload.execution.builtInTools.map((tool) =>
+          tool.name === "bash" || tool.name === "web_search" ? { ...tool, enabled: false } : tool,
+        ),
+      },
+    });
+
+    expect(toClaudeBuiltInTools(payload)).toEqual([
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "WebFetch",
+    ]);
   });
 });

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -1,11 +1,40 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { createBufferedSinkLogger } from "../src/observability";
 import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
+import { createAgentDriverContext } from "../src/runtimes/agent-driver-backend";
 import {
+  createClaudeQueryOptions,
   mergeClaudeQueryOptions,
   toClaudeBuiltInTools,
 } from "../src/runtimes/claude/agent-sdk-query-options";
 import { driverBootPayload } from "./driver-boot-payload-fixture";
+
+let runtimeHomes: string[] = [];
+
+async function createRuntimeHome(): Promise<string> {
+  const runtimeHome = await mkdtemp(join(tmpdir(), "mosoo-claude-query-options-"));
+  runtimeHomes.push(runtimeHome);
+  return runtimeHome;
+}
+
+function createTestLogger() {
+  return createBufferedSinkLogger({
+    level: "debug",
+    service: "claude-agent-sdk-query-options-test",
+    sink: async () => {},
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    runtimeHomes.map((runtimeHome) => rm(runtimeHome, { force: true, recursive: true })),
+  );
+  runtimeHomes = [];
+});
 
 describe("Claude Agent SDK query options", () => {
   test("deep-merges advanced provider options into generated query options", () => {
@@ -82,5 +111,62 @@ describe("Claude Agent SDK query options", () => {
       "Grep",
       "WebFetch",
     ]);
+  });
+
+  test("passes reasoning effort, turn budget, and tools into Claude SDK query options", async () => {
+    const runtimeHome = await createRuntimeHome();
+    const payload = createDriverStartInputFromBootPayload({
+      ...driverBootPayload,
+      execution: {
+        ...driverBootPayload.execution,
+        builtInTools: driverBootPayload.execution.builtInTools.map((tool) =>
+          tool.name === "bash" || tool.name === "web_search" ? { ...tool, enabled: false } : tool,
+        ),
+        model: "claude-sonnet-4-5",
+        provider: "anthropic",
+        providerOptions: {
+          effort: "max",
+          maxTurns: 7,
+        },
+        session: {
+          ...driverBootPayload.execution.session,
+          context: {
+            ...driverBootPayload.execution.session.context,
+            homePath: runtimeHome,
+            sessionOrganizationPath: runtimeHome,
+          },
+          cwd: runtimeHome,
+        },
+      },
+      runtime: "claude-agent-sdk",
+      runtimeTransport: "claude-agent-sdk",
+    });
+    const logger = createTestLogger();
+    const context = createAgentDriverContext({
+      eventSink: {
+        pushEvents: async () => {},
+      },
+      logger,
+      payload,
+      permission: {
+        request: async () => "allow_once",
+      },
+    });
+
+    const options = await createClaudeQueryOptions({
+      abortController: new AbortController(),
+      context,
+      nativeSessionId: null,
+      payload,
+    });
+    await logger.destroy();
+
+    expect(options).toMatchObject({
+      effort: "max",
+      maxTurns: 7,
+      model: "claude-sonnet-4-5",
+      permissionMode: "default",
+      tools: ["Read", "Write", "Edit", "Glob", "Grep", "WebFetch"],
+    });
   });
 });

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -21,6 +21,16 @@ export const driverBootPayload = {
   driverGeneration: 0,
   driverInstanceId: DRIVER_TEST_IDS.driverInstanceId,
   execution: {
+    builtInTools: [
+      { enabled: true, name: "bash" },
+      { enabled: true, name: "read" },
+      { enabled: true, name: "write" },
+      { enabled: true, name: "edit" },
+      { enabled: true, name: "glob" },
+      { enabled: true, name: "grep" },
+      { enabled: true, name: "web_fetch" },
+      { enabled: true, name: "web_search" },
+    ],
     configRevision: {
       agentId: DRIVER_TEST_IDS.agentId,
       deploymentVersionId: null,

--- a/tests/openai-app-server-auth-state.test.ts
+++ b/tests/openai-app-server-auth-state.test.ts
@@ -124,6 +124,29 @@ describe("OpenAI app-server auth state", () => {
     expectDisabledRuntimeFeatures(config);
   });
 
+  test("passes reasoning effort and verbosity provider options into generated config", async () => {
+    const runtimeHome = await createRuntimeHome();
+
+    const result = await materializeOpenAiModelProviderConfig({
+      env: {
+        OPENAI_API_KEY: "openai-key",
+      },
+      provider: "openai",
+      providerOptions: {
+        model_reasoning_effort: "high",
+        model_verbosity: "low",
+      },
+      runtimeHome,
+    });
+
+    expect(result.written).toBe(true);
+    const config = await readGeneratedConfig(result.configTomlPath);
+
+    expect(config["model_reasoning_effort"]).toBe("high");
+    expect(config["model_verbosity"]).toBe("low");
+    expectDisabledRuntimeFeatures(config);
+  });
+
   test("writes mcp_servers tables into the generated config", async () => {
     const runtimeHome = await createRuntimeHome();
 


### PR DESCRIPTION
## Summary
- carry Mosoo built-in tool toggles through the driver boot/execution payload
- map Claude built-in tool toggles to Claude Agent SDK tool names
- cover Claude effort/maxTurns/tools and OpenAI reasoning/verbosity passthrough

## Verification
- just ci