### PR TITLE
fix(acp): surface thought-only OpenCode output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ ANTHROPIC_API_KEY=
 # OpenCode ACP live smoke test.
 # just live-opencode sets AGENT_DRIVER_LIVE_OPENCODE=1 automatically.
 # If running the test file directly, set AGENT_DRIVER_LIVE_OPENCODE=1 yourself.
-# Supported values: openai, anthropic, deepseek, opencode.
+# Supported values: openai, anthropic, deepseek, zhipu, opencode.
 AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=openai
 AGENT_DRIVER_LIVE_OPENCODE_API_KEY=
 AGENT_DRIVER_LIVE_OPENCODE_MODEL=gpt-5.4
@@ -42,6 +42,11 @@ AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=gpt-5-nano
 # AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=opencode
 # AGENT_DRIVER_LIVE_OPENCODE_MODEL=deepseek-v4-flash-free
 # AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=deepseek-v4-flash-free
+
+# Zhipu official API example:
+# AGENT_DRIVER_LIVE_OPENCODE_PROVIDER=zhipu
+# AGENT_DRIVER_LIVE_OPENCODE_MODEL=glm-4.7
+# AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=glm-4.7-flash
 
 # ACP fallback runtime. The packaged Docker image defaults this generic ACP
 # fallback to OpenCode. Override these for another ACP-compatible agent.

--- a/src/runtimes/acp/acp-event-translator.ts
+++ b/src/runtimes/acp/acp-event-translator.ts
@@ -45,6 +45,7 @@ export class AcpTurnEventState {
   #sequence = 0;
   #sessionId: string | null = null;
   #thoughtCompleted = false;
+  #thoughtFallbackText = "";
   #thoughtId: string | null = null;
   #thoughtStarted = false;
   readonly #tools = new AcpToolEventState();
@@ -61,6 +62,7 @@ export class AcpTurnEventState {
     this.#sequence = 0;
     this.#sessionId = input.sessionId;
     this.#thoughtCompleted = false;
+    this.#thoughtFallbackText = "";
     this.#thoughtId = `${input.messageId}:thought`;
     this.#thoughtStarted = false;
     this.#tools.clear();
@@ -74,6 +76,7 @@ export class AcpTurnEventState {
     this.#sequence = 0;
     this.#sessionId = null;
     this.#thoughtCompleted = false;
+    this.#thoughtFallbackText = "";
     this.#thoughtId = null;
     this.#thoughtStarted = false;
     this.#tools.clear();
@@ -82,6 +85,8 @@ export class AcpTurnEventState {
   completePrompt(stopReason: AcpPromptStopReason, usage: unknown): DriverEventInput[] {
     const events: DriverEventInput[] = [];
     const runId = this.#requireRunId();
+
+    events.push(...this.#promoteThoughtFallbackToMessage());
 
     if (this.#messageStarted && !this.#messageCompleted) {
       this.#messageCompleted = true;
@@ -348,6 +353,10 @@ export class AcpTurnEventState {
       return [];
     }
 
+    if (!this.#messageStarted && readNonEmptyString(update, "messageId") !== null) {
+      this.#thoughtFallbackText += delta;
+    }
+
     return [
       ...this.#ensureThoughtStarted(),
       {
@@ -444,6 +453,7 @@ export class AcpTurnEventState {
     }
 
     this.#messageStarted = true;
+    this.#thoughtFallbackText = "";
     return [
       {
         kind: "message.started",
@@ -452,6 +462,46 @@ export class AcpTurnEventState {
           role: "agent",
         },
         runId: this.#requireRunId(),
+      },
+    ];
+  }
+
+  #promoteThoughtFallbackToMessage(): DriverEventInput[] {
+    if (this.#messageStarted) {
+      return [];
+    }
+
+    const contentDelta = this.#thoughtFallbackText.trim();
+
+    if (contentDelta.length === 0) {
+      return [];
+    }
+
+    this.#messageStarted = true;
+    this.#thoughtFallbackText = "";
+    return [
+      {
+        kind: "message.started",
+        payload: {
+          messageId: this.#requireMessageId(),
+          role: "agent",
+        },
+        runId: this.#requireRunId(),
+      },
+      {
+        delivery: "best_effort",
+        kind: "message.delta",
+        payload: {
+          contentBlock: {
+            text: contentDelta,
+            type: "text",
+          },
+          contentDelta,
+          messageId: this.#requireMessageId(),
+          role: "agent",
+        },
+        runId: this.#requireRunId(),
+        sourceEventId: this.#nextSourceEventId("agent-thought-fallback-message"),
       },
     ];
   }

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -262,6 +262,56 @@ describe("ACP runtime event translation", () => {
     ).toEqual([]);
   });
 
+  test("promotes message-scoped thought-only ACP output into an assistant message", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const events = [
+      ...state.translateUpdate({
+        update: {
+          content: {
+            text: "\n",
+            type: "text",
+          },
+          messageId: "opencode-message-1",
+          sessionUpdate: "agent_thought_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: {
+            text: "pong",
+            type: "text",
+          },
+          messageId: "opencode-message-1",
+          sessionUpdate: "agent_thought_chunk",
+        },
+      }),
+      ...state.completePrompt("end_turn", null),
+    ];
+
+    expect(eventKinds(events)).toEqual([
+      "thought.started",
+      "thought.delta",
+      "thought.delta",
+      "message.started",
+      "message.delta",
+      "message.completed",
+      "thought.completed",
+      "run.completed",
+    ]);
+    expect(eventPayload(events[4])).toMatchObject({
+      contentDelta: "pong",
+      messageId: "message-1",
+      role: "agent",
+    });
+  });
+
   test("closes open stream items before a failed turn event", () => {
     const state = new AcpTurnEventState();
 

--- a/tests/opencode-acp-live.test.ts
+++ b/tests/opencode-acp-live.test.ts
@@ -23,16 +23,19 @@ const ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
 const DEEPSEEK_API_KEY_ENV = "DEEPSEEK_API_KEY";
 const OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY";
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+const ZHIPU_API_KEY_ENV = "ZHIPU_API_KEY";
 const LIVE_START_TIMEOUT_MS = 120_000;
 const LIVE_TURN_TIMEOUT_MS = 120_000;
 const OPENCODE_ACP_ARGS = ["acp", "--pure", "--print-logs", "--log-level", "DEBUG"] as const;
 
-type OpenCodeLiveProvider = "anthropic" | "deepseek" | "openai" | "opencode";
+type OpenCodeLiveProvider = "anthropic" | "deepseek" | "openai" | "opencode" | "zhipu";
 
 interface OpenCodeLiveProviderConfig {
+  readonly apiBase?: string;
   readonly defaultModel: string;
   readonly defaultSmallModel: string;
   readonly id: OpenCodeLiveProvider;
+  readonly openCodeProviderId?: string;
   readonly providerApiKeyEnv: string;
 }
 
@@ -60,6 +63,14 @@ const PROVIDER_CONFIGS = {
     defaultSmallModel: "deepseek-v4-flash-free",
     id: "opencode",
     providerApiKeyEnv: OPENCODE_API_KEY_ENV,
+  },
+  zhipu: {
+    apiBase: "https://api.z.ai/api/paas/v4",
+    defaultModel: "glm-4.7",
+    defaultSmallModel: "glm-4.7-flash",
+    id: "zhipu",
+    openCodeProviderId: "zai",
+    providerApiKeyEnv: ZHIPU_API_KEY_ENV,
   },
 } as const satisfies Record<OpenCodeLiveProvider, OpenCodeLiveProviderConfig>;
 
@@ -116,7 +127,8 @@ function readLiveProvider(): OpenCodeLiveProvider {
     provider === "anthropic" ||
     provider === "deepseek" ||
     provider === "openai" ||
-    provider === "opencode"
+    provider === "opencode" ||
+    provider === "zhipu"
   ) {
     return provider;
   }
@@ -196,8 +208,9 @@ function readOpenCodeVersion(command: string): string {
 
 function toOpenCodeModelId(model: string): string {
   const providerConfig = liveProviderConfig ?? PROVIDER_CONFIGS.openai;
+  const providerId = providerConfig.openCodeProviderId ?? providerConfig.id;
 
-  return model.includes("/") ? model : `${providerConfig.id}/${model}`;
+  return model.includes("/") ? model : `${providerId}/${model}`;
 }
 
 function createOpenCodeConfig(): string {
@@ -207,13 +220,18 @@ function createOpenCodeConfig(): string {
   const options: Record<string, string> = {
     apiKey: `{env:${liveProviderConfig.providerApiKeyEnv}}`,
   };
+  const providerId = liveProviderConfig.openCodeProviderId ?? liveProviderConfig.id;
+
+  if (liveProviderConfig.apiBase !== undefined) {
+    options["baseURL"] = liveProviderConfig.apiBase;
+  }
 
   return JSON.stringify({
     $schema: "https://opencode.ai/config.json",
-    enabled_providers: [liveProviderConfig.id],
+    enabled_providers: [providerId],
     model: toOpenCodeModelId(readLiveModel()),
     provider: {
-      [liveProviderConfig.id]: { options },
+      [providerId]: { options },
     },
     small_model: toOpenCodeModelId(readLiveSmallModel()),
   });


### PR DESCRIPTION
## Summary
- add Zhipu live OpenCode ACP smoke config using OpenCode provider id `zai`
- promote message-scoped thought-only ACP output into assistant message events

## Verification
- vp fmt --check --ignore-path .gitignore src/runtimes/acp/acp-event-translator.ts tests/acp-event-translator.test.ts
- vp exec bun test tests/acp-event-translator.test.ts
- vp exec bun test tests/acp-provider-fixtures.test.ts
- bun run tc
- vp exec bun test tests/opencode-acp-live.test.ts with live Zhipu key