### PR TITLE
fix(acp): normalize opencode tool events

### DIFF
--- a/src/runtimes/acp/acp-client-request-handler.ts
+++ b/src/runtimes/acp/acp-client-request-handler.ts
@@ -218,7 +218,10 @@ export class AcpClientRequestHandler {
       return;
     }
 
-    if (this.#replayingSession && shouldIgnoreAcpReplayUpdate(params)) {
+    if (
+      (this.#replayingSession || this.#turnEvents.activeRunId() === null) &&
+      shouldIgnoreAcpReplayUpdate(params)
+    ) {
       return;
     }
 

--- a/src/runtimes/acp/acp-tool-events.ts
+++ b/src/runtimes/acp/acp-tool-events.ts
@@ -1,11 +1,35 @@
 import type { DriverEventInput } from "../../protocol/events";
 import type { RunId } from "../../protocol/id";
-import { readNonEmptyString, readNullableString, readString } from "./acp-types";
+import {
+  isRecord,
+  readNonEmptyString,
+  readNullableString,
+  readString,
+  stringifyForDisplay,
+} from "./acp-types";
 import type { JsonObject } from "./acp-types";
 
 export type RuntimeToolStatus = "completed" | "failed" | "running";
 
 const TERMINAL_TOOL_STATUSES = new Set(["cancelled", "completed", "failed"]);
+
+function readToolDisplayString(value: unknown): string | undefined {
+  const display = stringifyForDisplay(value);
+
+  return display.length > 0 ? display : undefined;
+}
+
+function readToolContentString(value: unknown): string | undefined {
+  if (isRecord(value)) {
+    const text = readString(value, "text");
+
+    if (text !== null && text.length > 0) {
+      return text;
+    }
+  }
+
+  return readToolDisplayString(value);
+}
 
 export class AcpToolEventState {
   readonly #completed = new Set<string>();
@@ -115,12 +139,16 @@ export function toToolCallPayload(
   status: RuntimeToolStatus,
   update: JsonObject | null,
 ): JsonObject {
+  const content = readToolContentString(update?.["content"]);
+  const rawInput = readToolDisplayString(update?.["rawInput"]);
+  const rawOutput = readToolDisplayString(update?.["rawOutput"]);
+
   return {
-    content: update?.["content"],
+    ...(content === undefined ? {} : { content }),
     kind: readNonEmptyString(update, "kind") ?? "tool",
     locations: update?.["locations"],
-    rawInput: update?.["rawInput"],
-    rawOutput: update?.["rawOutput"],
+    ...(rawInput === undefined ? {} : { rawInput }),
+    ...(rawOutput === undefined ? {} : { rawOutput }),
     status,
     title: readNullableString(update, "title") ?? null,
     toolCallId,

--- a/tests/acp-client-request-handler.test.ts
+++ b/tests/acp-client-request-handler.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { AcpClientRequestHandler } from "../src/runtimes/acp/acp-client-request-handler";
+import { AcpTurnEventState } from "../src/runtimes/acp/acp-event-translator";
+
+describe("ACP client request handler", () => {
+  test("suppresses turn-scoped session updates before a turn is active", async () => {
+    const pushedReasons: string[] = [];
+    const handler = new AcpClientRequestHandler({
+      allowedRoots: [],
+      cwd: "/workspace",
+      isTurnCancelRequested: () => false,
+      nativeSessionId: () => "native-session-1",
+      push: async (_context, reason, _events) => {
+        pushedReasons.push(reason);
+      },
+      turnEvents: new AcpTurnEventState(),
+    });
+
+    for (const replaying of [false, true]) {
+      const sendUpdate = async () => {
+        await handler.handleNotification({} as never, {
+          method: "session/update",
+          params: {
+            sessionId: "native-session-1",
+            update: {
+              content: {
+                text: "replayed assistant text",
+                type: "text",
+              },
+              sessionUpdate: "agent_message_chunk",
+            },
+          },
+        });
+      };
+
+      if (replaying) {
+        await handler.withSessionReplay(sendUpdate);
+      } else {
+        await sendUpdate();
+      }
+    }
+
+    expect(pushedReasons).toEqual([]);
+  });
+});

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
 import type { DriverEventInput } from "../src/protocol/events";
 import {
   AcpTurnEventState,
@@ -7,6 +8,7 @@ import {
   toAcpPermissionResolvedEvent,
   toAcpSessionReadyEvents,
 } from "../src/runtimes/acp/acp-event-translator";
+import { DRIVER_TEST_IDS, driverBootPayload } from "./driver-boot-payload-fixture";
 
 function eventKinds(events: readonly DriverEventInput[]): string[] {
   return events.map((event) => event.kind);
@@ -83,6 +85,47 @@ describe("ACP runtime event translation", () => {
     expect(kinds.filter((kind) => kind === "item.started")).toHaveLength(1);
     expect(kinds.filter((kind) => kind === "item.completed")).toHaveLength(1);
     expect(kinds.every((kind) => kind.includes("."))).toBe(true);
+  });
+
+  test("omits empty ACP tool input before runtime event ingress", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: DRIVER_TEST_IDS.runId,
+      sessionId: DRIVER_TEST_IDS.sessionId,
+    });
+
+    const events = state.translateUpdate({
+      update: {
+        content: {
+          text: "Creating file",
+          type: "text",
+        },
+        rawInput: "",
+        sessionUpdate: "tool_call",
+        status: "running",
+        title: "Create file",
+        toolCallId: "tool-1",
+      },
+    });
+    const toolEvent = events.find((event) => event.kind === "tool.call.updated");
+
+    expect(toolEvent).toBeDefined();
+    expect(eventPayload(toolEvent as DriverEventInput)).toMatchObject({
+      content: "Creating file",
+    });
+    expect(eventPayload(toolEvent as DriverEventInput)).not.toHaveProperty("rawInput");
+
+    const envelopes = events.flatMap((event) =>
+      toDriverEventEnvelopes(driverBootPayload, event, DRIVER_TEST_IDS.runId),
+    );
+    const canonicalToolEvent = envelopes
+      .map((envelope) => envelope.event)
+      .find((event) => event.kind === "tool.call.updated");
+
+    expect(canonicalToolEvent).toBeDefined();
+    expect(eventPayload(canonicalToolEvent as DriverEventInput)).not.toHaveProperty("rawInput");
   });
 
   test("preserves the ACP request id across permission request and resolution events", () => {

--- a/tests/fixtures/providers/acp/cases/permission-request.json
+++ b/tests/fixtures/providers/acp/cases/permission-request.json
@@ -48,9 +48,7 @@
       "kind": "tool.call.updated",
       "payload": {
         "kind": "shell",
-        "rawInput": {
-          "command": "pwd"
-        },
+        "rawInput": "{\"command\":\"pwd\"}",
         "status": "running",
         "title": "Run command",
         "toolCallId": "tool-1"
@@ -79,9 +77,7 @@
         "title": "Run command",
         "toolCall": {
           "kind": "shell",
-          "rawInput": {
-            "command": "pwd"
-          },
+          "rawInput": "{\"command\":\"pwd\"}",
           "status": "running",
           "title": "Run command",
           "toolCallId": "tool-1"

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -91,9 +91,7 @@
       "kind": "tool.call.updated",
       "payload": {
         "kind": "shell",
-        "rawInput": {
-          "command": "pwd"
-        },
+        "rawInput": "{\"command\":\"pwd\"}",
         "status": "running",
         "title": "Run command",
         "toolCallId": "tool-1"
@@ -106,9 +104,7 @@
       "kind": "tool.call.updated",
       "payload": {
         "kind": "tool",
-        "rawOutput": {
-          "text": "/workspace"
-        },
+        "rawOutput": "{\"text\":\"/workspace\"}",
         "status": "completed",
         "title": null,
         "toolCallId": "tool-1"
@@ -133,9 +129,7 @@
       "kind": "tool.call.updated",
       "payload": {
         "kind": "tool",
-        "rawOutput": {
-          "text": "/workspace"
-        },
+        "rawOutput": "{\"text\":\"/workspace\"}",
         "status": "completed",
         "title": null,
         "toolCallId": "tool-1"


### PR DESCRIPTION
## Summary
- normalize ACP tool call content/rawInput/rawOutput before runtime event ingress
- suppress replayed turn-scoped ACP updates before a live run is active
- update ACP provider fixtures for normalized tool payloads

## Verification
- git diff --check
- bun run tc
- bun run lint
- bun run test
- bun test tests/acp-client-request-handler.test.ts tests/acp-event-translator.test.ts
- bun run build
- Local Mosoo smoke: MiniMax M3 + OpenCode created outputs/minimax-smoke-5.txt and completed run 01KWCFJ78JQ66NEWQVVEQRH107

## Generated files
- None

## GraphQL / DB
- Not touched; codegen and migrations not run
