### PR TITLE
style(driver): format root-visible files

### DIFF
--- a/src/host-ports/index.ts
+++ b/src/host-ports/index.ts
@@ -69,7 +69,6 @@ export interface AgentDriverHostIntegrationPort {
   snapshot(): Promise<DriverHostIntegrationSnapshot | null>;
 }
 
-
 export interface AgentDriverHostPorts {
   commandSource: AgentDriverCommandSource;
   eventSink: AgentDriverEventSink;

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -67,7 +67,6 @@ function createCanUseTool(context: AgentDriverContext): CanUseTool {
   };
 }
 
-
 function toClaudeMcpServers(
   servers: DriverBootMcpServer[],
 ): Record<string, McpServerConfig> | undefined {

--- a/src/runtimes/openai/mcp-config.ts
+++ b/src/runtimes/openai/mcp-config.ts
@@ -20,7 +20,6 @@ function isAuthorized(server: DriverBootMcpServer): server is AuthorizedDriverBo
   return server.authorizationState === "active";
 }
 
-
 function toBearerTokenEnvName(index: number): string {
   return `MOSOO_MCP_BEARER_TOKEN_${index}`;
 }

--- a/src/runtimes/provider-registry.ts
+++ b/src/runtimes/provider-registry.ts
@@ -85,7 +85,6 @@ export function createAgentDriverProviderRegistry(
 
   for (const provider of providers) {
     registerProviderTransport(providersByTransport, provider, provider.id);
-
   }
 
   return {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -101,14 +101,7 @@ describe("provider registry", () => {
       },
       {
         id: "acp-fallback",
-        requiredHostPorts: [
-          "event_sink",
-          "permission",
-          "mcp",
-          "skill",
-          "file",
-          "host_integration",
-        ],
+        requiredHostPorts: ["event_sink", "permission", "mcp", "skill", "file", "host_integration"],
       },
     ]);
   });


### PR DESCRIPTION
## Summary\n- Format root-visible driver files so Mosoo root formatter passes when this submodule commit is referenced.\n\n## Verification\n- vp fmt --check config scripts vite.config.ts justfile apps pkgs e2e --ignore-path .gitignore (from Mosoo root)\n- vp fmt --check --ignore-path .gitignore src/host-ports/index.ts src/runtimes/claude/agent-sdk-query-options.ts src/runtimes/openai/mcp-config.ts src/runtimes/provider-registry.ts tests/provider-registry.test.ts\n- vp exec bun test tests/provider-registry.test.ts\n- bun run tc