### PR TITLE
docs(readme): lead with mosoo-agent-driver brand for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <img src="./assets/logo.svg" alt="Mosoo" width="138" height="138" />
 
-<h1>agent-driver</h1>
+<h1>mosoo-agent-driver</h1>
 
 <strong>One Driver Kernel. Every agent backend.</strong>
 <br />
-The runtime that drives a sandbox-hosted agent session inside Mosoo.
+The Mosoo Agent Driver — the runtime that drives a sandbox-hosted agent session inside Mosoo.
 
 <br />
 <br />
@@ -29,7 +29,7 @@ The runtime that drives a sandbox-hosted agent session inside Mosoo.
 
 ---
 
-`agent-driver` is the standalone runtime driver for sandbox-hosted agent sessions. It runs inside the sandbox and drives a single agent session from boot to stop. The core product is the **Driver Kernel**: runtime-neutral commands, events, host ports, provider backends, and the provider registry.
+`mosoo-agent-driver` (published to npm as `agent-driver`) is the standalone runtime driver for sandbox-hosted agent sessions. It runs inside the sandbox and drives a single agent session from boot to stop. The core product is the **Driver Kernel**: runtime-neutral commands, events, host ports, provider backends, and the provider registry.
 
 CMA (the Anthropic Managed Agents compatibility surface) is layered on top of the Driver Kernel through projections. Provider backends must emit Driver runtime events and consume Driver commands; they must not emit CMA events directly.
 


### PR DESCRIPTION
## What

Improve the repo's Google discoverability by surfacing the **Mosoo** brand keyword in the README's highest-weight on-page fields (per the investigation in YEF-742):

- **H1**: `agent-driver` → `mosoo-agent-driver` (now matches the GitHub repo slug)
- **Intro sentence**: now leads with `mosoo-agent-driver`, while keeping the npm package name (`agent-driver`) explicit so nothing is misleading

## Why

The repo doesn't currently rank for `mosoo`-related searches. The brand keyword previously appeared only in the logo `alt`, HTML comments, and body tails — never in the H1 — so the term users are most likely to combine had weak ranking signal. The H1 and first body sentence are the strongest indexable text in a README.

## What this does NOT change

- No code changes.
- The npm package / `bin` name stays `agent-driver` — imports and the CLI command are untouched.

## Still requires repo admin (out of scope for this PR)

These two complementary fixes from the investigation need **admin** rights on `langgenius/mosoo-agent-driver` (my token only has push/maintain):

- Set the GitHub **description** to: `Mosoo Agent Driver — runtime-neutral driver for Claude Code, Codex, and ACP. Compatible with Claude Managed Agents (CMA) API.`
- Set **About → Website** to the Mosoo site/X.
