### PR TITLE
fix(acp): keep fallback sessions from stalling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG CLAUDE_AGENT_SDK_VERSION=0.3.158
 ARG ANTHROPIC_SDK_VERSION=0.100.1
 ARG OPENAI_RUNTIME_VERSION=0.135.0
 ARG OPENCODE_VERSION=1.17.7
+ARG WRANGLER_VERSION=4.103.0
 
 # Native agent CLIs pre-installed so the driver can spawn them via PATH.
 # Installed in a single npm invocation so Docker caches the whole agent
@@ -25,9 +26,11 @@ RUN OPENAI_RUNTIME_PACKAGE="@openai/co""dex@${OPENAI_RUNTIME_VERSION}" \
       @anthropic-ai/claude-agent-sdk@${CLAUDE_AGENT_SDK_VERSION} \
       @anthropic-ai/sdk@${ANTHROPIC_SDK_VERSION} \
       opencode-ai@${OPENCODE_VERSION} \
+      wrangler@${WRANGLER_VERSION} \
       "$OPENAI_RUNTIME_PACKAGE" \
     && opencode --version \
     && opencode acp --help >/dev/null \
+    && wrangler --version >/dev/null \
     && CLAUDE_ARCH_PACKAGE="$(node -p "'@anthropic-ai/claude-agent-sdk-' + (process.arch === 'arm64' ? 'linux-arm64' : 'linux-x64')")" \
     && CLAUDE_BIN="/usr/local/lib/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/${CLAUDE_ARCH_PACKAGE}/claude" \
     && test -x "$CLAUDE_BIN" \

--- a/src/core/agent-driver-kernel.ts
+++ b/src/core/agent-driver-kernel.ts
@@ -310,7 +310,12 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
   #createContext(payload: DriverStartInput): AgentDriverContext {
     return createAgentDriverContext({
       eventSink: this,
-      ...(this.#hostPorts === undefined ? {} : { ports: this.#hostPorts }),
+      ports: {
+        ...this.#hostPorts,
+        lifecycle: {
+          shutdown: async (reason) => this.#shutdown(reason),
+        },
+      },
       payload,
       logger: this.#logger,
       permission: {

--- a/src/core/driver-process.ts
+++ b/src/core/driver-process.ts
@@ -136,6 +136,7 @@ export class DriverProcess {
         });
 
         const runtimeContext = this.createAgentDriverContext(socket, logger);
+        this.#heartbeatLoop.start(socket, logger, hello.heartbeatIntervalMs);
 
         const backendLoadStartedAtMs = Date.now();
         const backend = await logger.span("driver.backend.load", async () =>
@@ -163,7 +164,6 @@ export class DriverProcess {
           runtime: this.payload.runtime,
         });
 
-        this.#heartbeatLoop.start(socket, logger, hello.heartbeatIntervalMs);
         const commandDispatcher = new DriverCommandDispatcher({
           backend,
           driverInstanceId: this.payload.driverInstanceId,
@@ -353,6 +353,9 @@ export class DriverProcess {
         },
         hostIntegration: {
           snapshot: async () => this.#hostSnapshot,
+        },
+        lifecycle: {
+          shutdown: async (reason) => this.shutdown(socket, reason),
         },
         skill: {
           materialize: async (execution) => materializeResolvedSkills(execution, logger),

--- a/src/host-ports/index.ts
+++ b/src/host-ports/index.ts
@@ -11,7 +11,8 @@ export type AgentDriverHostPortName =
   | "mcp"
   | "skill"
   | "file"
-  | "host_integration";
+  | "host_integration"
+  | "lifecycle";
 
 export interface AgentDriverCommandSource {
   nextCommand(): Promise<RuntimeCommand | null>;
@@ -69,11 +70,16 @@ export interface AgentDriverHostIntegrationPort {
   snapshot(): Promise<DriverHostIntegrationSnapshot | null>;
 }
 
+export interface AgentDriverLifecyclePort {
+  shutdown(reason: string): Promise<void>;
+}
+
 export interface AgentDriverHostPorts {
   commandSource: AgentDriverCommandSource;
   eventSink: AgentDriverEventSink;
   file: AgentDriverFilePort;
   hostIntegration: AgentDriverHostIntegrationPort;
+  lifecycle: AgentDriverLifecyclePort;
   mcp: AgentDriverMcpPort;
   permission: AgentDriverPermissionPort;
   skill: AgentDriverSkillPort;

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -114,7 +114,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
     const env = buildAcpChildProcessEnv(this.#payload);
     const agentProcess = await startAcpAgentProcess(context, this.#payload, env);
     this.#agentProcess = agentProcess;
-    this.#connection = new AcpJsonRpcConnection({
+    const connection = new AcpJsonRpcConnection({
       onInvalidMessage: (error, line) => {
         context.logger.warn("driver.acp.message.invalid", {
           line,
@@ -130,9 +130,18 @@ export class AcpDriverBackend implements AgentDriverBackend {
       stdin: agentProcess.stdin,
       stdout: agentProcess.stdout,
     });
+    this.#connection = connection;
+    agentProcess.once("exit", (code, signal) => {
+      const reason = `ACP agent process exited with ${
+        code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`
+      }.`;
+
+      connection.close(reason);
+      void context.ports.lifecycle.shutdown(reason);
+    });
 
     const initResult = parseAcpInitializeResult(
-      await this.#connection.request("initialize", {
+      await connection.request("initialize", {
         clientCapabilities: buildAcpClientCapabilities(),
         clientInfo: {
           name: "mosoo-driver",

--- a/src/runtimes/acp/acp-session-events.ts
+++ b/src/runtimes/acp/acp-session-events.ts
@@ -235,11 +235,23 @@ function normalizeConfigValueOptions(raw: unknown): JsonObject[] {
   }
 
   return raw.flatMap((entry): JsonObject[] => {
+    if (typeof entry === "string") {
+      return [
+        {
+          name: entry,
+          value: entry,
+        },
+      ];
+    }
+
     if (!isRecord(entry)) {
       return [];
     }
 
-    const value = readNonEmptyString(entry, "value");
+    const value =
+      readNonEmptyString(entry, "value") ??
+      readNonEmptyString(entry, "id") ??
+      readNonEmptyString(entry, "name");
 
     if (value === null) {
       return [];
@@ -267,12 +279,12 @@ function normalizeConfigOptions(raw: unknown): JsonObject[] | null {
   }
 
   return raw.flatMap((entry): JsonObject[] => {
-    if (!isRecord(entry) || entry["type"] !== "select") {
+    if (!isRecord(entry) || (entry["type"] !== undefined && entry["type"] !== "select")) {
       return [];
     }
 
-    const id = readNonEmptyString(entry, "id");
-    const currentValue = readString(entry, "currentValue");
+    const id = readNonEmptyString(entry, "id") ?? readNonEmptyString(entry, "name");
+    const currentValue = readString(entry, "currentValue") ?? readString(entry, "value") ?? "";
 
     if (id === null) {
       return [];
@@ -287,12 +299,12 @@ function normalizeConfigOptions(raw: unknown): JsonObject[] | null {
     return [
       {
         ...(category === undefined ? {} : { category }),
-        ...(currentValue === null ? {} : { currentValue }),
+        currentValue,
         ...(description === undefined ? {} : { description }),
         id,
-        ...(name === null ? {} : { name }),
+        name: name ?? id,
         type: "select",
-        ...(values === null ? {} : { values }),
+        values: values ?? [],
       },
     ];
   });

--- a/src/runtimes/agent-driver-backend.ts
+++ b/src/runtimes/agent-driver-backend.ts
@@ -5,6 +5,7 @@ import type {
   AgentDriverFilePort,
   AgentDriverHostIntegrationPort,
   AgentDriverHostPorts,
+  AgentDriverLifecyclePort,
   AgentDriverMcpPort,
   AgentDriverPermissionPort,
   AgentDriverSkillPort,
@@ -27,6 +28,7 @@ export type AgentDriverContextPortOverrides = Partial<{
   eventSink: AgentDriverEventSink;
   file: AgentDriverFilePort;
   hostIntegration: AgentDriverHostIntegrationPort;
+  lifecycle: AgentDriverLifecyclePort;
   mcp: AgentDriverMcpPort;
   permission: AgentDriverPermissionPort;
   skill: AgentDriverSkillPort;
@@ -92,6 +94,9 @@ function createDefaultHostPorts(input: AgentDriverContextInput): AgentDriverHost
     },
     hostIntegration: {
       snapshot: async () => null,
+    },
+    lifecycle: {
+      shutdown: async () => {},
     },
     mcp: {
       execute: async () => {

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -426,11 +426,15 @@ describe("ACP runtime event translation", () => {
       setup: {
         configOptions: [
           {
+            id: "approval",
+          },
+          {
             category: "model",
             currentValue: "deepseek/deepseek-v4-pro",
             id: "model",
             name: "Model",
             options: [
+              "deepseek/deepseek-v4-flash",
               {
                 name: "DeepSeek/DeepSeek V4 Pro",
                 value: "deepseek/deepseek-v4-pro",
@@ -447,12 +451,23 @@ describe("ACP runtime event translation", () => {
     expect(payload).toEqual({
       options: [
         {
+          currentValue: "",
+          id: "approval",
+          name: "approval",
+          type: "select",
+          values: [],
+        },
+        {
           category: "model",
           currentValue: "deepseek/deepseek-v4-pro",
           id: "model",
           name: "Model",
           type: "select",
           values: [
+            {
+              name: "deepseek/deepseek-v4-flash",
+              value: "deepseek/deepseek-v4-flash",
+            },
             {
               name: "DeepSeek/DeepSeek V4 Pro",
               value: "deepseek/deepseek-v4-pro",

--- a/tests/agent-driver-kernel.test.ts
+++ b/tests/agent-driver-kernel.test.ts
@@ -162,4 +162,35 @@ describe("AgentDriverKernelCore", () => {
     expect(mcpOutput).toBe("port:complete");
     expect(materializedSkillName).toBe("review");
   });
+
+  test("lets backend lifecycle shutdown stop the kernel", async () => {
+    const backend = createBackend();
+    let context: AgentDriverContext | null = null;
+    let stopReason: string | null = null;
+    backend.start = async (inputContext: AgentDriverContext) => {
+      context = inputContext;
+    };
+    backend.stop = async (_inputContext: AgentDriverContext, reason: string) => {
+      stopReason = reason;
+    };
+    const kernel = new AgentDriverKernelCore({
+      backendFactory: async () => backend,
+    });
+
+    await kernel.start(bootPayload);
+    await context?.ports.lifecycle.shutdown("backend.exit");
+
+    expect(stopReason).toBe("backend.exit");
+    await expect(
+      kernel.dispatch({
+        commandId: "input-after-shutdown",
+        input: {
+          text: "hello",
+        },
+        kind: "input.start",
+        requestId: "request-1",
+        runId: DRIVER_TEST_IDS.runId,
+      }),
+    ).rejects.toThrow("Driver kernel is shutting down.");
+  });
 });

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -109,9 +109,12 @@ describe("driver artifact contract", () => {
     expect(buildScript).toContain("src/bin/driver.ts");
     expect(buildScript).toContain("dist/driver.mjs");
     expect(buildScript).not.toContain("src/index.ts");
+    expect(dockerfile).toContain("ARG WRANGLER_VERSION=4.103.0");
     expect(dockerfile).toContain("COPY dist/driver.mjs /usr/local/bin/agent-driver");
     expect(dockerfile).toContain("RUN chmod +x /usr/local/bin/agent-driver");
     expect(dockerfile).toContain("ENV MOSOO_ACP_FALLBACK_COMMAND=opencode");
+    expect(dockerfile).toContain("wrangler@${WRANGLER_VERSION}");
+    expect(dockerfile).toContain("wrangler --version");
     expect(dockerignore).toContain("!dist/driver.mjs");
     expect(dockerBuildScript).toBe("bun run build && docker build -t agent-driver:local .");
   });

--- a/tests/fixtures/providers/acp/cases/session-ready.json
+++ b/tests/fixtures/providers/acp/cases/session-ready.json
@@ -62,8 +62,11 @@
       "payload": {
         "options": [
           {
+            "currentValue": "",
             "id": "approval",
-            "type": "select"
+            "name": "approval",
+            "type": "select",
+            "values": []
           }
         ]
       }


### PR DESCRIPTION
### What's changed?

- Start driver heartbeats after hello while keeping ready gated on backend startup.
- Shut down the driver lifecycle when the ACP child process exits so dead fallback sessions are not reused.
- Normalize ACP config options into the Mosoo session config shape and package wrangler in the driver image.

### Why

- ACP fallback startup can exceed the ready wait path and child process exits can leave the driver half-alive.
- Mosoo expects canonical session config and usage payloads before projecting runtime events.

### Verification

- `bun test tests/acp-event-translator.test.ts tests/driver-artifact-contract.test.ts`
- `bun test tests/agent-driver-kernel.test.ts`
- `bun run lint`
- `bun run tc`
- `bun run test`
- `bun run build`
- `docker build -t agent-driver:ship-acp-runtime-contracts .`

### Notes

- This PR is based on `fix/log-uplink-non-fatal` / PR #31 because current Mosoo `main` already points at that driver commit; this keeps the Mosoo submodule update as a forward move.
- Docker reported the existing local base-image platform warning for `cloudflare/sandbox:0.10.3` on arm64; the image build completed.