### PR TITLE
fix(skill): allow arbitrary support files in skill packages

### DIFF
--- a/src/skill-package/path-admission.ts
+++ b/src/skill-package/path-admission.ts
@@ -12,7 +12,6 @@ export interface SkillPackagePathAdmission {
 }
 
 export const SKILL_PACKAGE_MANIFEST_PATH = "SKILL.md";
-export const SKILL_PACKAGE_ALLOWED_ROOTS = ["assets", "references", "scripts"] as const;
 
 const RESERVED_PATH_KEYS = new Set([
   "__proto__",
@@ -31,7 +30,6 @@ const RESERVED_PATH_KEYS = new Set([
   "tokens",
   "vault",
 ]);
-const ALLOWED_ROOTS = new Set<string>(SKILL_PACKAGE_ALLOWED_ROOTS);
 
 export function createSkillPackagePathAdmission(): SkillPackagePathAdmission {
   const entries = new Map<string, SkillPackagePathKind>();
@@ -163,17 +161,6 @@ export function rejectUnsupportedArchivePath(admitted: AdmittedSkillPackagePath)
     );
   }
 
-  const [root] = admitted.path.split("/");
-
-  if (root === undefined || !ALLOWED_ROOTS.has(root)) {
-    throw new SkillPackageError(
-      `The skill package path is outside allowed roots: ${admitted.path}`,
-    );
-  }
-
-  if (admitted.path === root && admitted.entryKind !== "directory") {
-    throw new SkillPackageError(`The skill package root must be a directory: ${root}`);
-  }
 }
 
 function isAbsolutePath(path: string): boolean {


### PR DESCRIPTION
## Summary

- Drop the root whitelist (`assets/`, `references/`, `scripts/`) from the vendored skill-package path admission so the driver can materialize skills that bundle support files under custom roots (e.g. root-level `LICENSE.txt`, a `canvas-fonts/` directory).
- All other admission rules are unchanged: `SKILL.md` must be a root-level file with no child entries, and reserved-key, dotfile, traversal, control-character, absolute-path, duplicate, and file/directory-collision checks still apply.
- Removes the now-meaningless `SKILL_PACKAGE_ALLOWED_ROOTS` export.

## Why

Companion to langgenius/mosoo#205, which relaxes the same rule in the API's upload/import validation. Without this change, skills accepted by the API — such as [anthropics/skills canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design) — would still fail with `The skill package path is outside allowed roots` when the driver extracts them at session start.

## Verification

- `bun test` — 145 pass, 4 skip, 0 fail (including `tests/skill-materialization.test.ts`).
- `bun run tc` and `bun run lint` — clean.
- The real canvas-design zip was verified end to end against the identical admission logic in the mosoo PR.

## Notes

The `apps/driver` submodule pin in langgenius/mosoo should be bumped to include this commit after both PRs merge.
