### PR TITLE
fix(logging): make log uplink non-fatal and gate it on hello

### DIFF
--- a/src/core/driver-process.ts
+++ b/src/core/driver-process.ts
@@ -3,6 +3,7 @@ import {
   createDriverLogger,
   runWithDriverLogContext,
 } from "../infrastructure/logging/driver-logger";
+import type { DriverLogUplink } from "../infrastructure/logging/driver-logger";
 import { DriverInstanceSocket } from "../infrastructure/runtime/driver-instance-socket";
 import type { Logger } from "../observability";
 import { DRIVER_PROTOCOL_VERSION } from "../protocol/boot";
@@ -50,6 +51,7 @@ export class DriverProcess {
   readonly #heartbeatLoop: DriverHeartbeatLoop;
   #backend: AgentDriverBackend | null = null;
   #logger: Logger | null = null;
+  #logUplink: DriverLogUplink | null = null;
   private readonly payload: DriverBootPayload;
   readonly #permissionBroker: DriverPermissionBroker;
   readonly #hostSnapshot: DriverHostIntegrationSnapshot;
@@ -86,8 +88,9 @@ export class DriverProcess {
 
     this.registerSignals(socket);
     await socket.connect();
-    const logger = createDriverLogger(this.payload, socket);
+    const { logger, uplink } = createDriverLogger(this.payload, socket);
     this.#logger = logger;
+    this.#logUplink = uplink;
 
     try {
       await runWithDriverLogContext(this.payload, async () => {
@@ -114,6 +117,9 @@ export class DriverProcess {
           }),
         );
         const initialRunId = parseNullableRunId(hello.runId);
+        // The server accepts pushLogs only after hello commits; release the
+        // buffered boot logs now instead of racing the handshake round-trip.
+        uplink.open();
         const helloDurationMs = toDriverDurationMs(helloStartedAtMs);
 
         logger.info("driver.runtime.hello.completed", {
@@ -196,6 +202,9 @@ export class DriverProcess {
 
     this.#shuttingDown = true;
     this.#shutdownReason = reason;
+    // If hello never completed, a gated flush may still be pending; open the
+    // gate so log teardown cannot hang shutdown.
+    this.#logUplink?.open();
     this.#logger?.debug("driver.runtime.shutdown.requested", {
       driverInstanceId: this.payload.driverInstanceId,
       reason,

--- a/src/infrastructure/logging/driver-logger.ts
+++ b/src/infrastructure/logging/driver-logger.ts
@@ -22,7 +22,10 @@ function createFallbackPayload(
 }
 
 function logFallback(message: string, metadata: Record<string, unknown> = {}): void {
-  globalThis.reportError(new Error(JSON.stringify(createFallbackPayload(message, metadata))));
+  // Logging must never kill the driver: reportError is fatal under Bun (an
+  // unhandled error report exits the process), which turned transient log
+  // uplink failures into "closed before ready" driver deaths.
+  process.stderr.write(`${JSON.stringify(createFallbackPayload(message, metadata))}\n`);
 }
 
 function toDriverLogContext(entry: LogEntry): DriverLogEntry["context"] | undefined {
@@ -93,13 +96,31 @@ function toDriverLogEntry(entry: LogEntry, seq: number): DriverLogEntry {
   };
 }
 
+export interface DriverLogUplink {
+  open(): void;
+}
+
+export interface DriverLoggerHandle {
+  logger: Logger;
+  uplink: DriverLogUplink;
+}
+
 export function createDriverLogger(
   payload: DriverBootPayload,
   socket: DriverInstanceSocket,
-): Logger {
+): DriverLoggerHandle {
   let nextSeq = 0;
+  let openUplink: () => void = () => undefined;
+  // The API rejects pushLogs until the hello handshake commits, and the DO
+  // round-trip for hello can take arbitrarily long in production. Hold every
+  // batch behind this event gate (never a timer) until the boot flow opens it;
+  // the transport's ring buffer bounds what accumulates while gated. Shutdown
+  // paths must also open the gate so a pending flush can never hang teardown.
+  const uplinkOpened = new Promise<void>((resolve) => {
+    openUplink = resolve;
+  });
 
-  return createBufferedSinkLogger({
+  const logger = createBufferedSinkLogger({
     context: {
       sandboxId: payload.sandboxId,
     },
@@ -118,6 +139,7 @@ export function createDriverLogger(
     },
     service: "driver",
     sink: async (entries) => {
+      await uplinkOpened;
       await socket.pushLogs({
         logs: entries.map((entry) => {
           const mapped = toDriverLogEntry(entry, nextSeq);
@@ -127,6 +149,8 @@ export function createDriverLogger(
       });
     },
   });
+
+  return { logger, uplink: { open: openUplink } };
 }
 
 export async function runWithDriverLogContext<T>(

--- a/tests/driver-logger.test.ts
+++ b/tests/driver-logger.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import { createDriverLogger } from "../src/infrastructure/logging/driver-logger";
+import type { DriverInstanceSocket } from "../src/infrastructure/runtime/driver-instance-socket";
+import type { DriverBootPayload } from "../src/protocol/boot";
+import type { DriverLogBatchInput } from "../src/protocol/orpc";
+
+const FLUSH_INTERVAL_MS = 200;
+
+function createBootPayload(): DriverBootPayload {
+  return {
+    driverInstanceId: "01J00000000000000000000DRV",
+    sandboxId: "01J00000000000000000000SBX",
+  } as DriverBootPayload;
+}
+
+interface FakeSocket {
+  batches: Omit<DriverLogBatchInput, "driverInstanceId">[];
+  failNextPush: Error | null;
+  socket: DriverInstanceSocket;
+}
+
+function createFakeSocket(): FakeSocket {
+  const state: FakeSocket = {
+    batches: [],
+    failNextPush: null,
+    socket: null as unknown as DriverInstanceSocket,
+  };
+
+  state.socket = {
+    pushLogs: async (input: Omit<DriverLogBatchInput, "driverInstanceId">) => {
+      if (state.failNextPush) {
+        const error = state.failNextPush;
+        state.failNextPush = null;
+        throw error;
+      }
+
+      state.batches.push(input);
+    },
+  } as unknown as DriverInstanceSocket;
+
+  return state;
+}
+
+async function waitForFlushWindow(): Promise<void> {
+  await Bun.sleep(FLUSH_INTERVAL_MS + 100);
+}
+
+describe("createDriverLogger", () => {
+  test("holds log batches until the uplink gate opens", async () => {
+    const fake = createFakeSocket();
+    const { logger, uplink } = createDriverLogger(createBootPayload(), fake.socket);
+
+    logger.info("driver.runtime.boot.loaded");
+    logger.info("driver.runtime.hello.sending");
+
+    await waitForFlushWindow();
+    expect(fake.batches).toHaveLength(0);
+
+    uplink.open();
+    await logger.flush();
+
+    const sent = fake.batches.flatMap((batch) => batch.logs);
+    expect(sent.map((entry) => entry.message)).toEqual([
+      "driver.runtime.boot.loaded",
+      "driver.runtime.hello.sending",
+    ]);
+    expect(sent.map((entry) => entry.seq)).toEqual([0, 1]);
+
+    await logger.destroy();
+  });
+
+  test("keeps the process alive and keeps shipping after an uplink failure", async () => {
+    const fake = createFakeSocket();
+    const { logger, uplink } = createDriverLogger(createBootPayload(), fake.socket);
+    uplink.open();
+
+    const stderrWrites: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrWrites.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      fake.failNextPush = new Error("Internal server error");
+      logger.info("driver.first.batch");
+      await logger.flush();
+
+      logger.info("driver.second.batch");
+      await logger.flush();
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const fallback = stderrWrites.find((line) => line.includes("driver.log.uplink.failed"));
+    expect(fallback).toBeDefined();
+    expect(fallback).toContain("Internal server error");
+
+    // The transport re-buffers a failed batch, so the first entry is retried
+    // and delivered alongside the second flush instead of being lost.
+    const sent = fake.batches.flatMap((batch) => batch.logs);
+    expect(sent.map((entry) => entry.message)).toEqual([
+      "driver.first.batch",
+      "driver.second.batch",
+    ]);
+
+    await logger.destroy();
+  });
+
+  test("opening the gate twice is harmless", async () => {
+    const fake = createFakeSocket();
+    const { logger, uplink } = createDriverLogger(createBootPayload(), fake.socket);
+
+    uplink.open();
+    uplink.open();
+
+    logger.info("driver.after.open");
+    await logger.flush();
+
+    expect(fake.batches.flatMap((batch) => batch.logs)).toHaveLength(1);
+    await logger.destroy();
+  });
+});


### PR DESCRIPTION
Related YEF-806. Replacement for #31 because the original PR branch was blocked by linear-history rules after accumulated merge commits.

## Summary
- gate driver log uplink batches until hello completes
- make log uplink failures fall back to stderr without killing the process
- add driver logger regression coverage

## Verification
- bun run lint (passed; existing warning in tests/driver-runtime-boundary.test.ts)
- bun run tc
- bun run test
- bun run build