### PR TITLE
fix(acp): support DeepSeek OpenCode runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,22 @@ ANTHROPIC_API_KEY=
 # OpenCode ACP live smoke test.
 # just live-opencode sets AGENT_DRIVER_LIVE_OPENCODE=1 automatically.
 # If running the test file directly, set AGENT_DRIVER_LIVE_OPENCODE=1 yourself.
+# Supported values: openai, anthropic, deepseek, opencode.
 AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=openai
 AGENT_DRIVER_LIVE_OPENCODE_API_KEY=
 AGENT_DRIVER_LIVE_OPENCODE_MODEL=gpt-5.4
 AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=gpt-5-nano
 # AGENT_DRIVER_LIVE_OPENCODE_COMMAND=/path/to/opencode
+
+# DeepSeek official API example:
+# AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=deepseek
+# AGENT_DRIVER_LIVE_OPENCODE_MODEL=deepseek-v4-pro
+# AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=deepseek-v4-pro
+
+# OpenCode Zen example:
+# AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=opencode
+# AGENT_DRIVER_LIVE_OPENCODE_MODEL=deepseek-v4-flash-free
+# AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=deepseek-v4-flash-free
 
 # ACP fallback runtime. The packaged Docker image defaults this generic ACP
 # fallback to OpenCode. Override these for another ACP-compatible agent.

--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -6,6 +6,17 @@ import { isRecord, readRecord } from "./acp-types";
 export const ACP_PROTOCOL_VERSION = 1 as const;
 const ACP_RUNTIME_HOME_DIR = "acp-fallback";
 const ACP_DEFAULT_COMMAND = "acp-agent";
+const ACP_INHERITED_PROCESS_ENV_KEYS = [
+  "ALL_PROXY",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NODE_USE_ENV_PROXY",
+  "NO_PROXY",
+  "all_proxy",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+] as const;
 
 export function readAcpFallbackCommand(): string {
   const command = process.env["MOSOO_ACP_FALLBACK_COMMAND"];
@@ -30,18 +41,36 @@ export function readAcpFallbackArgs(): string[] {
   return parsed;
 }
 
-export function buildAcpChildProcessEnv(payload: DriverStartInput): Record<string, string> {
+function buildAcpInheritedProcessEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const inherited: Record<string, string> = {};
+
+  for (const key of ACP_INHERITED_PROCESS_ENV_KEYS) {
+    const value = env[key];
+
+    if (typeof value === "string" && value.trim().length > 0) {
+      inherited[key] = value;
+    }
+  }
+
+  return inherited;
+}
+
+export function buildAcpChildProcessEnv(
+  payload: DriverStartInput,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   const { homePath } = payload.execution.session;
 
   return {
     ...payload.execution.environment.variables,
+    ...buildAcpInheritedProcessEnv(processEnv),
     DISABLE_AUTOUPDATER: "1",
     DISABLE_ERROR_REPORTING: "1",
     DISABLE_TELEMETRY: "1",
     MOSOO_ACP_HOME: `${homePath}/${ACP_RUNTIME_HOME_DIR}`,
     HOME: homePath,
     IS_SANDBOX: "1",
-    PATH: process.env["PATH"] ?? "",
+    PATH: processEnv["PATH"] ?? "",
     PWD: payload.execution.session.cwd,
   };
 }

--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -62,8 +62,8 @@ export function buildAcpChildProcessEnv(
   const { homePath } = payload.execution.session;
 
   return {
-    ...payload.execution.environment.variables,
     ...buildAcpInheritedProcessEnv(processEnv),
+    ...payload.execution.environment.variables,
     DISABLE_AUTOUPDATER: "1",
     DISABLE_ERROR_REPORTING: "1",
     DISABLE_TELEMETRY: "1",

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -56,6 +56,20 @@ class AcpPromptTerminalError extends Error {
   }
 }
 
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+async function withAcpStartupStage<T>(stage: string, task: () => Promise<T>): Promise<T> {
+  try {
+    return await task();
+  } catch (error) {
+    throw new Error(`${stage} failed: ${toErrorMessage(error, "ACP startup step failed.")}`, {
+      cause: error,
+    });
+  }
+}
+
 export class AcpDriverBackend implements AgentDriverBackend {
   readonly runtime: DriverRuntime = "acp-fallback";
   #activeTurn: ActiveAcpTurn | null = null;
@@ -132,16 +146,18 @@ export class AcpDriverBackend implements AgentDriverBackend {
     this.#agentCapabilities = initResult.agentCapabilities;
     await this.#push(context, "driver.acp.initialize", toAcpInitializeEvents(initResult));
     await this.#authenticateIfConfigured(context, initResult, env);
-    const setup = await this.#setupSession();
+    const setup = await withAcpStartupStage("ACP session setup", () => this.#setupSession());
 
-    await this.#push(
-      context,
-      `driver.acp.session.${setup.mode}`,
-      toAcpSessionReadyEvents({
-        mode: setup.mode,
-        nativeSessionId: setup.sessionId,
-        setup: setup.raw,
-      }),
+    await withAcpStartupStage("ACP session ready event push", () =>
+      this.#push(
+        context,
+        `driver.acp.session.${setup.mode}`,
+        toAcpSessionReadyEvents({
+          mode: setup.mode,
+          nativeSessionId: setup.sessionId,
+          setup: setup.raw,
+        }),
+      ),
     );
 
     if (setup.mode === "created") {

--- a/src/runtimes/acp/acp-session-events.ts
+++ b/src/runtimes/acp/acp-session-events.ts
@@ -274,23 +274,25 @@ function normalizeConfigOptions(raw: unknown): JsonObject[] | null {
     const id = readNonEmptyString(entry, "id");
     const currentValue = readString(entry, "currentValue");
 
-    if (id === null || currentValue === null) {
+    if (id === null) {
       return [];
     }
 
     const category = readNullableString(entry, "category");
     const description = readNullableString(entry, "description");
+    const name = readNonEmptyString(entry, "name");
     const rawValues = entry["values"] ?? entry["options"];
+    const values = Array.isArray(rawValues) ? normalizeConfigValueOptions(rawValues) : null;
 
     return [
       {
         ...(category === undefined ? {} : { category }),
-        currentValue,
+        ...(currentValue === null ? {} : { currentValue }),
         ...(description === undefined ? {} : { description }),
         id,
-        name: readNonEmptyString(entry, "name") ?? id,
+        ...(name === null ? {} : { name }),
         type: "select",
-        values: normalizeConfigValueOptions(rawValues),
+        ...(values === null ? {} : { values }),
       },
     ];
   });

--- a/src/runtimes/acp/acp-session-events.ts
+++ b/src/runtimes/acp/acp-session-events.ts
@@ -11,6 +11,8 @@ import {
 } from "./acp-types";
 import type { AcpInitializeResult, JsonObject } from "./acp-types";
 
+const ACP_USAGE_CONTRACT = "openai_total_with_cached_breakdown";
+
 export function toAcpInitializeEvents(result: AcpInitializeResult): DriverEventInput[] {
   const events: DriverEventInput[] = [
     {
@@ -162,8 +164,9 @@ export function normalizePromptUsage(raw: unknown): JsonObject | null {
     inputTokens,
     outputTokens,
     raw,
-    source: "acp.prompt",
+    source: "prompt_response",
     totalTokens,
+    usageContract: ACP_USAGE_CONTRACT,
   };
 }
 
@@ -216,7 +219,7 @@ function normalizeAvailableCommands(raw: unknown): JsonObject[] | null {
 
     return [
       {
-        description: readNullableString(entry, "description") ?? null,
+        description: readNullableString(entry, "description") ?? "",
         input: entry["input"] ?? null,
         name,
       },
@@ -226,12 +229,71 @@ function normalizeAvailableCommands(raw: unknown): JsonObject[] | null {
   return commands;
 }
 
+function normalizeConfigValueOptions(raw: unknown): JsonObject[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.flatMap((entry): JsonObject[] => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+
+    const value = readNonEmptyString(entry, "value");
+
+    if (value === null) {
+      return [];
+    }
+
+    const description = readNullableString(entry, "description");
+    const group = readNullableString(entry, "group");
+    const groupName = readNullableString(entry, "groupName");
+
+    return [
+      {
+        ...(description === undefined ? {} : { description }),
+        ...(group === undefined ? {} : { group }),
+        ...(groupName === undefined ? {} : { groupName }),
+        name: readNonEmptyString(entry, "name") ?? value,
+        value,
+      },
+    ];
+  });
+}
+
 function normalizeConfigOptions(raw: unknown): JsonObject[] | null {
   if (!Array.isArray(raw)) {
     return null;
   }
 
-  return raw.filter(isRecord);
+  return raw.flatMap((entry): JsonObject[] => {
+    if (!isRecord(entry) || entry["type"] !== "select") {
+      return [];
+    }
+
+    const id = readNonEmptyString(entry, "id");
+    const currentValue = readString(entry, "currentValue");
+
+    if (id === null || currentValue === null) {
+      return [];
+    }
+
+    const category = readNullableString(entry, "category");
+    const description = readNullableString(entry, "description");
+    const rawValues = entry["values"] ?? entry["options"];
+
+    return [
+      {
+        ...(category === undefined ? {} : { category }),
+        currentValue,
+        ...(description === undefined ? {} : { description }),
+        id,
+        name: readNonEmptyString(entry, "name") ?? id,
+        type: "select",
+        values: normalizeConfigValueOptions(rawValues),
+      },
+    ];
+  });
 }
 
 function normalizePlanEntries(raw: unknown): JsonObject[] {
@@ -402,9 +464,11 @@ function toSessionModelsEvents(setup: JsonObject | null): DriverEventInput[] {
 export function toUsageUpdateEvents(update: JsonObject | null): DriverEventInput[] {
   const used = readNumber(update, "used");
   const size = readNumber(update, "size");
-  const cost = update?.["cost"];
+  const cost = readRecord(update, "cost");
+  const costAmount = readNumber(cost, "amount");
+  const costCurrency = readNullableString(cost, "currency");
 
-  if (used === null && size === null && cost === undefined) {
+  if (used === null && size === null && cost === null) {
     return [];
   }
 
@@ -412,9 +476,11 @@ export function toUsageUpdateEvents(update: JsonObject | null): DriverEventInput
     {
       kind: "usage.updated",
       payload: {
-        cost,
+        costAmount,
+        ...(costCurrency === undefined ? {} : { costCurrency }),
         size,
-        source: "acp.session",
+        source: "session_update",
+        usageContract: ACP_USAGE_CONTRACT,
         used,
       },
     },

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -68,6 +68,32 @@ describe("ACP runtime configuration", () => {
     expect(env["RANDOM_SECRET"]).toBeUndefined();
   });
 
+  test("keeps explicit ACP execution proxy env above inherited process env", () => {
+    const env = buildAcpChildProcessEnv(
+      {
+        ...bootPayload,
+        execution: {
+          ...bootPayload.execution,
+          environment: {
+            variables: {
+              ...bootPayload.execution.environment.variables,
+              HTTPS_PROXY: "http://explicit-proxy:7897",
+              NO_PROXY: "metadata.google.internal",
+            },
+          },
+        },
+      },
+      {
+        HTTPS_PROXY: "http://ambient-proxy:7897",
+        NO_PROXY: "localhost,127.0.0.1",
+        PATH: "/usr/local/bin:/usr/bin",
+      },
+    );
+
+    expect(env["HTTPS_PROXY"]).toBe("http://explicit-proxy:7897");
+    expect(env["NO_PROXY"]).toBe("metadata.google.internal");
+  });
+
   test("requires host integration snapshot before starting", async () => {
     const logger = createBufferedSinkLogger({
       level: "debug",

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { createBufferedSinkLogger } from "../src/observability";
 import {
   ACP_PROTOCOL_VERSION,
+  buildAcpChildProcessEnv,
   enforceAcpProtocolVersion,
   resolveAcpAuthMethodId,
 } from "../src/runtimes/acp/acp-configuration";
@@ -47,6 +48,24 @@ describe("ACP runtime configuration", () => {
         MOSOO_ACP_AUTH_METHOD_ID: "device-login",
       }),
     ).toThrow();
+  });
+
+  test("inherits runtime proxy env for ACP child processes only", () => {
+    const env = buildAcpChildProcessEnv(bootPayload, {
+      HTTPS_PROXY: "http://host.docker.internal:7897",
+      NODE_USE_ENV_PROXY: "1",
+      PATH: "/usr/local/bin:/usr/bin",
+      RANDOM_SECRET: "secret",
+      http_proxy: "http://host.docker.internal:7897",
+    });
+
+    expect(env).toMatchObject({
+      HTTPS_PROXY: "http://host.docker.internal:7897",
+      NODE_USE_ENV_PROXY: "1",
+      PATH: "/usr/local/bin:/usr/bin",
+      http_proxy: "http://host.docker.internal:7897",
+    });
+    expect(env["RANDOM_SECRET"]).toBeUndefined();
   });
 
   test("requires host integration snapshot before starting", async () => {

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -325,4 +325,134 @@ describe("ACP runtime event translation", () => {
       visibility: "owner_debug",
     });
   });
+
+  test("normalizes ACP config options to the Mosoo session config contract", () => {
+    const events = toAcpSessionReadyEvents({
+      mode: "created",
+      nativeSessionId: "native-session-1",
+      setup: {
+        configOptions: [
+          {
+            category: "model",
+            currentValue: "deepseek/deepseek-v4-pro",
+            id: "model",
+            name: "Model",
+            options: [
+              {
+                name: "DeepSeek/DeepSeek V4 Pro",
+                value: "deepseek/deepseek-v4-pro",
+              },
+            ],
+            type: "select",
+          },
+        ],
+      },
+    });
+    const configEvent = events.find((event) => event.kind === "session.config.updated");
+    const payload = eventPayload(configEvent as DriverEventInput);
+
+    expect(payload).toEqual({
+      options: [
+        {
+          category: "model",
+          currentValue: "deepseek/deepseek-v4-pro",
+          id: "model",
+          name: "Model",
+          type: "select",
+          values: [
+            {
+              name: "DeepSeek/DeepSeek V4 Pro",
+              value: "deepseek/deepseek-v4-pro",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("normalizes ACP commands to the Mosoo session commands contract", () => {
+    const state = new AcpTurnEventState();
+    const events = state.translateUpdate({
+      update: {
+        availableCommands: [
+          {
+            name: "init",
+          },
+        ],
+        sessionUpdate: "available_commands_update",
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        kind: "session.commands.updated",
+        payload: {
+          commands: [
+            {
+              description: "",
+              input: null,
+              name: "init",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("normalizes ACP usage sources to the Mosoo usage contract", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const sessionUsage = state.translateUpdate({
+      update: {
+        cost: {
+          amount: 0.25,
+          currency: "USD",
+        },
+        sessionUpdate: "usage_update",
+        size: 1_000,
+        used: 12,
+      },
+    });
+    const completionUsage = state.completePrompt("end_turn", {
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+    });
+
+    expect(sessionUsage).toEqual([
+      {
+        kind: "usage.updated",
+        payload: {
+          costAmount: 0.25,
+          costCurrency: "USD",
+          size: 1_000,
+          source: "session_update",
+          usageContract: "openai_total_with_cached_breakdown",
+          used: 12,
+        },
+      },
+    ]);
+    expect(completionUsage).toContainEqual({
+      kind: "usage.updated",
+      payload: {
+        inputTokens: 10,
+        outputTokens: 2,
+        raw: {
+          inputTokens: 10,
+          outputTokens: 2,
+          totalTokens: 12,
+        },
+        source: "prompt_response",
+        totalTokens: 12,
+        usageContract: "openai_total_with_cached_breakdown",
+      },
+      runId: "run-1",
+    });
+  });
 });

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -159,8 +159,9 @@
         "raw": {
           "totalTokens": 12
         },
-        "source": "acp.prompt",
-        "totalTokens": 12
+        "source": "prompt_response",
+        "totalTokens": 12,
+        "usageContract": "openai_total_with_cached_breakdown"
       },
       "runId": "run-1"
     },

--- a/tests/opencode-acp-live.test.ts
+++ b/tests/opencode-acp-live.test.ts
@@ -34,11 +34,6 @@ interface OpenCodeLiveProviderConfig {
   readonly defaultSmallModel: string;
   readonly id: OpenCodeLiveProvider;
   readonly providerApiKeyEnv: string;
-  readonly openCodeProvider?: {
-    readonly baseURL: string;
-    readonly name: string;
-    readonly npm: string;
-  };
 }
 
 const PROVIDER_CONFIGS = {
@@ -52,11 +47,6 @@ const PROVIDER_CONFIGS = {
     defaultModel: "deepseek-v4-pro",
     defaultSmallModel: "deepseek-v4-pro",
     id: "deepseek",
-    openCodeProvider: {
-      baseURL: "https://api.deepseek.com",
-      name: "DeepSeek",
-      npm: "@ai-sdk/openai-compatible",
-    },
     providerApiKeyEnv: DEEPSEEK_API_KEY_ENV,
   },
   openai: {
@@ -261,23 +251,13 @@ function createOpenCodeConfig(): string {
   const options: Record<string, string> = {
     apiKey: `{env:${liveProviderConfig.providerApiKeyEnv}}`,
   };
-  const providerConfig = liveProviderConfig.openCodeProvider
-    ? {
-        name: liveProviderConfig.openCodeProvider.name,
-        npm: liveProviderConfig.openCodeProvider.npm,
-        options: {
-          ...options,
-          baseURL: liveProviderConfig.openCodeProvider.baseURL,
-        },
-      }
-    : { options };
 
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
     enabled_providers: [liveProviderConfig.id],
     model: toOpenCodeModelId(readLiveModel()),
     provider: {
-      [liveProviderConfig.id]: providerConfig,
+      [liveProviderConfig.id]: { options },
     },
     small_model: toOpenCodeModelId(readLiveSmallModel()),
   });

--- a/tests/opencode-acp-live.test.ts
+++ b/tests/opencode-acp-live.test.ts
@@ -20,18 +20,25 @@ const LIVE_MODEL_ENV = "AGENT_DRIVER_LIVE_OPENCODE_MODEL";
 const LIVE_PROVIDER_ENV = "AGENT_DRIVER_LIVE_OPENCODE_PROVIDER";
 const LIVE_SMALL_MODEL_ENV = "AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL";
 const ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
+const DEEPSEEK_API_KEY_ENV = "DEEPSEEK_API_KEY";
+const OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY";
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
 const LIVE_START_TIMEOUT_MS = 120_000;
 const LIVE_TURN_TIMEOUT_MS = 120_000;
 const OPENCODE_ACP_ARGS = ["acp", "--pure", "--print-logs", "--log-level", "DEBUG"] as const;
 
-type OpenCodeLiveProvider = "anthropic" | "openai";
+type OpenCodeLiveProvider = "anthropic" | "deepseek" | "openai" | "opencode";
 
 interface OpenCodeLiveProviderConfig {
   readonly defaultModel: string;
   readonly defaultSmallModel: string;
   readonly id: OpenCodeLiveProvider;
   readonly providerApiKeyEnv: string;
+  readonly openCodeProvider?: {
+    readonly baseURL: string;
+    readonly name: string;
+    readonly npm: string;
+  };
 }
 
 const PROVIDER_CONFIGS = {
@@ -41,11 +48,28 @@ const PROVIDER_CONFIGS = {
     id: "anthropic",
     providerApiKeyEnv: ANTHROPIC_API_KEY_ENV,
   },
+  deepseek: {
+    defaultModel: "deepseek-v4-pro",
+    defaultSmallModel: "deepseek-v4-pro",
+    id: "deepseek",
+    openCodeProvider: {
+      baseURL: "https://api.deepseek.com",
+      name: "DeepSeek",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    providerApiKeyEnv: DEEPSEEK_API_KEY_ENV,
+  },
   openai: {
     defaultModel: "gpt-5.4",
     defaultSmallModel: "gpt-5-nano",
     id: "openai",
     providerApiKeyEnv: OPENAI_API_KEY_ENV,
+  },
+  opencode: {
+    defaultModel: "deepseek-v4-flash-free",
+    defaultSmallModel: "deepseek-v4-flash-free",
+    id: "opencode",
+    providerApiKeyEnv: OPENCODE_API_KEY_ENV,
   },
 } as const satisfies Record<OpenCodeLiveProvider, OpenCodeLiveProviderConfig>;
 
@@ -98,7 +122,12 @@ function isLiveEnabled(): boolean {
 function readLiveProvider(): OpenCodeLiveProvider {
   const provider = readEnvString(LIVE_PROVIDER_ENV) ?? "openai";
 
-  if (provider === "anthropic" || provider === "openai") {
+  if (
+    provider === "anthropic" ||
+    provider === "deepseek" ||
+    provider === "openai" ||
+    provider === "opencode"
+  ) {
     return provider;
   }
 
@@ -229,17 +258,26 @@ function createOpenCodeConfig(): string {
   if (liveProviderConfig === null) {
     throw new Error("OpenCode live provider config is unavailable when live testing is disabled.");
   }
+  const options: Record<string, string> = {
+    apiKey: `{env:${liveProviderConfig.providerApiKeyEnv}}`,
+  };
+  const providerConfig = liveProviderConfig.openCodeProvider
+    ? {
+        name: liveProviderConfig.openCodeProvider.name,
+        npm: liveProviderConfig.openCodeProvider.npm,
+        options: {
+          ...options,
+          baseURL: liveProviderConfig.openCodeProvider.baseURL,
+        },
+      }
+    : { options };
 
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
     enabled_providers: [liveProviderConfig.id],
     model: toOpenCodeModelId(readLiveModel()),
     provider: {
-      [liveProviderConfig.id]: {
-        options: {
-          apiKey: `{env:${liveProviderConfig.providerApiKeyEnv}}`,
-        },
-      },
+      [liveProviderConfig.id]: providerConfig,
     },
     small_model: toOpenCodeModelId(readLiveSmallModel()),
   });


### PR DESCRIPTION
## Summary
- add DeepSeek as a live OpenCode ACP provider using the OpenAI-compatible AI SDK provider config
- pass runtime proxy env through to ACP child processes so OpenCode can reach provider endpoints from sandbox runs
- normalize ACP config/options/usage events to Mosoo contracts, including explicit usageContract for cost persistence

## Verification
- just test-file apps/driver/tests/acp-event-translator.test.ts
- just test-file apps/driver/tests/acp-configuration.test.ts
- just tc-package agent-driver
- vp run --filter agent-driver build
- just -f apps/driver/justfile live-opencode with provider=deepseek returned pong
- just -f apps/driver/justfile live-anthropic returned pong
