### PR TITLE
refactor(runtime): simplify cloudflare driver surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# Sandbox base image. Defaults to Cloudflare's sandbox (what Mosoo runs on),
-# but the Driver Kernel itself is sandbox-neutral — override at build time with
-# `--build-arg SANDBOX_BASE_IMAGE=...` to run the driver on a different base.
-ARG SANDBOX_BASE_IMAGE=cloudflare/sandbox:0.10.3
-FROM ${SANDBOX_BASE_IMAGE}
+FROM cloudflare/sandbox:0.10.3
 
 # Keep the default base image version in sync with apps/api/package.json -> @cloudflare/sandbox.
 ARG CLAUDE_AGENT_SDK_VERSION=0.3.158

--- a/src/host-ports/index.ts
+++ b/src/host-ports/index.ts
@@ -1,4 +1,3 @@
-import type { Logger } from "../observability";
 import type { DriverEventInput } from "../protocol/events";
 import type { DriverExecutionInput } from "../protocol/execution";
 import type { DriverHostIntegrationSnapshot } from "../protocol/host-integration";
@@ -12,9 +11,7 @@ export type AgentDriverHostPortName =
   | "mcp"
   | "skill"
   | "file"
-  | "host_integration"
-  | "logger"
-  | "policy";
+  | "host_integration";
 
 export interface AgentDriverCommandSource {
   nextCommand(): Promise<RuntimeCommand | null>;
@@ -72,22 +69,13 @@ export interface AgentDriverHostIntegrationPort {
   snapshot(): Promise<DriverHostIntegrationSnapshot | null>;
 }
 
-export interface AgentDriverLoggerPort {
-  logger(): Logger;
-}
-
-export interface AgentDriverPolicyPort {
-  assertSupported(input: { capability: string; subject: string }): Promise<void>;
-}
 
 export interface AgentDriverHostPorts {
   commandSource: AgentDriverCommandSource;
   eventSink: AgentDriverEventSink;
   file: AgentDriverFilePort;
   hostIntegration: AgentDriverHostIntegrationPort;
-  logger: AgentDriverLoggerPort;
   mcp: AgentDriverMcpPort;
   permission: AgentDriverPermissionPort;
-  policy: AgentDriverPolicyPort;
   skill: AgentDriverSkillPort;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,8 +80,6 @@ export type {
   AgentDriverSkillPort,
   AgentDriverFilePort,
   AgentDriverHostIntegrationPort,
-  AgentDriverLoggerPort,
-  AgentDriverPolicyPort,
 } from "./host-ports";
 export type {
   AgentDriverBackend,

--- a/src/runtimes/agent-driver-backend.ts
+++ b/src/runtimes/agent-driver-backend.ts
@@ -5,10 +5,8 @@ import type {
   AgentDriverFilePort,
   AgentDriverHostIntegrationPort,
   AgentDriverHostPorts,
-  AgentDriverLoggerPort,
   AgentDriverMcpPort,
   AgentDriverPermissionPort,
-  AgentDriverPolicyPort,
   AgentDriverSkillPort,
 } from "../host-ports";
 import type { Logger } from "../observability";
@@ -29,10 +27,8 @@ export type AgentDriverContextPortOverrides = Partial<{
   eventSink: AgentDriverEventSink;
   file: AgentDriverFilePort;
   hostIntegration: AgentDriverHostIntegrationPort;
-  logger: AgentDriverLoggerPort;
   mcp: AgentDriverMcpPort;
   permission: AgentDriverPermissionPort;
-  policy: AgentDriverPolicyPort;
   skill: AgentDriverSkillPort;
 }>;
 
@@ -94,9 +90,6 @@ function createDefaultHostPorts(input: AgentDriverContextInput): AgentDriverHost
         await eventSink.pushEvents({ events: [event] });
       },
     },
-    logger: {
-      logger: () => input.logger,
-    },
     hostIntegration: {
       snapshot: async () => null,
     },
@@ -106,9 +99,6 @@ function createDefaultHostPorts(input: AgentDriverContextInput): AgentDriverHost
       },
     },
     permission: input.permission,
-    policy: {
-      assertSupported: async () => {},
-    },
     skill: {
       materialize: async () => {
         throw new Error("Driver skill host port is not configured.");

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -14,6 +14,7 @@ import type { JsonObject } from "../../protocol/json";
 import type { DriverStartInput } from "../../protocol/start";
 import type { AgentDriverContext } from "../agent-driver-backend";
 import { buildRuntimeChildProcessEnv } from "../child-process-env";
+import { toMcpServerKey } from "../mcp/server-key";
 import { mergeProviderOptions } from "../provider-options";
 import { buildNativeRuntimeSystemPrompt } from "../skill-bootstrap";
 import { readProcessEnvString, stringifyForDisplay } from "./agent-sdk-json";
@@ -66,19 +67,6 @@ function createCanUseTool(context: AgentDriverContext): CanUseTool {
   };
 }
 
-function toMcpServerKey(server: DriverBootMcpServer, usedNames: Set<string>): string {
-  const baseName = server.name.trim() || server.serverId;
-  let candidate = baseName;
-  let suffix = 2;
-
-  while (usedNames.has(candidate)) {
-    candidate = `${baseName}-${suffix}`;
-    suffix += 1;
-  }
-
-  usedNames.add(candidate);
-  return candidate;
-}
 
 function toClaudeMcpServers(
   servers: DriverBootMcpServer[],
@@ -155,7 +143,8 @@ export async function createClaudeQueryOptions(input: {
       });
     },
   };
-  options.tools = toClaudeBuiltInTools(input.payload);
+  const builtInTools = toClaudeBuiltInTools(input.payload);
+  options.tools = builtInTools;
 
   const claudeCodeExecutable = readProcessEnvString(CLAUDE_CODE_EXECUTABLE_ENV);
   if (isTruthy(claudeCodeExecutable)) {
@@ -179,5 +168,7 @@ export async function createClaudeQueryOptions(input: {
     options.resume = input.nativeSessionId;
   }
 
-  return mergeClaudeQueryOptions(options, input.payload.execution.providerOptions);
+  const mergedOptions = mergeClaudeQueryOptions(options, input.payload.execution.providerOptions);
+  mergedOptions.tools = builtInTools;
+  return mergedOptions;
 }

--- a/src/runtimes/mcp/server-key.ts
+++ b/src/runtimes/mcp/server-key.ts
@@ -1,0 +1,15 @@
+import type { DriverBootMcpServer } from "../../protocol/boot";
+
+export function toMcpServerKey(server: DriverBootMcpServer, usedNames: Set<string>): string {
+  const baseName = server.name.trim() || server.serverId;
+  let candidate = baseName;
+  let suffix = 2;
+
+  while (usedNames.has(candidate)) {
+    candidate = `${baseName}-${suffix}`;
+    suffix += 1;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
+}

--- a/src/runtimes/openai/mcp-config.ts
+++ b/src/runtimes/openai/mcp-config.ts
@@ -1,5 +1,6 @@
 import type { AuthorizedDriverBootMcpServer, DriverBootMcpServer } from "../../protocol/boot";
 import type { JsonValue } from "../../protocol/json";
+import { toMcpServerKey } from "../mcp/server-key";
 
 export interface OpenAiMcpServerConfig {
   /**
@@ -19,19 +20,6 @@ function isAuthorized(server: DriverBootMcpServer): server is AuthorizedDriverBo
   return server.authorizationState === "active";
 }
 
-function toMcpServerKey(server: DriverBootMcpServer, usedNames: Set<string>): string {
-  const baseName = server.name.trim() || server.serverId;
-  let candidate = baseName;
-  let suffix = 2;
-
-  while (usedNames.has(candidate)) {
-    candidate = `${baseName}-${suffix}`;
-    suffix += 1;
-  }
-
-  usedNames.add(candidate);
-  return candidate;
-}
 
 function toBearerTokenEnvName(index: number): string {
   return `MOSOO_MCP_BEARER_TOKEN_${index}`;

--- a/src/runtimes/provider-registry.ts
+++ b/src/runtimes/provider-registry.ts
@@ -8,25 +8,21 @@ import { ClaudeAgentSdkDriverBackend } from "./claude/agent-sdk-driver-backend";
 import { OpenAiAppServerDriverBackend } from "./openai/app-server-driver-backend";
 
 export interface AgentDriverProviderDescriptor {
-  readonly aliases: readonly DriverRuntimeTransport[];
   readonly capabilities: readonly DriverCapability[];
   createBackend(input: DriverStartInput): AgentDriverBackend;
   readonly id: DriverRuntimeTransport;
   readonly requiredHostPorts: readonly AgentDriverHostPortName[];
   readonly runtime: DriverRuntime;
-  readonly unsupportedGaps: readonly string[];
 }
 
 export interface AgentDriverProviderRegistry {
   createBackend(input: DriverStartInput): AgentDriverBackend;
   getByStartInput(input: DriverStartInput): AgentDriverProviderDescriptor;
-  getByTransport(transport: DriverRuntimeTransport): AgentDriverProviderDescriptor | null;
   list(): readonly AgentDriverProviderDescriptor[];
 }
 
 const SHARED_REQUIRED_HOST_PORTS = [
   "event_sink",
-  "logger",
   "permission",
   "mcp",
   "skill",
@@ -48,7 +44,6 @@ const TEXT_TOOL_CAPABILITIES = [
 
 const PROVIDERS = [
   {
-    aliases: [],
     capabilities: [
       ...TEXT_TOOL_CAPABILITIES,
       { id: "native_resume", status: "supported", version: 1 },
@@ -58,10 +53,8 @@ const PROVIDERS = [
     id: "openai-app-server",
     requiredHostPorts: SHARED_REQUIRED_HOST_PORTS,
     runtime: "openai-runtime",
-    unsupportedGaps: ["thinking_stream"],
   },
   {
-    aliases: [],
     capabilities: [
       ...TEXT_TOOL_CAPABILITIES,
       { id: "native_resume", status: "supported", version: 1 },
@@ -71,10 +64,8 @@ const PROVIDERS = [
     id: "claude-agent-sdk",
     requiredHostPorts: SHARED_REQUIRED_HOST_PORTS,
     runtime: "claude-agent-sdk",
-    unsupportedGaps: [],
   },
   {
-    aliases: [],
     capabilities: [
       ...TEXT_TOOL_CAPABILITIES,
       { id: "native_resume", status: "supported", version: 1 },
@@ -84,7 +75,6 @@ const PROVIDERS = [
     id: "acp-fallback",
     requiredHostPorts: [...SHARED_REQUIRED_HOST_PORTS, "file", "host_integration"],
     runtime: "acp-fallback",
-    unsupportedGaps: [],
   },
 ] as const satisfies readonly AgentDriverProviderDescriptor[];
 
@@ -96,9 +86,6 @@ export function createAgentDriverProviderRegistry(
   for (const provider of providers) {
     registerProviderTransport(providersByTransport, provider, provider.id);
 
-    for (const alias of provider.aliases) {
-      registerProviderTransport(providersByTransport, provider, alias);
-    }
   }
 
   return {
@@ -107,9 +94,6 @@ export function createAgentDriverProviderRegistry(
     },
     getByStartInput(input) {
       return resolveProviderForStartInput(providersByTransport, input);
-    },
-    getByTransport(transport) {
-      return providersByTransport.get(transport) ?? null;
     },
     list() {
       return providers;

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -131,6 +131,7 @@ describe("Claude Agent SDK query options", () => {
         providerOptions: {
           effort: "max",
           maxTurns: 7,
+          tools: ["Bash", "Read", "WebFetch"],
         },
         session: {
           ...driverBootPayload.execution.session,

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -93,17 +93,16 @@ describe("provider registry", () => {
     ).toEqual([
       {
         id: "openai-app-server",
-        requiredHostPorts: ["event_sink", "logger", "permission", "mcp", "skill"],
+        requiredHostPorts: ["event_sink", "permission", "mcp", "skill"],
       },
       {
         id: "claude-agent-sdk",
-        requiredHostPorts: ["event_sink", "logger", "permission", "mcp", "skill"],
+        requiredHostPorts: ["event_sink", "permission", "mcp", "skill"],
       },
       {
         id: "acp-fallback",
         requiredHostPorts: [
           "event_sink",
-          "logger",
           "permission",
           "mcp",
           "skill",


### PR DESCRIPTION
### What's changed?

- Remove unused host logger/policy ports and provider registry metadata.
- Share MCP server key normalization across Claude and OpenAI config paths.
- Use the direct Cloudflare sandbox base image in Dockerfile.
- Keep Claude built-in tools authoritative after provider option merging.

### Why

- Tightens the Cloudflare-hosted driver surface to the code paths that are actually used.
- Prevents provider options from re-enabling disabled Claude built-in tools.

### Verification

- `bun run tc`
- `bun run lint` (existing warning: `tests/driver-runtime-boundary.test.ts` unused `bootPayload`)
- `bun run test`
- `bun run build`
- `git diff --cached --check` before commit
- `/pre-ship --committed` local gate