### PR TITLE
fix(runtime): preserve canonical final message text

### DIFF
--- a/src/infrastructure/runtime/driver-instance-socket.ts
+++ b/src/infrastructure/runtime/driver-instance-socket.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/websocket";
 
@@ -29,6 +27,7 @@ interface DriverInstanceSocketHandlers {
 export class DriverInstanceSocket {
   #activeRunId: RunId | null = null;
   #client: DriverRuntimeClient | null = null;
+  readonly #sourceEventIdAllocator: DriverEventSourceIdAllocator;
   private readonly handlers: DriverInstanceSocketHandlers;
   private readonly payload: DriverBootPayload;
   #socket: DriverWireSocket | null = null;
@@ -36,6 +35,7 @@ export class DriverInstanceSocket {
   constructor(payload: DriverBootPayload, handlers: DriverInstanceSocketHandlers) {
     this.handlers = handlers;
     this.payload = payload;
+    this.#sourceEventIdAllocator = new DriverEventSourceIdAllocator(payload.driverInstanceId);
   }
 
   async connect(): Promise<void> {
@@ -125,11 +125,15 @@ export class DriverInstanceSocket {
   }
 
   async pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput> {
-    const sourceEventIdOccurrences = new Map<string, number>();
     return this.#requireClient().driver.pushEvents({
       driverInstanceId: this.payload.driverInstanceId,
       events: input.events.flatMap((event) =>
-        toDriverEventEnvelopes(this.payload, event, this.#activeRunId, sourceEventIdOccurrences),
+        toDriverEventEnvelopes(
+          this.payload,
+          event,
+          this.#activeRunId,
+          this.#sourceEventIdAllocator.sourceEventIdFor(event),
+        ),
       ),
     });
   }
@@ -170,49 +174,65 @@ export class DriverInstanceSocket {
   }
 }
 
+/**
+ * Assigns a stable source identity to draft events that do not already carry
+ * one. A publisher retries the same draft object after a transport failure, so
+ * the WeakMap keeps that retry idempotent. A distinct later draft with identical
+ * text receives a new identity instead of being mistaken for a replay. The boot
+ * identity prevents a replacement process from restarting the sequence in the
+ * same driver-instance namespace.
+ */
+export class DriverEventSourceIdAllocator {
+  readonly #sourceEventIds = new WeakMap<object, string>();
+  #nextSourceEventSequence = 0;
+  private readonly prefix: string;
+
+  constructor(driverInstanceId: DriverInstanceId, bootId: string = createDriverId()) {
+    this.prefix = `driver:${driverInstanceId}:${bootId}:event`;
+  }
+
+  sourceEventIdFor(event: DriverEventInput): string | undefined {
+    if (isRuntimeEventEnvelope(event) || readExplicitSourceEventId(event) !== undefined) {
+      return undefined;
+    }
+
+    const existing = this.#sourceEventIds.get(event);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    this.#nextSourceEventSequence += 1;
+    const sourceEventId = `${this.prefix}:${this.#nextSourceEventSequence}`;
+    this.#sourceEventIds.set(event, sourceEventId);
+    return sourceEventId;
+  }
+}
+
+function readExplicitSourceEventId(event: DriverEventInput): string | undefined {
+  return typeof event.sourceEventId === "string" && event.sourceEventId.length > 0
+    ? event.sourceEventId
+    : undefined;
+}
+
 function readEventOccurredAt(event: DriverEventInput): number {
   const occurredAt = isRuntimeEventEnvelope(event) ? event.occurredAt : event.occurredAt;
   const timestamp = occurredAt === undefined ? Date.now() : Date.parse(occurredAt);
   return Number.isFinite(timestamp) ? timestamp : Date.now();
 }
 
-function readSourceEventId(event: DriverEventInput): string {
+function readSourceEventId(event: DriverEventInput, generatedSourceEventId?: string): string {
   if (isRuntimeEventEnvelope(event)) {
-    return event.sourceEventId ?? event.id;
+    return readExplicitSourceEventId(event) ?? event.id;
   }
 
-  return event.sourceEventId ?? createDeterministicSourceEventId(event);
-}
+  const sourceEventId = readExplicitSourceEventId(event) ?? generatedSourceEventId;
 
-function addSourceEventIdOccurrence(
-  sourceEventId: string,
-  occurrences: Map<string, number>,
-): string {
-  const nextOccurrence = (occurrences.get(sourceEventId) ?? 0) + 1;
-  occurrences.set(sourceEventId, nextOccurrence);
-
-  return nextOccurrence === 1 ? sourceEventId : `${sourceEventId}:${nextOccurrence}`;
-}
-
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
+  if (sourceEventId === undefined) {
+    throw new Error("Driver draft event must have an allocated source event ID.");
   }
 
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`;
-  }
-
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .filter((key) => record[key] !== undefined)
-    .toSorted()
-    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
-    .join(",")}}`;
-}
-
-function createDeterministicSourceEventId(event: DriverEventInput): string {
-  return `sha256:${createHash("sha256").update(stableJson(event)).digest("hex")}`;
+  return sourceEventId;
 }
 
 function parseRunId(value: string): RunId {
@@ -233,13 +253,10 @@ export function toDriverEventEnvelopes(
   payload: DriverBootPayload,
   event: DriverEventInput,
   activeRunId: RunId | null,
-  sourceEventIdOccurrences = new Map<string, number>(),
+  generatedSourceEventId?: string,
 ): DriverEventEnvelope[] {
   const occurredAtMs = readEventOccurredAt(event);
-  const sourceEventId = addSourceEventIdOccurrence(
-    readSourceEventId(event),
-    sourceEventIdOccurrences,
-  );
+  const sourceEventId = readSourceEventId(event, generatedSourceEventId);
   const occurredAt = new Date(occurredAtMs).toISOString();
   const runId = readEventRunId(event, activeRunId);
 

--- a/src/runtimes/acp/acp-event-translator.ts
+++ b/src/runtimes/acp/acp-event-translator.ts
@@ -41,6 +41,7 @@ export class AcpTurnEventState {
   #messageCompleted = false;
   #messageId: string | null = null;
   #messageStarted = false;
+  #messageText = "";
   #runId: RunId | null = null;
   #sequence = 0;
   #sessionId: string | null = null;
@@ -58,6 +59,7 @@ export class AcpTurnEventState {
     this.#messageCompleted = false;
     this.#messageId = input.messageId;
     this.#messageStarted = false;
+    this.#messageText = "";
     this.#runId = input.runId;
     this.#sequence = 0;
     this.#sessionId = input.sessionId;
@@ -72,6 +74,7 @@ export class AcpTurnEventState {
     this.#messageCompleted = false;
     this.#messageId = null;
     this.#messageStarted = false;
+    this.#messageText = "";
     this.#runId = null;
     this.#sequence = 0;
     this.#sessionId = null;
@@ -164,6 +167,12 @@ export class AcpTurnEventState {
       events.push({
         kind: "run.completed",
         payload: {
+          ...(this.#messageStarted
+            ? {
+                finalMessageId: this.#requireMessageId(),
+                finalMessageText: this.#messageText,
+              }
+            : {}),
           stopReason,
         },
         runId,
@@ -329,6 +338,8 @@ export class AcpTurnEventState {
       return [];
     }
 
+    this.#messageText += delta;
+
     return [
       ...this.#ensureMessageStarted(),
       {
@@ -478,6 +489,7 @@ export class AcpTurnEventState {
     }
 
     this.#messageStarted = true;
+    this.#messageText = contentDelta;
     this.#thoughtFallbackText = "";
     return [
       {

--- a/src/runtimes/acp/acp-event-translator.ts
+++ b/src/runtimes/acp/acp-event-translator.ts
@@ -1,5 +1,6 @@
 import type { DriverEventInput } from "../../protocol/events";
 import type { RunId } from "../../protocol/id";
+import { RuntimeAssistantMessageIdIndex } from "../runtime-turn-transcript";
 import { toAcpPermissionRequest } from "./acp-permission-events";
 import type { AcpPermissionTranslation } from "./acp-permission-events";
 import {
@@ -37,16 +38,30 @@ export interface AcpTurnEventStateInput {
   readonly sessionId: string;
 }
 
+interface AcpAssistantMessageState {
+  readonly id: string;
+  readonly nativeMessageId: string | null;
+  text: string;
+}
+
+interface AcpAssistantMessageStart {
+  readonly events: DriverEventInput[];
+  readonly message: AcpAssistantMessageState;
+}
+
 export class AcpTurnEventState {
-  #messageCompleted = false;
-  #messageId: string | null = null;
-  #messageStarted = false;
-  #messageText = "";
+  #activeAssistantMessage: AcpAssistantMessageState | null = null;
+  readonly #assistantMessageIds = new RuntimeAssistantMessageIdIndex<string>();
+  #lastCompletedAssistantMessage: Pick<AcpAssistantMessageState, "id" | "text"> | null = null;
+  #promptMessageId: string | null = null;
   #runId: RunId | null = null;
   #sequence = 0;
   #sessionId: string | null = null;
+  readonly #settledAssistantNativeMessageIds = new Set<string>();
+  #unidentifiedAssistantMessageSequence = 0;
   #thoughtCompleted = false;
   #thoughtFallbackText = "";
+  #thoughtFallbackNativeMessageId: string | null = null;
   #thoughtId: string | null = null;
   #thoughtStarted = false;
   readonly #tools = new AcpToolEventState();
@@ -56,30 +71,36 @@ export class AcpTurnEventState {
   }
 
   begin(input: AcpTurnEventStateInput): void {
-    this.#messageCompleted = false;
-    this.#messageId = input.messageId;
-    this.#messageStarted = false;
-    this.#messageText = "";
+    this.#activeAssistantMessage = null;
+    this.#assistantMessageIds.reset();
+    this.#lastCompletedAssistantMessage = null;
+    this.#promptMessageId = input.messageId;
     this.#runId = input.runId;
     this.#sequence = 0;
     this.#sessionId = input.sessionId;
+    this.#settledAssistantNativeMessageIds.clear();
+    this.#unidentifiedAssistantMessageSequence = 0;
     this.#thoughtCompleted = false;
     this.#thoughtFallbackText = "";
+    this.#thoughtFallbackNativeMessageId = null;
     this.#thoughtId = `${input.messageId}:thought`;
     this.#thoughtStarted = false;
     this.#tools.clear();
   }
 
   clear(): void {
-    this.#messageCompleted = false;
-    this.#messageId = null;
-    this.#messageStarted = false;
-    this.#messageText = "";
+    this.#activeAssistantMessage = null;
+    this.#assistantMessageIds.reset();
+    this.#lastCompletedAssistantMessage = null;
+    this.#promptMessageId = null;
     this.#runId = null;
     this.#sequence = 0;
     this.#sessionId = null;
+    this.#settledAssistantNativeMessageIds.clear();
+    this.#unidentifiedAssistantMessageSequence = 0;
     this.#thoughtCompleted = false;
     this.#thoughtFallbackText = "";
+    this.#thoughtFallbackNativeMessageId = null;
     this.#thoughtId = null;
     this.#thoughtStarted = false;
     this.#tools.clear();
@@ -90,18 +111,7 @@ export class AcpTurnEventState {
     const runId = this.#requireRunId();
 
     events.push(...this.#promoteThoughtFallbackToMessage());
-
-    if (this.#messageStarted && !this.#messageCompleted) {
-      this.#messageCompleted = true;
-      events.push({
-        kind: "message.completed",
-        payload: {
-          messageId: this.#requireMessageId(),
-          role: "agent",
-        },
-        runId,
-      });
-    }
+    events.push(...this.#completeActiveAssistantMessage());
 
     if (this.#thoughtStarted && !this.#thoughtCompleted) {
       this.#thoughtCompleted = true;
@@ -164,15 +174,17 @@ export class AcpTurnEventState {
         runId,
       });
     } else {
+      const finalMessage = this.#lastCompletedAssistantMessage;
+
       events.push({
         kind: "run.completed",
         payload: {
-          ...(this.#messageStarted
-            ? {
-                finalMessageId: this.#requireMessageId(),
-                finalMessageText: this.#messageText,
-              }
-            : {}),
+          ...(finalMessage === null
+            ? {}
+            : {
+                finalMessageId: finalMessage.id,
+                finalMessageText: finalMessage.text,
+              }),
           stopReason,
         },
         runId,
@@ -192,19 +204,9 @@ export class AcpTurnEventState {
     }
 
     const events: DriverEventInput[] = [];
-    const messageId = this.#messageId;
     const thoughtId = this.#thoughtId;
 
-    if (this.#messageStarted && !this.#messageCompleted && messageId !== null) {
-      events.push({
-        kind: "message.completed",
-        payload: {
-          messageId,
-          role: "agent",
-        },
-        runId,
-      });
-    }
+    events.push(...this.#completeActiveAssistantMessage());
 
     if (this.#thoughtStarted && !this.#thoughtCompleted && thoughtId !== null) {
       events.push({
@@ -317,7 +319,7 @@ export class AcpTurnEventState {
       ...translation,
       events: [
         ...this.#tools.ensureStarted({
-          parentMessageId: this.#messageId ?? undefined,
+          parentMessageId: this.#toolParentMessageId(),
           runId,
           title: translation.title,
           toolCallId: translation.targetItemId,
@@ -338,17 +340,30 @@ export class AcpTurnEventState {
       return [];
     }
 
-    this.#messageText += delta;
+    const nativeMessageId = readNonEmptyString(update, "messageId");
+    const started =
+      nativeMessageId === null
+        ? this.#startUnidentifiedAssistantMessage()
+        : this.#startIdentifiedAssistantMessage(nativeMessageId);
+
+    if (started === null) {
+      // An already settled native message can only be a late replay. Keeping
+      // the newer active message intact avoids letting a progress replay win
+      // the final-message identity by arrival order.
+      return [];
+    }
+
+    started.message.text += delta;
 
     return [
-      ...this.#ensureMessageStarted(),
+      ...started.events,
       {
         delivery: "best_effort",
         kind: "message.delta",
         payload: {
           contentBlock: update?.["content"],
           contentDelta: delta,
-          messageId: this.#requireMessageId(),
+          messageId: started.message.id,
           role: "agent",
         },
         runId: this.#requireRunId(),
@@ -364,25 +379,51 @@ export class AcpTurnEventState {
       return [];
     }
 
-    if (!this.#messageStarted && readNonEmptyString(update, "messageId") !== null) {
-      this.#thoughtFallbackText += delta;
+    const nativeMessageId = readNonEmptyString(update, "messageId");
+    const events: DriverEventInput[] = [];
+
+    if (nativeMessageId === null) {
+      // Thought updates can carry the provider's final answer. Without a
+      // native identity there is no safe way to decide whether this text
+      // belongs to the active assistant message or starts a newer one. Close
+      // the live message boundary, then fail closed instead of projecting an
+      // earlier identified progress message as canonical final output.
+      events.push(...this.#completeActiveAssistantMessage());
+      this.#lastCompletedAssistantMessage = null;
+      this.#clearThoughtFallback();
+    } else if (!this.#settledAssistantNativeMessageIds.has(nativeMessageId)) {
+      const active = this.#activeAssistantMessage;
+
+      if (active !== null && active.nativeMessageId !== nativeMessageId) {
+        // ACP runtimes can expose final answer text through a thought update.
+        // A new native identity is an explicit message boundary: settle the
+        // active progress message so this thought can become the final fallback.
+        events.push(...this.#completeActiveAssistantMessage());
+      }
+
+      if (this.#activeAssistantMessage === null) {
+        if (this.#thoughtFallbackNativeMessageId === nativeMessageId) {
+          this.#thoughtFallbackText += delta;
+        } else {
+          this.#thoughtFallbackNativeMessageId = nativeMessageId;
+          this.#thoughtFallbackText = delta;
+        }
+      }
     }
 
-    return [
-      ...this.#ensureThoughtStarted(),
-      {
-        delivery: "best_effort",
-        kind: "thought.delta",
-        payload: {
-          channel: "summary",
-          contentBlock: update?.["content"],
-          contentDelta: delta,
-          thoughtId: this.#requireThoughtId(),
-        },
-        runId: this.#requireRunId(),
-        sourceEventId: this.#nextSourceEventId("agent-thought"),
+    events.push(...this.#ensureThoughtStarted(), {
+      delivery: "best_effort",
+      kind: "thought.delta",
+      payload: {
+        channel: "summary",
+        contentBlock: update?.["content"],
+        contentDelta: delta,
+        thoughtId: this.#requireThoughtId(),
       },
-    ];
+      runId: this.#requireRunId(),
+      sourceEventId: this.#nextSourceEventId("agent-thought"),
+    });
+    return events;
   }
 
   #translateToolCall(update: JsonObject | null): DriverEventInput[] {
@@ -397,7 +438,7 @@ export class AcpTurnEventState {
     const title =
       readNonEmptyString(update, "title") ?? readNonEmptyString(update, "kind") ?? "tool";
     const events = this.#tools.ensureStarted({
-      parentMessageId: this.#messageId ?? undefined,
+      parentMessageId: this.#toolParentMessageId(),
       runId,
       title,
       toolCallId,
@@ -433,7 +474,7 @@ export class AcpTurnEventState {
     const title =
       readNonEmptyString(update, "title") ?? readNonEmptyString(update, "kind") ?? "tool";
     const events = this.#tools.ensureStarted({
-      parentMessageId: this.#messageId ?? undefined,
+      parentMessageId: this.#toolParentMessageId(),
       runId,
       title,
       toolCallId,
@@ -458,48 +499,28 @@ export class AcpTurnEventState {
     return events;
   }
 
-  #ensureMessageStarted(): DriverEventInput[] {
-    if (this.#messageStarted) {
-      return [];
-    }
-
-    this.#messageStarted = true;
-    this.#thoughtFallbackText = "";
-    return [
-      {
-        kind: "message.started",
-        payload: {
-          messageId: this.#requireMessageId(),
-          role: "agent",
-        },
-        runId: this.#requireRunId(),
-      },
-    ];
-  }
-
   #promoteThoughtFallbackToMessage(): DriverEventInput[] {
-    if (this.#messageStarted) {
+    if (this.#activeAssistantMessage !== null) {
       return [];
     }
 
-    const contentDelta = this.#thoughtFallbackText.trim();
+    const contentDelta = this.#thoughtFallbackText;
+    const nativeMessageId = this.#thoughtFallbackNativeMessageId;
 
-    if (contentDelta.length === 0) {
+    if (contentDelta.trim().length === 0 || nativeMessageId === null) {
       return [];
     }
 
-    this.#messageStarted = true;
-    this.#messageText = contentDelta;
-    this.#thoughtFallbackText = "";
+    this.#clearThoughtFallback();
+    const started = this.#startIdentifiedAssistantMessage(nativeMessageId);
+
+    if (started === null) {
+      return [];
+    }
+
+    started.message.text += contentDelta;
     return [
-      {
-        kind: "message.started",
-        payload: {
-          messageId: this.#requireMessageId(),
-          role: "agent",
-        },
-        runId: this.#requireRunId(),
-      },
+      ...started.events,
       {
         delivery: "best_effort",
         kind: "message.delta",
@@ -509,13 +530,113 @@ export class AcpTurnEventState {
             type: "text",
           },
           contentDelta,
-          messageId: this.#requireMessageId(),
+          messageId: started.message.id,
           role: "agent",
         },
         runId: this.#requireRunId(),
         sourceEventId: this.#nextSourceEventId("agent-thought-fallback-message"),
       },
     ];
+  }
+
+  #clearThoughtFallback(): void {
+    this.#thoughtFallbackNativeMessageId = null;
+    this.#thoughtFallbackText = "";
+  }
+
+  #completeActiveAssistantMessage(): DriverEventInput[] {
+    const message = this.#activeAssistantMessage;
+
+    if (message === null) {
+      return [];
+    }
+
+    this.#activeAssistantMessage = null;
+
+    if (message.nativeMessageId !== null) {
+      this.#settledAssistantNativeMessageIds.add(message.nativeMessageId);
+      this.#lastCompletedAssistantMessage = {
+        id: message.id,
+        text: message.text,
+      };
+    } else {
+      // ACP v1 does not give anonymous chunks a stable message boundary. If
+      // this is the last assistant message, do not let an earlier progress
+      // message become the canonical final output.
+      this.#lastCompletedAssistantMessage = null;
+    }
+
+    return [
+      {
+        kind: "message.completed",
+        payload: {
+          messageId: message.id,
+          role: "agent",
+        },
+        runId: this.#requireRunId(),
+      },
+    ];
+  }
+
+  #startIdentifiedAssistantMessage(nativeMessageId: string): AcpAssistantMessageStart | null {
+    if (this.#settledAssistantNativeMessageIds.has(nativeMessageId)) {
+      return null;
+    }
+
+    const active = this.#activeAssistantMessage;
+
+    if (active?.nativeMessageId === nativeMessageId) {
+      return { events: [], message: active };
+    }
+
+    const events = this.#completeActiveAssistantMessage();
+    const message: AcpAssistantMessageState = {
+      id: this.#assistantMessageIds.getOrCreate(`native:${nativeMessageId}`),
+      nativeMessageId,
+      text: "",
+    };
+
+    this.#activeAssistantMessage = message;
+    this.#clearThoughtFallback();
+    events.push({
+      kind: "message.started",
+      payload: {
+        messageId: message.id,
+        role: "agent",
+      },
+      runId: this.#requireRunId(),
+    });
+    return { events, message };
+  }
+
+  #startUnidentifiedAssistantMessage(): AcpAssistantMessageStart {
+    const active = this.#activeAssistantMessage;
+
+    if (active?.nativeMessageId === null) {
+      return { events: [], message: active };
+    }
+
+    const events = this.#completeActiveAssistantMessage();
+    this.#unidentifiedAssistantMessageSequence += 1;
+    const message: AcpAssistantMessageState = {
+      id: this.#assistantMessageIds.getOrCreate(
+        `fallback:unidentified:${this.#unidentifiedAssistantMessageSequence}`,
+      ),
+      nativeMessageId: null,
+      text: "",
+    };
+
+    this.#activeAssistantMessage = message;
+    this.#clearThoughtFallback();
+    events.push({
+      kind: "message.started",
+      payload: {
+        messageId: message.id,
+        role: "agent",
+      },
+      runId: this.#requireRunId(),
+    });
+    return { events, message };
   }
 
   #ensureThoughtStarted(): DriverEventInput[] {
@@ -536,14 +657,6 @@ export class AcpTurnEventState {
     ];
   }
 
-  #requireMessageId(): string {
-    if (this.#messageId === null) {
-      throw new Error("ACP turn message id is not initialized.");
-    }
-
-    return this.#messageId;
-  }
-
   #requireRunId(): RunId {
     if (this.#runId === null) {
       throw new Error("ACP turn run id is not initialized.");
@@ -558,5 +671,9 @@ export class AcpTurnEventState {
     }
 
     return this.#thoughtId;
+  }
+
+  #toolParentMessageId(): string | undefined {
+    return this.#activeAssistantMessage?.id ?? this.#promptMessageId ?? undefined;
   }
 }

--- a/src/runtimes/acp/acp-json.ts
+++ b/src/runtimes/acp/acp-json.ts
@@ -53,31 +53,43 @@ export class AcpJsonRpcError extends Error {
 export class AcpJsonRpcConnection {
   readonly #interface: Interface;
   #closed = false;
+  #inboundQueue: Promise<void> = Promise.resolve();
   #nextRequestId = 1;
   readonly #options: AcpJsonRpcConnectionOptions;
+  #pendingInboundLineCount = 0;
   readonly #pending = new Map<AcpJsonRpcId, PendingAcpRequest>();
+  #pendingTransportCloseError: Error | null = null;
+  #transportCloseScheduled = false;
+  #writeError: Error | null = null;
 
   constructor(options: AcpJsonRpcConnectionOptions) {
     this.#options = options;
     this.#interface = createInterface({ input: options.stdout });
     this.#interface.on("line", (line) => {
-      void this.#handleLine(line).catch((error: unknown) => {
-        this.#failTransport(
-          error instanceof Error ? error : new Error("ACP JSON-RPC line handler failed."),
-        );
-      });
+      this.#enqueueInboundLine(line);
+    });
+    this.#interface.on("error", (error) => {
+      this.#failTransportAfterInboundQueue(
+        error instanceof Error ? error : new Error("ACP stdout failed."),
+      );
     });
     this.#interface.on("close", () => {
-      this.#failTransport(new Error("ACP JSON-RPC stream closed."));
+      // readline can emit close immediately after the last line. Drain frames
+      // already accepted from stdout before rejecting pending requests so a
+      // final session/update and its prompt response cannot be discarded at
+      // EOF merely because their async handlers have not settled yet.
+      this.#failTransportAfterInboundQueue(new Error("ACP JSON-RPC stream closed."));
     });
     options.stdout.on("error", (error) => {
-      this.#failTransport(error instanceof Error ? error : new Error("ACP stdout failed."));
+      this.#failTransportAfterInboundQueue(
+        error instanceof Error ? error : new Error("ACP stdout failed."),
+      );
     });
     options.stdin.on("error", (error) => {
-      this.#failTransport(error instanceof Error ? error : new Error("ACP stdin failed."));
+      this.#recordWriteError(error instanceof Error ? error : new Error("ACP stdin failed."));
     });
     options.stdin.on("close", () => {
-      this.#failTransport(new Error("ACP stdin closed."));
+      this.#recordWriteError(new Error("ACP stdin closed."));
     });
   }
 
@@ -102,6 +114,10 @@ export class AcpJsonRpcConnection {
   async request<T>(method: string, params: unknown): Promise<T> {
     if (this.#closed) {
       throw new Error("ACP JSON-RPC connection is closed.");
+    }
+
+    if (this.#writeError !== null) {
+      throw this.#writeError;
     }
 
     const id = this.#nextRequestId;
@@ -153,6 +169,51 @@ export class AcpJsonRpcConnection {
     }
 
     this.#handleInboundResponse(parsed);
+  }
+
+  #enqueueInboundLine(line: string): void {
+    this.#pendingInboundLineCount += 1;
+    this.#inboundQueue = this.#inboundQueue.then(() => this.#processInboundLine(line));
+  }
+
+  #failTransportAfterInboundQueue(error: Error): void {
+    if (this.#closed || this.#transportCloseScheduled) {
+      return;
+    }
+
+    this.#transportCloseScheduled = true;
+    this.#pendingTransportCloseError = error;
+    this.#failTransportIfInboundQueueDrained();
+  }
+
+  #recordWriteError(error: Error): void {
+    this.#writeError ??= error;
+  }
+
+  #failTransportIfInboundQueueDrained(): void {
+    const error = this.#pendingTransportCloseError;
+
+    if (error === null || this.#pendingInboundLineCount > 0) {
+      return;
+    }
+
+    this.#pendingTransportCloseError = null;
+    this.#failTransport(error);
+  }
+
+  async #processInboundLine(line: string): Promise<void> {
+    try {
+      if (!this.#closed) {
+        await this.#handleLine(line);
+      }
+    } catch (error) {
+      this.#failTransport(
+        error instanceof Error ? error : new Error("ACP JSON-RPC line handler failed."),
+      );
+    } finally {
+      this.#pendingInboundLineCount -= 1;
+      this.#failTransportIfInboundQueueDrained();
+    }
   }
 
   async #handleInboundRequestOrNotification(message: JsonObject): Promise<void> {
@@ -230,6 +291,10 @@ export class AcpJsonRpcConnection {
   async #write(message: JsonObject): Promise<void> {
     if (this.#closed) {
       throw new Error("ACP JSON-RPC connection is closed.");
+    }
+
+    if (this.#writeError !== null) {
+      throw this.#writeError;
     }
 
     const line = `${JSON.stringify(message)}\n`;

--- a/src/runtimes/claude/agent-sdk-event-writer.ts
+++ b/src/runtimes/claude/agent-sdk-event-writer.ts
@@ -1,7 +1,7 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import type { DriverEventInput } from "../../protocol/events";
-import type { RunId } from "../../protocol/id";
+import type { MessageId, RunId } from "../../protocol/id";
 import type { AgentDriverContext } from "../agent-driver-backend";
 import type { JsonObject } from "./agent-sdk-json";
 import { toClaudeDiagnosticEvent, toClaudeUsageUpdatedEvents } from "./agent-sdk-message-events";
@@ -76,9 +76,9 @@ export class ClaudeAgentSdkEventWriter {
     return this.#toolParentMessage.get(toolCallId) ?? null;
   }
 
-  async endMessage(context: AgentDriverContext, messageId: string): Promise<void> {
+  async endMessage(context: AgentDriverContext, messageId: string): Promise<boolean> {
     if (!this.#messageStarted.has(messageId) || this.#messageEnded.has(messageId)) {
-      return;
+      return false;
     }
 
     this.#messageEnded.add(messageId);
@@ -91,6 +91,7 @@ export class ClaudeAgentSdkEventWriter {
         },
       },
     ]);
+    return true;
   }
 
   async ensureMessageStarted(context: AgentDriverContext, messageId: string): Promise<void> {
@@ -179,12 +180,22 @@ export class ClaudeAgentSdkEventWriter {
     ]);
   }
 
-  async pushRunFinished(context: AgentDriverContext, runId: RunId): Promise<void> {
+  async pushRunFinished(
+    context: AgentDriverContext,
+    runId: RunId,
+    finalMessage: { id: MessageId; text: string } | null,
+  ): Promise<void> {
     await this.#push(context, "driver.claude.turn.completed", [
       {
         runId,
         kind: "run.completed",
         payload: {
+          ...(finalMessage === null
+            ? {}
+            : {
+                finalMessageId: finalMessage.id,
+                finalMessageText: finalMessage.text,
+              }),
           stopReason: "end_turn",
         },
       },

--- a/src/runtimes/claude/agent-sdk-message-state.ts
+++ b/src/runtimes/claude/agent-sdk-message-state.ts
@@ -10,17 +10,5 @@ export function isDuplicateClaudeFinalText(
   messageId: string,
   text: string,
 ): boolean {
-  const sameMessageText = streamedTextByMessageId.get(messageId);
-
-  if (sameMessageText === text) {
-    return true;
-  }
-
-  for (const streamedText of streamedTextByMessageId.values()) {
-    if (streamedText === text) {
-      return true;
-    }
-  }
-
-  return false;
+  return streamedTextByMessageId.get(messageId) === text;
 }

--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -27,13 +27,17 @@ function toClaudeThoughtId(messageId: string): string {
 }
 
 export class ClaudeAgentSdkMessageTranslator {
+  readonly #activeAssistantMessageIds = new Map<RunId, MessageId>();
   #activeThoughtId: string | null = null;
-  readonly #assistantMessageIds = new RuntimeAssistantMessageIdIndex<RunId>();
+  readonly #assistantMessageIds = new RuntimeAssistantMessageIdIndex<string>();
+  readonly #assistantMessageSequences = new Map<RunId, number>();
   readonly #blockIndexToToolCallId = new Map<number, string>();
   readonly #events: ClaudeAgentSdkEventWriter;
+  readonly #lastCompletedAssistantMessageIds = new Map<RunId, MessageId>();
   readonly #options: ClaudeMessageTranslatorOptions;
   readonly #streamedTextMessages = new Set<string>();
   readonly #streamedTextByMessageId = new Map<string, string>();
+  readonly #textByAssistantMessageId = new Map<MessageId, string>();
 
   constructor(options: ClaudeMessageTranslatorOptions) {
     this.#options = options;
@@ -41,12 +45,16 @@ export class ClaudeAgentSdkMessageTranslator {
   }
 
   resetTurnMessageState(): void {
+    this.#activeAssistantMessageIds.clear();
     this.#activeThoughtId = null;
     this.#assistantMessageIds.reset();
+    this.#assistantMessageSequences.clear();
     this.#blockIndexToToolCallId.clear();
     this.#events.resetTurnState();
+    this.#lastCompletedAssistantMessageIds.clear();
     this.#streamedTextByMessageId.clear();
     this.#streamedTextMessages.clear();
+    this.#textByAssistantMessageId.clear();
   }
 
   async endActiveThought(context: AgentDriverContext): Promise<void> {
@@ -113,8 +121,9 @@ export class ClaudeAgentSdkMessageTranslator {
     message: Extract<SDKMessage, { type: "assistant" }>,
     runId: RunId,
   ): Promise<void> {
-    const messageId = this.#assistantMessageId(runId);
+    const messageId = this.#assistantMessageId(runId, this.#readNativeMessageId(message));
     const content = Array.isArray(message.message.content) ? message.message.content : [];
+    const authoritativeText: string[] = [];
 
     for (const [index, block] of content.entries()) {
       if (!isRecord(block)) {
@@ -125,12 +134,17 @@ export class ClaudeAgentSdkMessageTranslator {
 
       if (blockType === "text") {
         const text = readString(block, "text");
+
+        if (text !== null) {
+          authoritativeText.push(text);
+        }
         const isDuplicateStreamedText =
           text === null ||
           this.#streamedTextMessages.has(messageId) ||
           isDuplicateClaudeFinalText(this.#streamedTextByMessageId, messageId, text);
 
         if (isTruthy(text) && !isDuplicateStreamedText) {
+          this.#appendAssistantText(messageId, text);
           // Claude content blocks are protocol-ordered; push each derived event before reading the next block.
           await this.#events.pushTextDelta({
             context,
@@ -167,7 +181,11 @@ export class ClaudeAgentSdkMessageTranslator {
       }
     }
 
-    await this.#events.endMessage(context, messageId);
+    if (authoritativeText.length > 0) {
+      this.#textByAssistantMessageId.set(messageId, authoritativeText.join(""));
+    }
+
+    await this.#endAssistantMessage(context, runId, messageId);
   }
 
   async #handleStreamEvent(
@@ -179,10 +197,14 @@ export class ClaudeAgentSdkMessageTranslator {
     const eventType = readString(event, "type");
 
     if (eventType === "message_start") {
+      await this.#events.ensureMessageStarted(
+        context,
+        this.#assistantMessageId(runId, this.#readNativeMessageId(message)),
+      );
       return;
     }
 
-    const messageId = this.#assistantMessageId(runId);
+    const messageId = this.#assistantMessageId(runId, this.#readNativeMessageId(message));
 
     if (eventType === "content_block_start") {
       await this.#handleContentBlockStart(context, messageId, event);
@@ -205,7 +227,7 @@ export class ClaudeAgentSdkMessageTranslator {
 
     if (eventType === "message_stop") {
       await this.endActiveThought(context);
-      await this.#events.endMessage(context, messageId);
+      await this.#endAssistantMessage(context, runId, messageId);
       this.#blockIndexToToolCallId.clear();
       return;
     }
@@ -222,6 +244,14 @@ export class ClaudeAgentSdkMessageTranslator {
     this.#streamedTextByMessageId.set(
       messageId,
       `${this.#streamedTextByMessageId.get(messageId) ?? ""}${text}`,
+    );
+    this.#appendAssistantText(messageId as MessageId, text);
+  }
+
+  #appendAssistantText(messageId: MessageId, text: string): void {
+    this.#textByAssistantMessageId.set(
+      messageId,
+      `${this.#textByAssistantMessageId.get(messageId) ?? ""}${text}`,
     );
   }
 
@@ -370,14 +400,58 @@ export class ClaudeAgentSdkMessageTranslator {
       await this.#events.pushToolResult({
         content: resultText,
         context,
-        messageId: this.#events.toolParentMessageId(toolCallId) ?? this.#assistantMessageId(runId),
+        messageId:
+          this.#events.toolParentMessageId(toolCallId) ??
+          this.#activeAssistantMessageIds.get(runId) ??
+          this.#lastCompletedAssistantMessageIds.get(runId) ??
+          this.#assistantMessageId(runId, null),
         toolCallId,
       });
     }
   }
 
-  #assistantMessageId(runId: RunId): MessageId {
-    return this.#assistantMessageIds.getOrCreate(runId);
+  #assistantMessageId(runId: RunId, nativeMessageId: string | null): MessageId {
+    const active = this.#activeAssistantMessageIds.get(runId);
+    let messageId: MessageId;
+
+    if (nativeMessageId !== null) {
+      messageId = this.#assistantMessageIds.getOrCreate(`${runId}:native:${nativeMessageId}`);
+    } else if (active !== undefined) {
+      messageId = active;
+    } else {
+      messageId = this.#assistantMessageIds.getOrCreate(
+        `${runId}:sequence:${this.#nextAssistantMessageSequence(runId)}`,
+      );
+    }
+
+    this.#activeAssistantMessageIds.set(runId, messageId);
+    return messageId;
+  }
+
+  async #endAssistantMessage(
+    context: AgentDriverContext,
+    runId: RunId,
+    messageId: MessageId,
+  ): Promise<void> {
+    const ended = await this.#events.endMessage(context, messageId);
+
+    if (ended) {
+      this.#lastCompletedAssistantMessageIds.set(runId, messageId);
+    }
+
+    if (this.#activeAssistantMessageIds.get(runId) === messageId) {
+      this.#activeAssistantMessageIds.delete(runId);
+    }
+  }
+
+  #nextAssistantMessageSequence(runId: RunId): number {
+    const sequence = (this.#assistantMessageSequences.get(runId) ?? 0) + 1;
+    this.#assistantMessageSequences.set(runId, sequence);
+    return sequence;
+  }
+
+  #readNativeMessageId(message: SDKMessage): string | null {
+    return isRecord(message) ? readString(message, "uuid") : null;
   }
 
   async #handleSystemMessage(
@@ -424,7 +498,19 @@ export class ClaudeAgentSdkMessageTranslator {
     );
 
     if (message.subtype === "success") {
-      await this.#events.pushRunFinished(context, runId);
+      const finalMessageId = this.#lastCompletedAssistantMessageIds.get(runId) ?? null;
+      const finalMessageText =
+        finalMessageId === null
+          ? null
+          : (this.#textByAssistantMessageId.get(finalMessageId) ?? null);
+
+      await this.#events.pushRunFinished(
+        context,
+        runId,
+        finalMessageId === null || finalMessageText === null
+          ? null
+          : { id: finalMessageId, text: finalMessageText },
+      );
       return;
     }
 

--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -22,6 +22,11 @@ interface ClaudeMessageTranslatorOptions {
   recordNativeSessionId(context: AgentDriverContext, sessionId: string): Promise<void>;
 }
 
+interface ClaudeAssistantFinalCandidate {
+  readonly id: MessageId;
+  readonly ordinal: number;
+}
+
 function toClaudeThoughtId(messageId: string): string {
   return `${messageId}:thought`;
 }
@@ -29,11 +34,14 @@ function toClaudeThoughtId(messageId: string): string {
 export class ClaudeAgentSdkMessageTranslator {
   readonly #activeAssistantMessageIds = new Map<RunId, MessageId>();
   #activeThoughtId: string | null = null;
+  readonly #authoritativeAssistantMessageIds = new Set<MessageId>();
   readonly #assistantMessageIds = new RuntimeAssistantMessageIdIndex<string>();
+  readonly #assistantMessageOrdinals = new Map<MessageId, number>();
+  readonly #assistantMessageRunIds = new Map<MessageId, RunId>();
   readonly #assistantMessageSequences = new Map<RunId, number>();
   readonly #blockIndexToToolCallId = new Map<number, string>();
   readonly #events: ClaudeAgentSdkEventWriter;
-  readonly #lastCompletedAssistantMessageIds = new Map<RunId, MessageId>();
+  readonly #lastCompletedAssistantMessages = new Map<RunId, ClaudeAssistantFinalCandidate>();
   readonly #options: ClaudeMessageTranslatorOptions;
   readonly #streamedTextMessages = new Set<string>();
   readonly #streamedTextByMessageId = new Map<string, string>();
@@ -47,11 +55,14 @@ export class ClaudeAgentSdkMessageTranslator {
   resetTurnMessageState(): void {
     this.#activeAssistantMessageIds.clear();
     this.#activeThoughtId = null;
+    this.#authoritativeAssistantMessageIds.clear();
     this.#assistantMessageIds.reset();
+    this.#assistantMessageOrdinals.clear();
+    this.#assistantMessageRunIds.clear();
     this.#assistantMessageSequences.clear();
     this.#blockIndexToToolCallId.clear();
     this.#events.resetTurnState();
-    this.#lastCompletedAssistantMessageIds.clear();
+    this.#lastCompletedAssistantMessages.clear();
     this.#streamedTextByMessageId.clear();
     this.#streamedTextMessages.clear();
     this.#textByAssistantMessageId.clear();
@@ -182,6 +193,7 @@ export class ClaudeAgentSdkMessageTranslator {
     }
 
     if (authoritativeText.length > 0) {
+      this.#authoritativeAssistantMessageIds.add(messageId);
       this.#textByAssistantMessageId.set(messageId, authoritativeText.join(""));
     }
 
@@ -403,7 +415,7 @@ export class ClaudeAgentSdkMessageTranslator {
         messageId:
           this.#events.toolParentMessageId(toolCallId) ??
           this.#activeAssistantMessageIds.get(runId) ??
-          this.#lastCompletedAssistantMessageIds.get(runId) ??
+          this.#lastCompletedAssistantMessages.get(runId)?.id ??
           this.#assistantMessageId(runId, null),
         toolCallId,
       });
@@ -419,11 +431,13 @@ export class ClaudeAgentSdkMessageTranslator {
     } else if (active !== undefined) {
       messageId = active;
     } else {
-      messageId = this.#assistantMessageIds.getOrCreate(
-        `${runId}:sequence:${this.#nextAssistantMessageSequence(runId)}`,
-      );
+      const ordinal = this.#nextAssistantMessageSequence(runId);
+      messageId = this.#assistantMessageIds.getOrCreate(`${runId}:sequence:${ordinal}`);
+      this.#assistantMessageOrdinals.set(messageId, ordinal);
     }
 
+    this.#ensureAssistantMessageOrdinal(runId, messageId);
+    this.#assistantMessageRunIds.set(messageId, runId);
     this.#activeAssistantMessageIds.set(runId, messageId);
     return messageId;
   }
@@ -436,7 +450,16 @@ export class ClaudeAgentSdkMessageTranslator {
     const ended = await this.#events.endMessage(context, messageId);
 
     if (ended) {
-      this.#lastCompletedAssistantMessageIds.set(runId, messageId);
+      const ordinal = this.#requireAssistantMessageOrdinal(messageId);
+      const current = this.#lastCompletedAssistantMessages.get(runId);
+
+      // A reconnect can deliver an older complete assistant snapshot after a
+      // newer message has already completed. Keep the snapshot repair for the
+      // old message, but never let arrival order move the canonical final
+      // candidate backwards.
+      if (current === undefined || ordinal > current.ordinal) {
+        this.#lastCompletedAssistantMessages.set(runId, { id: messageId, ordinal });
+      }
     }
 
     if (this.#activeAssistantMessageIds.get(runId) === messageId) {
@@ -448,6 +471,51 @@ export class ClaudeAgentSdkMessageTranslator {
     const sequence = (this.#assistantMessageSequences.get(runId) ?? 0) + 1;
     this.#assistantMessageSequences.set(runId, sequence);
     return sequence;
+  }
+
+  #ensureAssistantMessageOrdinal(runId: RunId, messageId: MessageId): number {
+    const existing = this.#assistantMessageOrdinals.get(messageId);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const ordinal = this.#nextAssistantMessageSequence(runId);
+    this.#assistantMessageOrdinals.set(messageId, ordinal);
+    return ordinal;
+  }
+
+  #requireAssistantMessageOrdinal(messageId: MessageId): number {
+    const ordinal = this.#assistantMessageOrdinals.get(messageId);
+
+    if (ordinal === undefined) {
+      throw new Error("Claude assistant message ordinal is not initialized.");
+    }
+
+    return ordinal;
+  }
+
+  #resolveFinalAssistantSnapshot(
+    runId: RunId,
+    resultText: string,
+  ): { id: MessageId; text: string } | null {
+    let selected: ClaudeAssistantFinalCandidate | null = null;
+
+    for (const [messageId, ordinal] of this.#assistantMessageOrdinals) {
+      if (
+        this.#assistantMessageRunIds.get(messageId) !== runId ||
+        !this.#authoritativeAssistantMessageIds.has(messageId) ||
+        this.#textByAssistantMessageId.get(messageId) !== resultText
+      ) {
+        continue;
+      }
+
+      if (selected === null || ordinal > selected.ordinal) {
+        selected = { id: messageId, ordinal };
+      }
+    }
+
+    return selected === null ? null : { id: selected.id, text: resultText };
   }
 
   #readNativeMessageId(message: SDKMessage): string | null {
@@ -498,19 +566,14 @@ export class ClaudeAgentSdkMessageTranslator {
     );
 
     if (message.subtype === "success") {
-      const finalMessageId = this.#lastCompletedAssistantMessageIds.get(runId) ?? null;
-      const finalMessageText =
-        finalMessageId === null
-          ? null
-          : (this.#textByAssistantMessageId.get(finalMessageId) ?? null);
+      const resultText = isRecord(message) ? readString(message, "result") : null;
+      // SDKResultSuccess.result is the provider's terminal text. Bind it only
+      // to a complete assistant snapshot with identical bytes; arrival order
+      // alone cannot distinguish a late replayed progress frame from final.
+      const finalMessage =
+        resultText === null ? null : this.#resolveFinalAssistantSnapshot(runId, resultText);
 
-      await this.#events.pushRunFinished(
-        context,
-        runId,
-        finalMessageId === null || finalMessageText === null
-          ? null
-          : { id: finalMessageId, text: finalMessageText },
-      );
+      await this.#events.pushRunFinished(context, runId, finalMessage);
       return;
     }
 

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -355,6 +355,11 @@ export class OpenAiAppServerEventBridge {
 
     await this.publishRunStarted(context, { runId, turnId });
     await this.#itemEvents.handleTurnCompletedItems(context, params, turnId);
+    const authoritativeFinalMessage = await this.#itemEvents.resolveTurnFinalAssistantSnapshot(
+      context,
+      params,
+      turnId,
+    );
     const status = turn ? readString(turn, "status") : null;
     const error = turn ? readRecord(turn, "error") : null;
     const cancellationReason = this.#turns.takeCancellationReason(turnId);
@@ -393,15 +398,6 @@ export class OpenAiAppServerEventBridge {
       return;
     }
 
-    const finalMessageId = this.#messages.finalMessageForTurn(turnId);
-    const finalMessage =
-      finalMessageId === null
-        ? null
-        : {
-            id: finalMessageId,
-            text: this.#messages.currentText(finalMessageId),
-          };
-
     await this.#push(context, "driver.openai.turn.completed", [
       {
         ...createOpenAiTurnEventFields({
@@ -411,11 +407,11 @@ export class OpenAiAppServerEventBridge {
         }),
         kind: "run.completed",
         payload: {
-          ...(finalMessage === null
+          ...(authoritativeFinalMessage === null
             ? {}
             : {
-                finalMessageId: finalMessage.id,
-                finalMessageText: finalMessage.text,
+                finalMessageId: authoritativeFinalMessage.id,
+                finalMessageText: authoritativeFinalMessage.text,
               }),
           stopReason: "end_turn",
         },

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -393,6 +393,15 @@ export class OpenAiAppServerEventBridge {
       return;
     }
 
+    const finalMessageId = this.#messages.finalMessageForTurn(turnId);
+    const finalMessage =
+      finalMessageId === null
+        ? null
+        : {
+            id: finalMessageId,
+            text: this.#messages.currentText(finalMessageId),
+          };
+
     await this.#push(context, "driver.openai.turn.completed", [
       {
         ...createOpenAiTurnEventFields({
@@ -402,6 +411,12 @@ export class OpenAiAppServerEventBridge {
         }),
         kind: "run.completed",
         payload: {
+          ...(finalMessage === null
+            ? {}
+            : {
+                finalMessageId: finalMessage.id,
+                finalMessageText: finalMessage.text,
+              }),
           stopReason: "end_turn",
         },
       },

--- a/src/runtimes/openai/app-server-event-state.ts
+++ b/src/runtimes/openai/app-server-event-state.ts
@@ -14,8 +14,10 @@ export class OpenAiMessageState {
   readonly #reasoningStarted = new Set<string>();
   readonly #started = new Set<string>();
   readonly #textById = new Map<string, string>();
+  readonly #turnByMessageId = new Map<MessageId, string>();
   readonly #turnMessages = new RuntimeAssistantMessageIdIndex<string>();
   readonly #turnMessageIds = new Map<string, MessageId>();
+  readonly #turnMessageSequences = new Map<string, number>();
 
   appendText(messageId: string, delta: string): void {
     if (delta.length === 0) {
@@ -56,8 +58,11 @@ export class OpenAiMessageState {
       return existing;
     }
 
-    const generated = this.#turnMessages.getOrCreate(turnId);
+    const nextSequence = (this.#turnMessageSequences.get(turnId) ?? 0) + 1;
+    this.#turnMessageSequences.set(turnId, nextSequence);
+    const generated = this.#turnMessages.getOrCreate(`${turnId}:${nextSequence}`);
     this.#turnMessageIds.set(turnId, generated);
+    this.#turnByMessageId.set(generated, turnId);
     await this.ensureMessageStarted(context, generated, push);
     return generated;
   }
@@ -83,12 +88,22 @@ export class OpenAiMessageState {
     ]);
   }
 
-  markEnded(messageId: string): boolean {
+  markEnded(messageId: MessageId): boolean {
     if (this.#ended.has(messageId)) {
       return false;
     }
 
     this.#ended.add(messageId);
+    const turnId = this.#turnByMessageId.get(messageId);
+
+    if (turnId !== undefined) {
+      this.#turnByMessageId.delete(messageId);
+
+      if (this.#turnMessageIds.get(turnId) === messageId) {
+        this.#turnMessageIds.delete(turnId);
+      }
+    }
+
     return true;
   }
 

--- a/src/runtimes/openai/app-server-event-state.ts
+++ b/src/runtimes/openai/app-server-event-state.ts
@@ -11,6 +11,9 @@ export type OpenAiEventPush = (
 
 export class OpenAiMessageState {
   readonly #ended = new Set<string>();
+  readonly #itemByMessageId = new Map<MessageId, string>();
+  readonly #itemMessageIds = new Map<string, MessageId>();
+  readonly #lastEndedMessageIds = new Map<string, MessageId>();
   readonly #reasoningStarted = new Set<string>();
   readonly #started = new Set<string>();
   readonly #textById = new Map<string, string>();
@@ -20,7 +23,7 @@ export class OpenAiMessageState {
   readonly #turnMessageSequences = new Map<string, number>();
 
   appendText(messageId: string, delta: string): void {
-    if (delta.length === 0) {
+    if (delta.length === 0 || this.#ended.has(messageId)) {
       return;
     }
 
@@ -29,6 +32,10 @@ export class OpenAiMessageState {
 
   currentText(messageId: string): string {
     return this.#textById.get(messageId) ?? "";
+  }
+
+  setText(messageId: string, text: string): void {
+    this.#textById.set(messageId, text);
   }
 
   ensureReasoningStarted(messageId: string, events: DriverEventInput[]): void {
@@ -67,6 +74,38 @@ export class OpenAiMessageState {
     return generated;
   }
 
+  async ensureItemMessage(
+    context: AgentDriverContext,
+    input: { itemId: string; turnId: string },
+    push: OpenAiEventPush,
+  ): Promise<MessageId> {
+    const itemKey = `${input.turnId}:${input.itemId}`;
+    const existing = this.#itemMessageIds.get(itemKey);
+
+    if (existing !== undefined) {
+      if (!this.#ended.has(existing)) {
+        this.#turnMessageIds.set(input.turnId, existing);
+      }
+      await this.ensureMessageStarted(context, existing, push);
+      return existing;
+    }
+
+    const activeMessageId = this.#turnMessageIds.get(input.turnId);
+    const messageId =
+      activeMessageId !== undefined &&
+      !this.#ended.has(activeMessageId) &&
+      !this.#itemByMessageId.has(activeMessageId)
+        ? activeMessageId
+        : this.#turnMessages.getOrCreate(`item:${itemKey}`);
+
+    this.#itemMessageIds.set(itemKey, messageId);
+    this.#itemByMessageId.set(messageId, itemKey);
+    this.#turnMessageIds.set(input.turnId, messageId);
+    this.#turnByMessageId.set(messageId, input.turnId);
+    await this.ensureMessageStarted(context, messageId, push);
+    return messageId;
+  }
+
   async ensureMessageStarted(
     context: AgentDriverContext,
     messageId: string,
@@ -97,6 +136,7 @@ export class OpenAiMessageState {
     const turnId = this.#turnByMessageId.get(messageId);
 
     if (turnId !== undefined) {
+      this.#lastEndedMessageIds.set(turnId, messageId);
       this.#turnByMessageId.delete(messageId);
 
       if (this.#turnMessageIds.get(turnId) === messageId) {
@@ -105,6 +145,14 @@ export class OpenAiMessageState {
     }
 
     return true;
+  }
+
+  isEnded(messageId: MessageId): boolean {
+    return this.#ended.has(messageId);
+  }
+
+  finalMessageForTurn(turnId: string): MessageId | null {
+    return this.#lastEndedMessageIds.get(turnId) ?? null;
   }
 
   messageForTurn(turnId: string): MessageId | null {

--- a/src/runtimes/openai/app-server-event-state.ts
+++ b/src/runtimes/openai/app-server-event-state.ts
@@ -10,10 +10,20 @@ export type OpenAiEventPush = (
 ) => Promise<void>;
 
 export class OpenAiMessageState {
+  readonly #completedSnapshots = new Map<
+    string,
+    {
+      itemId: string;
+      messageId: MessageId;
+      sequence: number;
+      text: string;
+      turnId: string;
+    }
+  >();
   readonly #ended = new Set<string>();
+  readonly #itemSequences = new Map<string, number>();
   readonly #itemByMessageId = new Map<MessageId, string>();
   readonly #itemMessageIds = new Map<string, MessageId>();
-  readonly #lastEndedMessageIds = new Map<string, MessageId>();
   readonly #reasoningStarted = new Set<string>();
   readonly #started = new Set<string>();
   readonly #textById = new Map<string, string>();
@@ -21,6 +31,7 @@ export class OpenAiMessageState {
   readonly #turnMessages = new RuntimeAssistantMessageIdIndex<string>();
   readonly #turnMessageIds = new Map<string, MessageId>();
   readonly #turnMessageSequences = new Map<string, number>();
+  readonly #turnNextItemSequences = new Map<string, number>();
 
   appendText(messageId: string, delta: string): void {
     if (delta.length === 0 || this.#ended.has(messageId)) {
@@ -80,6 +91,7 @@ export class OpenAiMessageState {
     push: OpenAiEventPush,
   ): Promise<MessageId> {
     const itemKey = `${input.turnId}:${input.itemId}`;
+    this.#observeItem(itemKey, input.turnId);
     const existing = this.#itemMessageIds.get(itemKey);
 
     if (existing !== undefined) {
@@ -104,6 +116,43 @@ export class OpenAiMessageState {
     this.#turnByMessageId.set(messageId, input.turnId);
     await this.ensureMessageStarted(context, messageId, push);
     return messageId;
+  }
+
+  recordCompletedSnapshot(input: {
+    itemId: string;
+    messageId: MessageId;
+    text: string;
+    turnId: string;
+  }): void {
+    const itemKey = `${input.turnId}:${input.itemId}`;
+    const sequence = this.#observeItem(itemKey, input.turnId);
+
+    this.#completedSnapshots.set(itemKey, { ...input, sequence });
+  }
+
+  finalCompletedSnapshotForTurn(turnId: string): { id: MessageId; text: string } | null {
+    let finalSnapshot:
+      | {
+          itemId: string;
+          messageId: MessageId;
+          sequence: number;
+          text: string;
+          turnId: string;
+        }
+      | undefined;
+
+    for (const snapshot of this.#completedSnapshots.values()) {
+      if (
+        snapshot.turnId === turnId &&
+        (finalSnapshot === undefined || snapshot.sequence > finalSnapshot.sequence)
+      ) {
+        finalSnapshot = snapshot;
+      }
+    }
+
+    return finalSnapshot === undefined
+      ? null
+      : { id: finalSnapshot.messageId, text: finalSnapshot.text };
   }
 
   async ensureMessageStarted(
@@ -136,7 +185,6 @@ export class OpenAiMessageState {
     const turnId = this.#turnByMessageId.get(messageId);
 
     if (turnId !== undefined) {
-      this.#lastEndedMessageIds.set(turnId, messageId);
       this.#turnByMessageId.delete(messageId);
 
       if (this.#turnMessageIds.get(turnId) === messageId) {
@@ -151,12 +199,21 @@ export class OpenAiMessageState {
     return this.#ended.has(messageId);
   }
 
-  finalMessageForTurn(turnId: string): MessageId | null {
-    return this.#lastEndedMessageIds.get(turnId) ?? null;
-  }
-
   messageForTurn(turnId: string): MessageId | null {
     return this.#turnMessageIds.get(turnId) ?? null;
+  }
+
+  #observeItem(itemKey: string, turnId: string): number {
+    const existing = this.#itemSequences.get(itemKey);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const sequence = (this.#turnNextItemSequences.get(turnId) ?? 0) + 1;
+    this.#turnNextItemSequences.set(turnId, sequence);
+    this.#itemSequences.set(itemKey, sequence);
+    return sequence;
   }
 }
 

--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -39,13 +39,23 @@ export class OpenAiAppServerItemEventBridge {
 
   async handleAgentMessageDelta(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const turnId = readNonEmptyString(params, "turnId");
+    const itemId = readNonEmptyString(params, "itemId");
     const delta = readNonEmptyString(params, "delta");
 
-    if (turnId === null || delta === null) {
+    if (turnId === null || itemId === null || delta === null) {
       return;
     }
 
-    const messageId = await this.#messages.ensureTurnMessage(context, turnId, this.#push);
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
+
+    if (this.#messages.isEnded(messageId)) {
+      return;
+    }
+
     this.#messages.appendText(messageId, delta);
     await this.#push(context, "driver.openai.agent.delta", [
       {
@@ -293,7 +303,11 @@ export class OpenAiAppServerItemEventBridge {
     }
 
     const finalText = readString(item, "text");
-    const messageId = await this.#messages.ensureTurnMessage(context, turnId, this.#push);
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
     const currentText = this.#messages.currentText(messageId);
 
     if (finalText !== null && finalText.length > currentText.length) {
@@ -327,6 +341,13 @@ export class OpenAiAppServerItemEventBridge {
           itemId,
         });
       }
+    }
+
+    if (finalText !== null) {
+      // item/completed is the provider's authoritative snapshot. Streaming
+      // deltas may be missing or replayed, so canonical completion must not
+      // inherit a corrupted accumulator even when live deltas cannot be undone.
+      this.#messages.setText(messageId, finalText);
     }
 
     if (this.#messages.markEnded(messageId)) {

--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -259,6 +259,55 @@ export class OpenAiAppServerItemEventBridge {
     }
   }
 
+  async resolveTurnFinalAssistantSnapshot(
+    context: AgentDriverContext,
+    params: JsonObject,
+    turnId: string,
+  ): Promise<{ id: string; text: string } | null> {
+    const turn = readRecord(params, "turn");
+
+    if (turn === null) {
+      return null;
+    }
+
+    const items = readArray(turn, "items");
+    const itemsView = readString(turn, "itemsView");
+
+    const finalAssistantItem = items.findLast(
+      (item) => isRecord(item) && readString(item, "type") === "agentMessage",
+    );
+
+    if (!isRecord(finalAssistantItem)) {
+      // Terminal notifications commonly use `itemsView: "notLoaded"` with an
+      // empty items list. The provider's item/completed frames are complete
+      // snapshots; first-seen item order remains stable when older completion
+      // frames arrive late. A full or legacy non-empty list stays authoritative.
+      if (itemsView === "full" || (itemsView === null && items.length > 0)) {
+        return null;
+      }
+
+      return this.#messages.finalCompletedSnapshotForTurn(turnId);
+    }
+
+    const itemId = readNonEmptyString(finalAssistantItem, "id");
+    const text = readString(finalAssistantItem, "text");
+
+    // The provider's ordered turn snapshot is the only authoritative final
+    // identity. If its final assistant item is incomplete, fail closed instead
+    // of selecting an earlier progress item or an arrival-ordered stream item.
+    if (itemId === null || text === null) {
+      return null;
+    }
+
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
+    this.#messages.setText(messageId, text);
+    return { id: messageId, text };
+  }
+
   async handleTurnPlanUpdated(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const plan = readArray(params, "plan").flatMap((entry) => {
       if (!isRecord(entry)) {
@@ -348,6 +397,12 @@ export class OpenAiAppServerItemEventBridge {
       // deltas may be missing or replayed, so canonical completion must not
       // inherit a corrupted accumulator even when live deltas cannot be undone.
       this.#messages.setText(messageId, finalText);
+      this.#messages.recordCompletedSnapshot({
+        itemId,
+        messageId,
+        text: finalText,
+        turnId,
+      });
     }
 
     if (this.#messages.markEnded(messageId)) {

--- a/src/runtimes/openai/generated/app-server-protocol-common.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-common.ts
@@ -11,6 +11,7 @@ import type {
   ThreadTokenUsage,
   TokenUsageBreakdown,
   Turn,
+  TurnItemsView,
   TurnPlanStep,
   TurnPlanStepStatus,
   TurnStatus,
@@ -359,6 +360,18 @@ function parseTurnStatus(value: unknown, label: string): TurnStatus | undefined 
   throw new Error(`${label} is unsupported.`);
 }
 
+function parseTurnItemsView(value: unknown, label: string): TurnItemsView | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === "notLoaded" || value === "summary" || value === "full") {
+    return value;
+  }
+
+  throw new Error(`${label} is unsupported.`);
+}
+
 export function parseTurn(value: unknown, label: string): Turn {
   const record = expectRecord(value, label);
   const id = readString(record, "id");
@@ -372,6 +385,7 @@ export function parseTurn(value: unknown, label: string): Turn {
     error === undefined || error === null ? null : expectRecord(error, `${label}.error`);
   const errorMessage = parsedError === null ? null : readString(parsedError, "message");
   const items = parseOptionalThreadItems(record["items"], `${label}.items`);
+  const itemsView = parseTurnItemsView(record["itemsView"], `${label}.itemsView`);
   const startedAt = readOptionalNullableNumber(record, "startedAt", label);
   const completedAt = readOptionalNullableNumber(record, "completedAt", label);
   const durationMs = readOptionalNullableNumber(record, "durationMs", label);
@@ -383,6 +397,7 @@ export function parseTurn(value: unknown, label: string): Turn {
     ...(durationMs === undefined ? {} : { durationMs }),
     ...(errorMessage === null ? {} : { error: { message: errorMessage } }),
     ...(items === undefined ? {} : { items }),
+    ...(itemsView === undefined ? {} : { itemsView }),
     ...(startedAt === undefined ? {} : { startedAt }),
     ...(status === undefined ? {} : { status }),
   };

--- a/src/runtimes/openai/generated/app-server-protocol-server.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-server.ts
@@ -16,6 +16,7 @@ import {
   readRequiredString,
 } from "./app-server-protocol-common";
 import type {
+  AgentMessageDeltaNotification,
   ConfigWarningNotification,
   ErrorNotification,
   FileChangePatchUpdatedNotification,
@@ -124,16 +125,15 @@ function parseThreadSettingsUpdatedNotification(value: unknown): ThreadSettingsU
   };
 }
 
-function parseOptionalDeltaNotification(
-  value: unknown,
-  method: string,
-): { delta?: string; threadId?: string; turnId?: string } {
-  const record = readParams(value, method);
+function parseAgentMessageDeltaNotification(value: unknown): AgentMessageDeltaNotification {
+  const label = "item/agentMessage/delta params";
+  const record = readParams(value, "item/agentMessage/delta");
 
   return {
-    ...parseOptionalNotificationString(record, "delta", `${method} params`),
-    ...parseOptionalNotificationString(record, "threadId", `${method} params`),
-    ...parseOptionalNotificationString(record, "turnId", `${method} params`),
+    delta: readRequiredString(record, "delta", label),
+    itemId: readRequiredString(record, "itemId", label),
+    threadId: readRequiredString(record, "threadId", label),
+    turnId: readRequiredString(record, "turnId", label),
   };
 }
 
@@ -301,8 +301,7 @@ const SERVER_NOTIFICATION_PARAM_PARSERS: {
 } = {
   configWarning: parseConfigWarningNotification,
   error: parseErrorNotification,
-  "item/agentMessage/delta": (value) =>
-    parseOptionalDeltaNotification(value, "item/agentMessage/delta"),
+  "item/agentMessage/delta": parseAgentMessageDeltaNotification,
   "item/commandExecution/outputDelta": (value) =>
     parseOptionalToolDeltaNotification(value, "item/commandExecution/outputDelta"),
   "item/completed": (value) => parseItemNotificationBase(value, "item/completed"),

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -257,10 +257,17 @@ export interface ThreadSettingsUpdatedNotification {
   threadSettings: JsonObject;
 }
 
+export interface AgentMessageDeltaNotification {
+  delta: string;
+  itemId: string;
+  threadId: string;
+  turnId: string;
+}
+
 export interface ServerNotificationParams {
   configWarning: ConfigWarningNotification;
   error: ErrorNotification;
-  "item/agentMessage/delta": { delta?: string; threadId?: string; turnId?: string };
+  "item/agentMessage/delta": AgentMessageDeltaNotification;
   "item/commandExecution/outputDelta": {
     delta?: string;
     itemId?: string;

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -91,6 +91,7 @@ export interface TurnStartParams {
 }
 
 export type TurnStatus = "completed" | "interrupted" | "failed" | "inProgress";
+export type TurnItemsView = "notLoaded" | "summary" | "full";
 
 export type PatchChangeKind =
   | { type: "add" }
@@ -121,6 +122,7 @@ export interface Turn {
   error?: { message?: string } | null;
   id: string;
   items?: ThreadItem[];
+  itemsView?: TurnItemsView;
   startedAt?: number | null;
   status?: TurnStatus;
 }

--- a/src/runtimes/runtime-turn-transcript.ts
+++ b/src/runtimes/runtime-turn-transcript.ts
@@ -4,6 +4,10 @@ import type { MessageId } from "../protocol/id";
 export class RuntimeAssistantMessageIdIndex<TKey extends string> {
   readonly #messageIds = new Map<TKey, MessageId>();
 
+  get(key: TKey): MessageId | null {
+    return this.#messageIds.get(key) ?? null;
+  }
+
   getOrCreate(key: TKey): MessageId {
     const existing = this.#messageIds.get(key);
 

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -22,7 +22,228 @@ function eventPayload(event: DriverEventInput): Record<string, unknown> {
   return event.payload as Record<string, unknown>;
 }
 
+function eventPayloadString(event: DriverEventInput, field: string): string {
+  const value = eventPayload(event)[field];
+
+  if (typeof value !== "string") {
+    throw new Error(`Expected ACP event payload ${field} to be a string.`);
+  }
+
+  return value;
+}
+
+function requireEvent(events: readonly DriverEventInput[], kind: string): DriverEventInput {
+  const event = events.find((candidate) => candidate.kind === kind);
+
+  if (event === undefined) {
+    throw new Error(`Expected ACP event ${kind}.`);
+  }
+
+  return event;
+}
+
 describe("ACP runtime event translation", () => {
+  test("keeps native assistant messages separate across tools and projects only the final one", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "prompt-message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const progressOne = "进度 1：正在读取上游报告。";
+    const progressTwo = "进度 2：已完成工具校验。";
+    const finalChunkOne = [
+      "CANARY-FINAL-START：中文与 ASCII 最终回答必须逐字保留。",
+      "",
+      "| 校验项 | 结果 |",
+      "| --- | --- |",
+      "| 多字节 | ✅ 中文😀 |",
+      "",
+      "链接：https://example.com/final-output",
+      "",
+    ].join("\n");
+    const finalChunkTwo = ["```text", "最终代码块|中文😀|END", "```", "CANARY-FINAL-END"].join(
+      "\n",
+    );
+    const finalText = `${finalChunkOne}${finalChunkTwo}`;
+    const events = [
+      ...state.translateUpdate({
+        update: {
+          content: { text: progressOne, type: "text" },
+          messageId: "native-progress-1",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          sessionUpdate: "tool_call",
+          status: "running",
+          title: "Read report",
+          toolCallId: "tool-1",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: progressTwo, type: "text" },
+          messageId: "native-progress-2",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: finalChunkOne, type: "text" },
+          messageId: "native-final",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: finalChunkTwo, type: "text" },
+          messageId: "native-final",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      // A late replay of a settled progress message must not replace the
+      // newer final message by arrival order.
+      ...state.translateUpdate({
+        update: {
+          content: { text: "late progress replay", type: "text" },
+          messageId: "native-progress-1",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.completePrompt("end_turn", null),
+    ];
+    const messageDeltas = events.filter((event) => event.kind === "message.delta");
+    const toolStarted = requireEvent(events, "item.started");
+    const completed = requireEvent(events, "run.completed");
+
+    expect(messageDeltas).toHaveLength(4);
+    expect(messageDeltas.map((event) => eventPayloadString(event, "contentDelta"))).toEqual([
+      progressOne,
+      progressTwo,
+      finalChunkOne,
+      finalChunkTwo,
+    ]);
+
+    const [progressOneEvent, progressTwoEvent, finalChunkOneEvent, finalChunkTwoEvent] =
+      messageDeltas;
+    const progressOneId = eventPayloadString(progressOneEvent, "messageId");
+    const progressTwoId = eventPayloadString(progressTwoEvent, "messageId");
+    const finalMessageId = eventPayloadString(finalChunkOneEvent, "messageId");
+
+    expect([...new Set([progressOneId, progressTwoId, finalMessageId])]).toHaveLength(3);
+    expect(eventPayloadString(finalChunkTwoEvent, "messageId")).toBe(finalMessageId);
+    expect(eventPayload(toolStarted)).toMatchObject({
+      parentMessageId: progressOneId,
+    });
+    expect(eventPayload(completed)).toMatchObject({
+      finalMessageId,
+      finalMessageText: finalText,
+    });
+    expect(eventPayloadString(completed, "finalMessageText")).not.toContain(progressOne);
+    expect(new TextEncoder().encode(eventPayloadString(completed, "finalMessageText"))).toEqual(
+      new TextEncoder().encode(finalText),
+    );
+  });
+
+  test("uses a later identified final after anonymous progress, but fails closed for an anonymous final", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "prompt-message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const identifiedFinalText = "最终回答：native identity 使它可安全成为 canonical final。";
+    const events = [
+      ...state.translateUpdate({
+        update: {
+          content: { text: "进度消息，不能作为 canonical final。", type: "text" },
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: identifiedFinalText, type: "text" },
+          messageId: "native-final",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.completePrompt("end_turn", null),
+    ];
+    const completed = requireEvent(events, "run.completed");
+    const finalDelta = requireEvent(
+      events.filter(
+        (event) =>
+          event.kind === "message.delta" &&
+          eventPayloadString(event, "contentDelta") === identifiedFinalText,
+      ),
+      "message.delta",
+    );
+
+    expect(eventPayload(completed)).toMatchObject({
+      finalMessageId: eventPayloadString(finalDelta, "messageId"),
+      finalMessageText: identifiedFinalText,
+    });
+
+    const anonymousFinalState = new AcpTurnEventState();
+
+    anonymousFinalState.begin({
+      messageId: "prompt-message-2",
+      runId: "run-2",
+      sessionId: "session-1",
+    });
+    const anonymousFinalEvents = [
+      ...anonymousFinalState.translateUpdate({
+        update: {
+          content: { text: "匿名进度消息，必须与后续匿名消息分隔。", type: "text" },
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...anonymousFinalState.translateUpdate({
+        update: {
+          content: { text: "已识别的进度消息。", type: "text" },
+          messageId: "native-progress",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...anonymousFinalState.translateUpdate({
+        update: {
+          content: { text: "匿名最终消息，不能猜测身份。", type: "text" },
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...anonymousFinalState.completePrompt("end_turn", null),
+    ];
+    const anonymousCompleted = requireEvent(anonymousFinalEvents, "run.completed");
+    const firstAnonymousDelta = requireEvent(
+      anonymousFinalEvents.filter(
+        (event) =>
+          event.kind === "message.delta" &&
+          eventPayloadString(event, "contentDelta") === "匿名进度消息，必须与后续匿名消息分隔。",
+      ),
+      "message.delta",
+    );
+    const finalAnonymousDelta = requireEvent(
+      anonymousFinalEvents.filter(
+        (event) =>
+          event.kind === "message.delta" &&
+          eventPayloadString(event, "contentDelta") === "匿名最终消息，不能猜测身份。",
+      ),
+      "message.delta",
+    );
+
+    expect(eventPayloadString(firstAnonymousDelta, "messageId")).not.toBe(
+      eventPayloadString(finalAnonymousDelta, "messageId"),
+    );
+    expect(eventPayload(anonymousCompleted)).not.toHaveProperty("finalMessageId");
+    expect(eventPayload(anonymousCompleted)).not.toHaveProperty("finalMessageText");
+  });
+
   test("maps ACP turn updates onto canonical runtime events with one tool lifecycle", () => {
     const state = new AcpTurnEventState();
 
@@ -340,7 +561,7 @@ describe("ACP runtime event translation", () => {
       ...state.translateUpdate({
         update: {
           content: {
-            text: "pong",
+            text: "pong\n",
             type: "text",
           },
           messageId: "opencode-message-1",
@@ -360,11 +581,110 @@ describe("ACP runtime event translation", () => {
       "thought.completed",
       "run.completed",
     ]);
+    const fallbackMessageId = eventPayloadString(events[3], "messageId");
+
     expect(eventPayload(events[4])).toMatchObject({
-      contentDelta: "pong",
-      messageId: "message-1",
+      contentDelta: "\npong\n",
+      messageId: fallbackMessageId,
       role: "agent",
     });
+    expect(eventPayload(events[7])).toMatchObject({
+      finalMessageId: fallbackMessageId,
+      finalMessageText: "\npong\n",
+    });
+  });
+
+  test("treats a different native thought as the final assistant message boundary", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const progressText = "PROGRESS：正在整理资料。";
+    const finalText = "FINAL：中文表格与结论均已完成。";
+    const events = [
+      ...state.translateUpdate({
+        update: {
+          content: { text: progressText, type: "text" },
+          messageId: "native-progress",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: finalText, type: "text" },
+          messageId: "native-final-thought",
+          sessionUpdate: "agent_thought_chunk",
+        },
+      }),
+      ...state.completePrompt("end_turn", null),
+    ];
+    const messageDeltas = events.filter((event) => event.kind === "message.delta");
+    const progressMessageId = eventPayloadString(messageDeltas[0], "messageId");
+    const finalMessageId = eventPayloadString(messageDeltas[1], "messageId");
+    const completed = requireEvent(events, "run.completed");
+
+    expect(eventKinds(events)).toEqual([
+      "message.started",
+      "message.delta",
+      "message.completed",
+      "thought.started",
+      "thought.delta",
+      "message.started",
+      "message.delta",
+      "message.completed",
+      "thought.completed",
+      "run.completed",
+    ]);
+    expect(progressMessageId).not.toBe(finalMessageId);
+    expect(eventPayload(completed)).toMatchObject({
+      finalMessageId,
+      finalMessageText: finalText,
+    });
+    expect(eventPayloadString(completed, "finalMessageText")).not.toContain(progressText);
+  });
+
+  test("fails closed when an anonymous thought follows identified progress", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const events = [
+      ...state.translateUpdate({
+        update: {
+          content: { text: "PROGRESS：已识别但不是最终回答。", type: "text" },
+          messageId: "native-progress",
+          sessionUpdate: "agent_message_chunk",
+        },
+      }),
+      ...state.translateUpdate({
+        update: {
+          content: { text: "匿名 thought 可能是更新的最终回答。", type: "text" },
+          sessionUpdate: "agent_thought_chunk",
+        },
+      }),
+      ...state.completePrompt("end_turn", null),
+    ];
+    const completed = requireEvent(events, "run.completed");
+
+    expect(eventKinds(events)).toEqual([
+      "message.started",
+      "message.delta",
+      "message.completed",
+      "thought.started",
+      "thought.delta",
+      "thought.completed",
+      "run.completed",
+    ]);
+    expect(eventPayload(completed)).not.toHaveProperty("finalMessageId");
+    expect(eventPayload(completed)).not.toHaveProperty("finalMessageText");
   });
 
   test("closes open stream items before a failed turn event", () => {

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
+import {
+  DriverEventSourceIdAllocator,
+  toDriverEventEnvelopes,
+} from "../src/infrastructure/runtime/driver-instance-socket";
 import type { DriverEventInput } from "../src/protocol/events";
 import {
   AcpTurnEventState,
@@ -117,8 +120,17 @@ describe("ACP runtime event translation", () => {
     });
     expect(eventPayload(toolEvent as DriverEventInput)).not.toHaveProperty("rawInput");
 
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "acp-empty-input-test",
+    );
     const envelopes = events.flatMap((event) =>
-      toDriverEventEnvelopes(driverBootPayload, event, DRIVER_TEST_IDS.runId),
+      toDriverEventEnvelopes(
+        driverBootPayload,
+        event,
+        DRIVER_TEST_IDS.runId,
+        sourceIds.sourceEventIdFor(event),
+      ),
     );
     const canonicalToolEvent = envelopes
       .map((envelope) => envelope.event)

--- a/tests/acp-json.test.ts
+++ b/tests/acp-json.test.ts
@@ -10,14 +10,19 @@ interface TestConnection {
   readonly stdout: PassThrough;
 }
 
-function createConnection(input?: { readonly transportErrors?: string[] }): TestConnection {
+interface TestConnectionOptions {
+  readonly onNotification?: (() => Promise<void>) | undefined;
+  readonly transportErrors?: string[] | undefined;
+}
+
+function createConnection(input?: TestConnectionOptions): TestConnection {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
 
   return {
     connection: new AcpJsonRpcConnection({
       onInvalidMessage: () => undefined,
-      onNotification: async () => undefined,
+      onNotification: input?.onNotification ?? (async () => undefined),
       onRequest: async () => null,
       onTransportError: (error) => {
         input?.transportErrors?.push(error.message);
@@ -31,8 +36,29 @@ function createConnection(input?: { readonly transportErrors?: string[] }): Test
 }
 
 function closeStreams(input: TestConnection): void {
+  input.connection.close("test cleanup");
   input.stdin.destroy();
   input.stdout.destroy();
+}
+
+async function readRequestId(stdin: PassThrough): Promise<number> {
+  return new Promise((resolve) => {
+    stdin.once("data", (chunk: Buffer | string) => {
+      const payload: unknown = JSON.parse(chunk.toString());
+
+      if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+        throw new Error("Expected an ACP JSON-RPC request object.");
+      }
+
+      const id = (payload as Record<string, unknown>)["id"];
+
+      if (typeof id !== "number") {
+        throw new Error("Expected a numeric ACP JSON-RPC request id.");
+      }
+
+      resolve(id);
+    });
+  });
 }
 
 describe("ACP JSON-RPC connection", () => {
@@ -73,6 +99,277 @@ describe("ACP JSON-RPC connection", () => {
 
     try {
       await expect(request).rejects.toThrow();
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("drains an earlier session update before resolving its prompt response", async () => {
+    let releaseNotification: (() => void) | null = null;
+    const notificationGate = new Promise<void>((resolve) => {
+      releaseNotification = resolve;
+    });
+    let notificationHandled = false;
+    const rpc = createConnection({
+      onNotification: async () => {
+        await notificationGate;
+        notificationHandled = true;
+      },
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+
+      const beforeNotification = await Promise.race([
+        request.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        setTimeout(20).then(() => "pending" as const),
+      ]);
+
+      expect(beforeNotification).toBe("pending");
+      expect(notificationHandled).toBe(false);
+      releaseNotification?.();
+      await expect(request).resolves.toBe("done");
+      expect(notificationHandled).toBe(true);
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("drains queued final frames before EOF closes the transport", async () => {
+    let releaseNotification: (() => void) | null = null;
+    const notificationGate = new Promise<void>((resolve) => {
+      releaseNotification = resolve;
+    });
+    const rpc = createConnection({
+      onNotification: async () => notificationGate,
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+      rpc.stdout.end();
+
+      releaseNotification?.();
+      await expect(request).resolves.toBe("done");
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("drains queued final frames when process stdin and stdout close together", async () => {
+    let releaseNotification: (() => void) | null = null;
+    const notificationGate = new Promise<void>((resolve) => {
+      releaseNotification = resolve;
+    });
+    const rpc = createConnection({
+      onNotification: async () => notificationGate,
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+      rpc.stdout.end();
+      rpc.stdin.destroy();
+
+      const beforeNotification = await Promise.race([
+        request.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        setTimeout(20).then(() => "pending" as const),
+      ]);
+
+      expect(beforeNotification).toBe("pending");
+      releaseNotification?.();
+      await expect(request).resolves.toBe("done");
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("keeps draining stdout after stdin closes first", async () => {
+    let notificationHandled = false;
+    const rpc = createConnection({
+      onNotification: async () => {
+        notificationHandled = true;
+      },
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+      const stdinClosed = new Promise<void>((resolve) => {
+        rpc.stdin.once("close", resolve);
+      });
+
+      rpc.stdin.destroy();
+      await stdinClosed;
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+
+      await expect(request).resolves.toBe("done");
+      expect(notificationHandled).toBe(true);
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("rejects new requests after stdin closes", async () => {
+    const rpc = createConnection();
+
+    try {
+      const stdinClosed = new Promise<void>((resolve) => {
+        rpc.stdin.once("close", resolve);
+      });
+
+      rpc.stdin.destroy();
+      await stdinClosed;
+
+      await expect(rpc.connection.request("ping", {})).rejects.toThrow("ACP stdin closed.");
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("keeps draining stdout after stdin errors first", async () => {
+    const rpc = createConnection();
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+      const stdinClosed = new Promise<void>((resolve) => {
+        rpc.stdin.once("close", resolve);
+      });
+
+      rpc.stdin.destroy(new Error("ACP stdin failed before final stdout frames."));
+      await stdinClosed;
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+
+      await expect(request).resolves.toBe("done");
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("drains queued final frames before a simultaneous stdin error closes transport", async () => {
+    let releaseNotification: (() => void) | null = null;
+    const notificationGate = new Promise<void>((resolve) => {
+      releaseNotification = resolve;
+    });
+    const rpc = createConnection({
+      onNotification: async () => notificationGate,
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+      rpc.stdout.end();
+      rpc.stdin.destroy(new Error("ACP stdin failed during process exit."));
+
+      const beforeNotification = await Promise.race([
+        request.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        setTimeout(20).then(() => "pending" as const),
+      ]);
+
+      expect(beforeNotification).toBe("pending");
+      releaseNotification?.();
+      await expect(request).resolves.toBe("done");
+    } finally {
+      closeStreams(rpc);
+    }
+  });
+
+  test("drains queued final frames before a simultaneous stdout error closes transport", async () => {
+    let releaseNotification: (() => void) | null = null;
+    const notificationGate = new Promise<void>((resolve) => {
+      releaseNotification = resolve;
+    });
+    const rpc = createConnection({
+      onNotification: async () => notificationGate,
+    });
+
+    try {
+      const requestIdPromise = readRequestId(rpc.stdin);
+      const request = rpc.connection.request("session/prompt", {});
+      const requestId = await requestIdPromise;
+
+      rpc.stdout.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: { update: { sessionUpdate: "agent_message_chunk" } },
+        })}\n`,
+      );
+      rpc.stdout.write(`${JSON.stringify({ id: requestId, jsonrpc: "2.0", result: "done" })}\n`);
+      rpc.stdout.destroy(new Error("ACP stdout failed during process exit."));
+      rpc.stdin.destroy();
+
+      const beforeNotification = await Promise.race([
+        request.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        setTimeout(20).then(() => "pending" as const),
+      ]);
+
+      expect(beforeNotification).toBe("pending");
+      releaseNotification?.();
+      await expect(request).resolves.toBe("done");
     } finally {
       closeStreams(rpc);
     }

--- a/tests/acp-provider-fixtures.test.ts
+++ b/tests/acp-provider-fixtures.test.ts
@@ -220,14 +220,63 @@ function stripUndefined(value: unknown): unknown {
   return Object.fromEntries(entries);
 }
 
-function normalizeAcpEvent(event: DriverEventInput): Record<string, unknown> {
+function readAssistantMessageId(event: DriverEventInput): string | null {
+  if (event.kind !== "message.started" || !isRecord(event.payload)) {
+    return null;
+  }
+
+  return event.payload["role"] === "agent" ? readStringField(event.payload, "messageId") : null;
+}
+
+function replaceAssistantMessageIds(value: unknown, aliases: ReadonlyMap<string, string>): unknown {
+  if (typeof value === "string") {
+    return aliases.get(value) ?? value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => replaceAssistantMessageIds(entry, aliases));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, replaceAssistantMessageIds(entry, aliases)]),
+  );
+}
+
+function normalizeAcpEvent(
+  event: DriverEventInput,
+  aliases: ReadonlyMap<string, string>,
+): Record<string, unknown> {
   const eventRecord = stripUndefined(event);
 
   if (!isRecord(eventRecord)) {
     throw new Error("ACP translator event must be an object.");
   }
 
-  return eventRecord;
+  const normalized = replaceAssistantMessageIds(eventRecord, aliases);
+
+  if (!isRecord(normalized)) {
+    throw new Error("ACP normalized event must be an object.");
+  }
+
+  return normalized;
+}
+
+function normalizeAcpEvents(events: readonly DriverEventInput[]): Record<string, unknown>[] {
+  const aliases = new Map<string, string>();
+
+  for (const event of events) {
+    const messageId = readAssistantMessageId(event);
+
+    if (messageId !== null && !aliases.has(messageId)) {
+      aliases.set(messageId, `assistant-message-${aliases.size + 1}`);
+    }
+  }
+
+  return events.map((event) => normalizeAcpEvent(event, aliases));
 }
 
 function appAcpFixture(fixture: AcpProviderFixtureCase): DriverEventInput[] {
@@ -267,6 +316,6 @@ describe("ACP provider fixtures", () => {
   test.each(acpFixtureNames)("apps provider-native fixture %s", (name) => {
     const fixture = readAcpProviderFixtureCase(`./fixtures/providers/acp/cases/${name}.json`);
 
-    expect(appAcpFixture(fixture).map(normalizeAcpEvent)).toEqual(fixture.expectedEvents);
+    expect(normalizeAcpEvents(appAcpFixture(fixture))).toEqual(fixture.expectedEvents);
   });
 });

--- a/tests/claude-agent-sdk-provider-fixtures.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures.test.ts
@@ -220,6 +220,7 @@ describe("Claude Agent SDK provider fixtures", () => {
         uuid: "assistant-final",
       },
       {
+        result: "最终：中文 Markdown ✅",
         subtype: "success",
         total_cost_usd: 0,
         type: "result",
@@ -280,6 +281,7 @@ describe("Claude Agent SDK provider fixtures", () => {
         uuid: "assistant-final",
       },
       {
+        result: "完整最终回答",
         subtype: "success",
         total_cost_usd: 0,
         type: "result",
@@ -298,6 +300,257 @@ describe("Claude Agent SDK provider fixtures", () => {
       runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
 
     expect(payload?.["finalMessageText"]).toBe("完整最终回答");
+  });
+
+  test("keeps duplicate text scoped to its native assistant message", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "相同文本", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-progress-a",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "assistant-progress-a",
+      },
+      {
+        message: {
+          content: [{ text: "相同文本", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-final-b",
+      },
+      {
+        result: "相同文本",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const textMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+      return typeof contentDelta === "string" && typeof messageId === "string"
+        ? [{ contentDelta, messageId }]
+        : [];
+    });
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(textMessages.map((entry) => entry.contentDelta)).toEqual(["相同文本", "相同文本"]);
+    expect(new Set(textMessages.map((entry) => entry.messageId)).size).toBe(2);
+    expect(payload?.["finalMessageId"]).toBe(textMessages.at(-1)?.messageId);
+    expect(payload?.["finalMessageText"]).toBe("相同文本");
+  });
+
+  test("does not promote a replayed stream-only message stop to canonical final", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "中", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-final",
+      },
+      {
+        event: {
+          delta: { text: "中", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-final",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "assistant-final",
+      },
+      {
+        result: "中",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const liveText = events().flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      return typeof contentDelta === "string" ? [contentDelta] : [];
+    });
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(liveText).toEqual(["中", "中"]);
+    expect(payload).not.toBeNull();
+    expect(payload).not.toHaveProperty("finalMessageId");
+    expect(payload).not.toHaveProperty("finalMessageText");
+  });
+
+  test("does not let a late older assistant completion replace the final message", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "进度 A", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-progress-a",
+      },
+      {
+        message: {
+          content: [{ text: "最终回答 B", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-final-b",
+      },
+      {
+        message: {
+          content: [{ text: "进度 A（迟到完整快照）", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-progress-a",
+      },
+      {
+        result: "最终回答 B",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(runCompleted).toBeDefined();
+    expect(payload).not.toBeNull();
+    expect(payload?.["finalMessageText"]).toBe("最终回答 B");
+  });
+
+  test("fails closed when a newer assistant is still incomplete at result success", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        message: {
+          content: [{ text: "已完成的较早进度", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-progress-a",
+      },
+      {
+        event: {
+          delta: { text: "尚未结束的最终回答 B", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-final-b",
+      },
+      {
+        result: "尚未结束的最终回答 B",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(runCompleted).toBeDefined();
+    expect(payload).not.toBeNull();
+    expect(payload).not.toHaveProperty("finalMessageId");
+    expect(payload).not.toHaveProperty("finalMessageText");
+  });
+
+  test("fails closed when an older full frame arrives after a newer incomplete message", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "最终回答 B 的流式片段", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-final-b",
+      },
+      {
+        message: {
+          content: [{ text: "迟到的进度 A", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-progress-a",
+      },
+      {
+        result: "最终回答 B",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(runCompleted).toBeDefined();
+    expect(payload).not.toBeNull();
+    expect(payload).not.toHaveProperty("finalMessageId");
+    expect(payload).not.toHaveProperty("finalMessageText");
   });
 
   test.each(claudeFixtureNames)("apps provider-native fixture %s", async (name) => {

--- a/tests/claude-agent-sdk-provider-fixtures.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures.test.ts
@@ -186,6 +186,120 @@ function createHarness() {
 }
 
 describe("Claude Agent SDK provider fixtures", () => {
+  test("rotates assistant identity across a tool boundary and marks the final message", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        message: {
+          content: [
+            { text: "进度：准备工具。", type: "text" },
+            { id: "tool-1", input: { command: "pwd" }, name: "Bash", type: "tool_use" },
+          ],
+        },
+        type: "assistant",
+        uuid: "assistant-progress",
+      },
+      {
+        message: {
+          content: [
+            {
+              content: [{ text: "/workspace", type: "text" }],
+              tool_use_id: "tool-1",
+              type: "tool_result",
+            },
+          ],
+        },
+        type: "user",
+        uuid: "tool-result",
+      },
+      {
+        message: {
+          content: [{ text: "最终：中文 Markdown ✅", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-final",
+      },
+      {
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const textMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+      return typeof contentDelta === "string" && typeof messageId === "string"
+        ? [{ contentDelta, messageId }]
+        : [];
+    });
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const runCompletedPayload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(textMessages.map((entry) => entry.contentDelta)).toEqual([
+      "进度：准备工具。",
+      "最终：中文 Markdown ✅",
+    ]);
+    expect(new Set(textMessages.map((entry) => entry.messageId)).size).toBe(2);
+    expect(runCompletedPayload?.["finalMessageId"]).toBe(textMessages.at(-1)?.messageId);
+  });
+
+  test("uses the complete assistant message to repair an incomplete stream snapshot", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "残缺流", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "assistant-final",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "assistant-final",
+      },
+      {
+        message: {
+          content: [{ text: "完整最终回答", type: "text" }],
+        },
+        type: "assistant",
+        uuid: "assistant-final",
+      },
+      {
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(payload?.["finalMessageText"]).toBe("完整最终回答");
+  });
+
   test.each(claudeFixtureNames)("apps provider-native fixture %s", async (name) => {
     const fixture = readClaudeProviderFixtureCase(
       `./fixtures/providers/claude-agent-sdk/cases/${name}.json`,

--- a/tests/driver-runtime-boundary.test.ts
+++ b/tests/driver-runtime-boundary.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { DriverRuntimeStateMachine } from "../src/core/driver-runtime-state";
 import { createDriverRuntimeTimingEvent } from "../src/core/driver-runtime-timing";
-import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
+import {
+  DriverEventSourceIdAllocator,
+  toDriverEventEnvelopes,
+} from "../src/infrastructure/runtime/driver-instance-socket";
 import { createPromiseDeferred } from "../src/utils/async";
 import { DRIVER_TEST_IDS, driverBootPayload } from "./driver-boot-payload-fixture";
 import {
@@ -36,79 +39,191 @@ describe("driver runtime boundary", () => {
   });
 
   test("driver socket stamps warm turn events with the active run id", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "warm-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: "sdk-internal-run",
+    } as const;
     const [event] = toDriverEventEnvelopes(
       driverBootPayload,
-      {
-        kind: "run.started",
-        payload: {
-          startedAt: new Date(1_000).toISOString(),
-        },
-        runId: "sdk-internal-run",
-      },
+      draft,
       DRIVER_TEST_IDS.secondRunId,
+      sourceIds.sourceEventIdFor(draft),
     );
 
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.secondRunId);
   });
 
   test("driver socket rejects provider turn ids outside an active platform run", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "invalid-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: "provider-turn-1",
+    } as const;
+
     expect(() =>
-      toDriverEventEnvelopes(
-        driverBootPayload,
-        {
-          kind: "run.started",
-          payload: {
-            startedAt: new Date(1_000).toISOString(),
-          },
-          runId: "provider-turn-1",
-        },
-        null,
-      ),
+      toDriverEventEnvelopes(driverBootPayload, draft, null, sourceIds.sourceEventIdFor(draft)),
     ).toThrow("Run ID must be a valid ULID.");
   });
 
   test("driver socket preserves explicit event run ids outside active turns", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "explicit-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: DRIVER_TEST_IDS.thirdRunId,
+    } as const;
     const [event] = toDriverEventEnvelopes(
       driverBootPayload,
-      {
-        kind: "run.started",
-        payload: {
-          startedAt: new Date(1_000).toISOString(),
-        },
-        runId: DRIVER_TEST_IDS.thirdRunId,
-      },
+      draft,
       null,
+      sourceIds.sourceEventIdFor(draft),
     );
 
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.thirdRunId);
   });
 
-  test("driver socket creates deterministic source ids for draft event replay", () => {
+  test("driver socket keeps retries idempotent without aliasing equal draft events", () => {
     const draft = {
-      kind: "message.started",
+      delivery: "best_effort",
+      kind: "message.delta",
       payload: {
+        contentDelta: "的",
         messageId: "message-1",
         role: "agent",
       },
     } as const;
-    const occurrences = new Map<string, number>();
+    const laterEqualDraft = {
+      ...draft,
+      payload: { ...draft.payload },
+    };
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "retry-test",
+    );
     const [first] = toDriverEventEnvelopes(
       driverBootPayload,
       draft,
       DRIVER_TEST_IDS.runId,
-      occurrences,
+      sourceIds.sourceEventIdFor(draft),
     );
-    const [second] = toDriverEventEnvelopes(
+    const [retry] = toDriverEventEnvelopes(
       driverBootPayload,
       draft,
       DRIVER_TEST_IDS.runId,
-      occurrences,
+      sourceIds.sourceEventIdFor(draft),
     );
-    const [retry] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
+    const [laterEqual] = toDriverEventEnvelopes(
+      driverBootPayload,
+      laterEqualDraft,
+      DRIVER_TEST_IDS.runId,
+      sourceIds.sourceEventIdFor(laterEqualDraft),
+    );
 
-    expect(first?.event.sourceEventId).toMatch(/^sha256:/);
-    expect(second?.event.sourceEventId).toBe(`${first?.event.sourceEventId}:2`);
+    expect(first?.event.sourceEventId).toBe(
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:retry-test:event:1`,
+    );
     expect(retry?.event.sourceEventId).toBe(first?.event.sourceEventId);
+    expect(laterEqual?.event.sourceEventId).toBe(
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:retry-test:event:2`,
+    );
+  });
+
+  test("driver socket assigns unique identities to repeated Unicode stream chunks", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "unicode-test",
+    );
+    const chunks = [
+      "001|中文长文本校验-Aa0-表格字符|END001\\n",
+      "002|中文长文本校验-Aa1-表格字符|END002\\n",
+      "的",
+      "的",
+      "| ✅ 😀 | https://example.test/final |",
+    ];
+    const drafts = chunks.map((contentDelta) => ({
+      delivery: "best_effort" as const,
+      kind: "message.delta" as const,
+      payload: {
+        contentDelta,
+        messageId: "message-unicode",
+        role: "agent" as const,
+      },
+    }));
+    const envelopes = drafts.map(
+      (draft) =>
+        toDriverEventEnvelopes(
+          driverBootPayload,
+          draft,
+          DRIVER_TEST_IDS.runId,
+          sourceIds.sourceEventIdFor(draft),
+        )[0],
+    );
+
+    expect(envelopes.map((event) => event?.event.sourceEventId)).toEqual([
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:1`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:2`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:3`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:4`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:5`,
+    ]);
+    expect(
+      envelopes
+        .map((event) => {
+          const payload = event?.event.payload;
+          if (
+            typeof payload === "object" &&
+            payload !== null &&
+            "contentDelta" in payload &&
+            typeof payload.contentDelta === "string"
+          ) {
+            return payload.contentDelta;
+          }
+
+          return null;
+        })
+        .join(""),
+    ).toBe(chunks.join(""));
+  });
+
+  test("driver socket separates source identities across process boots", () => {
+    const firstBoot = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "boot-one",
+    );
+    const secondBoot = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "boot-two",
+    );
+    const firstDraft = {
+      kind: "message.delta",
+      payload: { contentDelta: "相同内容", messageId: "message-1", role: "agent" },
+    } as const;
+    const secondDraft = {
+      ...firstDraft,
+      payload: { ...firstDraft.payload },
+    };
+
+    expect(firstBoot.sourceEventIdFor(firstDraft)).not.toBe(
+      secondBoot.sourceEventIdFor(secondDraft),
+    );
   });
 
   test("runs input commands through the backend and reports completion to API", async () => {

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -57,7 +57,7 @@
     {
       "kind": "message.started",
       "payload": {
-        "messageId": "message-1",
+        "messageId": "assistant-message-1",
         "role": "agent"
       },
       "runId": "run-1"
@@ -71,7 +71,7 @@
           "type": "text"
         },
         "contentDelta": "hello",
-        "messageId": "message-1",
+        "messageId": "assistant-message-1",
         "role": "agent"
       },
       "runId": "run-1",
@@ -82,7 +82,7 @@
       "payload": {
         "itemId": "tool-1",
         "itemType": "tool_call",
-        "parentMessageId": "message-1",
+        "parentMessageId": "assistant-message-1",
         "title": "Run command"
       },
       "runId": "run-1"
@@ -140,7 +140,7 @@
     {
       "kind": "message.completed",
       "payload": {
-        "messageId": "message-1",
+        "messageId": "assistant-message-1",
         "role": "agent"
       },
       "runId": "run-1"
@@ -162,8 +162,6 @@
     {
       "kind": "run.completed",
       "payload": {
-        "finalMessageId": "message-1",
-        "finalMessageText": "hello",
         "stopReason": "end_turn"
       },
       "runId": "run-1"

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -162,6 +162,8 @@
     {
       "kind": "run.completed",
       "payload": {
+        "finalMessageId": "message-1",
+        "finalMessageText": "hello",
         "stopReason": "end_turn"
       },
       "runId": "run-1"

--- a/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
+++ b/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
@@ -209,6 +209,8 @@
     {
       "kind": "run.completed",
       "payload": {
+        "finalMessageId": "<driver-id>",
+        "finalMessageText": "hello",
         "stopReason": "end_turn"
       },
       "runId": "run-1"

--- a/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
+++ b/tests/fixtures/providers/claude-agent-sdk/cases/stream-text-thinking-tool-result.json
@@ -78,6 +78,7 @@
       "type": "stream_event"
     },
     {
+      "result": "hello",
       "subtype": "success",
       "total_cost_usd": 0.02,
       "type": "result",
@@ -209,8 +210,6 @@
     {
       "kind": "run.completed",
       "payload": {
-        "finalMessageId": "<driver-id>",
-        "finalMessageText": "hello",
         "stopReason": "end_turn"
       },
       "runId": "run-1"

--- a/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
+++ b/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
@@ -66,6 +66,8 @@
         "turnId": "turn-1"
       },
       "payload": {
+        "finalMessageId": "<driver-id>",
+        "finalMessageText": "pong",
         "stopReason": "end_turn"
       },
       "sourceEventId": "openai.turn.completed:turn-1"

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -308,6 +308,113 @@ describe("OpenAi app-server event bridge", () => {
     ]);
   });
 
+  test("rotates assistant message identity after each completed agent item", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    const progressMessages = [
+      "进度 1：已完成读取。",
+      "进度 2：已完成工具准备。",
+      "进度 3：准备最终总结。",
+    ];
+
+    for (const [index, progressMessage] of progressMessages.entries()) {
+      await bridge.handleNotification(context, "item/agentMessage/delta", {
+        delta: progressMessage,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+      await bridge.handleNotification(context, "item/completed", {
+        item: {
+          id: `message-progress-${index + 1}`,
+          text: progressMessage,
+          type: "agentMessage",
+        },
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    }
+    await bridge.handleNotification(context, "item/started", {
+      item: {
+        id: "artifact-tool",
+        type: "commandExecution",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        aggregatedOutput: "artifact 已创建。",
+        id: "artifact-tool",
+        type: "commandExecution",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "| 最终：表格 | `代码` | https://example.test/😀",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: "| 最终：表格 | `代码` | https://example.test/😀",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          ...progressMessages.map((text, index) => ({
+            id: `message-progress-${index + 1}`,
+            text,
+            type: "agentMessage",
+          })),
+          {
+            aggregatedOutput: "artifact 已创建。",
+            id: "artifact-tool",
+            type: "commandExecution",
+          },
+          {
+            id: "message-final",
+            text: "| 最终：表格 | `代码` | https://example.test/😀",
+            type: "agentMessage",
+          },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const assistantMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta") {
+        return [];
+      }
+
+      const messageId = readEventPayloadString(event, "messageId");
+      const contentDelta = readEventPayloadString(event, "contentDelta");
+      return messageId === null || contentDelta === null ? [] : [{ contentDelta, messageId }];
+    });
+
+    expect(assistantMessages.map((message) => message.contentDelta)).toEqual([
+      ...progressMessages,
+      "| 最终：表格 | `代码` | https://example.test/😀",
+    ]);
+    expect(new Set(assistantMessages.map((message) => message.messageId)).size).toBe(4);
+    const toolParentMessageId = events()
+      .filter((event) => event.kind === "item.started")
+      .map((event) => readEventPayloadString(event, "parentMessageId"))
+      .find((messageId): messageId is string => messageId !== null);
+
+    expect(toolParentMessageId).toBe(assistantMessages.at(-1)?.messageId);
+    expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(4);
+    expect(events().filter((event) => event.kind === "run.completed")).toHaveLength(1);
+  });
+
   test("command output streams as tool result content", async () => {
     const { bridge, context, events, logger } = createHarness();
 

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -181,6 +181,47 @@ describe("OpenAi app-server event bridge", () => {
     ]);
   });
 
+  test("uses item completion text as the authoritative final snapshot", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "损坏的流式片段",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: "完整最终回答：中文 Markdown ✅",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          {
+            id: "message-final",
+            text: "完整最终回答：中文 Markdown ✅",
+            type: "agentMessage",
+          },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    expect(readEventPayloadString(runCompleted as DriverEvent, "finalMessageText")).toBe(
+      "完整最终回答：中文 Markdown ✅",
+    );
+  });
+
   test("completed turns app final items before run finish", async () => {
     const { bridge, context, events, logger } = createHarness();
 
@@ -320,6 +361,7 @@ describe("OpenAi app-server event bridge", () => {
     for (const [index, progressMessage] of progressMessages.entries()) {
       await bridge.handleNotification(context, "item/agentMessage/delta", {
         delta: progressMessage,
+        itemId: `message-progress-${index + 1}`,
         threadId: "thread-1",
         turnId: "turn-1",
       });
@@ -352,6 +394,7 @@ describe("OpenAi app-server event bridge", () => {
     });
     await bridge.handleNotification(context, "item/agentMessage/delta", {
       delta: "| 最终：表格 | `代码` | https://example.test/😀",
+      itemId: "message-final",
       threadId: "thread-1",
       turnId: "turn-1",
     });
@@ -413,6 +456,54 @@ describe("OpenAi app-server event bridge", () => {
     expect(toolParentMessageId).toBe(assistantMessages.at(-1)?.messageId);
     expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(4);
     expect(events().filter((event) => event.kind === "run.completed")).toHaveLength(1);
+  });
+
+  test("keeps interleaved assistant item identities isolated and ignores late replay", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息甲",
+      itemId: "message-a",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息乙",
+      itemId: "message-b",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-b", text: "消息乙", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-a", text: "消息甲", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息甲",
+      itemId: "message-a",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await logger.destroy();
+
+    const deltas = events().flatMap((event) => {
+      if (event.kind !== "message.delta") {
+        return [];
+      }
+
+      const messageId = readEventPayloadString(event, "messageId");
+      const contentDelta = readEventPayloadString(event, "contentDelta");
+      return messageId === null || contentDelta === null ? [] : [{ contentDelta, messageId }];
+    });
+
+    expect(deltas.map((entry) => entry.contentDelta)).toEqual(["消息甲", "消息乙"]);
+    expect(new Set(deltas.map((entry) => entry.messageId)).size).toBe(2);
+    expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(2);
   });
 
   test("command output streams as tool result content", async () => {

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -193,7 +193,6 @@ describe("OpenAi app-server event bridge", () => {
     await bridge.handleNotification(context, "item/completed", {
       item: {
         id: "message-final",
-        text: "完整最终回答：中文 Markdown ✅",
         type: "agentMessage",
       },
       threadId: "thread-1",
@@ -217,9 +216,197 @@ describe("OpenAi app-server event bridge", () => {
 
     const runCompleted = events().find((event) => event.kind === "run.completed");
 
-    expect(readEventPayloadString(runCompleted as DriverEvent, "finalMessageText")).toBe(
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe(
       "完整最终回答：中文 Markdown ✅",
     );
+  });
+
+  test("does not fall back to progress when the final turn item is incomplete", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-progress",
+        text: "PROGRESS",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+          { id: "message-final", type: "agentMessage" },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageId")).toBeNull();
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBeNull();
+  });
+
+  test("uses the last completed assistant snapshot when turn items are omitted", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "PROGRESS",
+      itemId: "message-progress",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-progress",
+        text: "PROGRESS",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "最终回答：中文 Markdown ✅",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: "最终回答：中文 Markdown ✅",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageId")).not.toBeNull();
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe(
+      "最终回答：中文 Markdown ✅",
+    );
+  });
+
+  test("uses completed snapshots when terminal items are not loaded", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-final", text: "FINAL", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "notLoaded",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("FINAL");
+  });
+
+  test("does not fall back when a full terminal item list has no assistant", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "full",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBeNull();
+  });
+
+  test("uses first-seen item order when older completions arrive late", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    for (const [itemId, delta] of [
+      ["message-progress", "PROGRESS"],
+      ["message-final", "FINAL"],
+    ] as const) {
+      await bridge.handleNotification(context, "item/agentMessage/delta", {
+        delta,
+        itemId,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    }
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-final", text: "FINAL", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: { id: "turn-1", status: "completed" },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("FINAL");
   });
 
   test("completed turns app final items before run finish", async () => {
@@ -489,6 +676,17 @@ describe("OpenAi app-server event bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          { id: "message-a", text: "消息甲", type: "agentMessage" },
+          { id: "message-b", text: "消息乙", type: "agentMessage" },
+        ],
+        status: "completed",
+      },
+    });
     await logger.destroy();
 
     const deltas = events().flatMap((event) => {
@@ -504,6 +702,16 @@ describe("OpenAi app-server event bridge", () => {
     expect(deltas.map((entry) => entry.contentDelta)).toEqual(["消息甲", "消息乙"]);
     expect(new Set(deltas.map((entry) => entry.messageId)).size).toBe(2);
     expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(2);
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    const finalMessageId = readEventPayloadString(runCompleted, "finalMessageId");
+
+    expect(finalMessageId).toBe(deltas.find((entry) => entry.contentDelta === "消息乙")?.messageId);
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("消息乙");
   });
 
   test("command output streams as tool result content", async () => {

--- a/tests/openai-app-server-live.test.ts
+++ b/tests/openai-app-server-live.test.ts
@@ -164,6 +164,7 @@ describe("OpenAI app-server live provider", () => {
           timeoutMs: LIVE_TURN_TIMEOUT_MS,
         });
         const outputText = turnEvents.map(textDeltaFrom).join("").trim().toLowerCase();
+        const completedEvent = turnEvents.find((event) => event.kind === "run.completed");
         logLiveStatus("received output", {
           text: outputText,
         });
@@ -175,6 +176,10 @@ describe("OpenAI app-server live provider", () => {
           outputChars: outputText.length,
         });
         expect(outputText).toContain("pong");
+        expect(completedEvent?.payload).toMatchObject({
+          finalMessageId: expect.any(String),
+          finalMessageText: expect.stringContaining("pong"),
+        });
       } finally {
         if (kernelStarted) {
           logLiveStatus("stopping driver kernel");

--- a/tests/openai-app-server-provider-fixtures.test.ts
+++ b/tests/openai-app-server-provider-fixtures.test.ts
@@ -232,6 +232,29 @@ async function assertTrackTurnFixture(
 }
 
 describe("OpenAI app-server provider fixtures", () => {
+  test("preserves the assistant item identity on text deltas", () => {
+    expect(
+      parseServerNotificationParams("item/agentMessage/delta", {
+        delta: "中文 delta",
+        itemId: "message-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    ).toEqual({
+      delta: "中文 delta",
+      itemId: "message-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(() =>
+      parseServerNotificationParams("item/agentMessage/delta", {
+        delta: "missing identity",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    ).toThrow("itemId");
+  });
+
   test.each(providerFixtureNames)("apps provider-native fixture %s", async (name) => {
     const fixture = readProviderFixtureCase(
       `./fixtures/providers/openai-app-server/cases/${name}.json`,

--- a/tests/openai-app-server-provider-fixtures.test.ts
+++ b/tests/openai-app-server-provider-fixtures.test.ts
@@ -255,6 +255,27 @@ describe("OpenAI app-server provider fixtures", () => {
     ).toThrow("itemId");
   });
 
+  test("preserves the terminal turn item loading state", () => {
+    expect(
+      parseServerNotificationParams("turn/completed", {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          items: [],
+          itemsView: "notLoaded",
+          status: "completed",
+        },
+      }),
+    ).toMatchObject({
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "notLoaded",
+        status: "completed",
+      },
+    });
+  });
+
   test.each(providerFixtureNames)("apps provider-native fixture %s", async (name) => {
     const fixture = readProviderFixtureCase(
       `./fixtures/providers/openai-app-server/cases/${name}.json`,


### PR DESCRIPTION
## Summary

- give every runtime event a stable boot-scoped identity without aliasing equal Unicode deltas
- preserve provider assistant message identity across progress, tools, final messages, replay, and reconnect
- publish only an authoritative final assistant ID and complete text snapshot on `run.completed`
- process ACP inbound JSON-RPC frames in FIFO order and drain accepted frames before transport shutdown

## Reproduction evidence

Before this change, the fallback source ID was a hash of event content and its occurrence counter was recreated for every `pushEvents` call. Distinct equal deltas in separate flushes therefore received the same source ID and later valid text was treated as replay.

OpenAI also discarded `itemId` on assistant deltas, while Claude and ACP reused or selected assistant identity by completion arrival. Progress, tool-adjacent text, and final output could therefore be merged. ACP additionally processed each JSON-RPC line concurrently, allowing the prompt response to clear turn state before an earlier final notification finished.

Deterministic regressions reproduce repeated Chinese chunks, interleaved and replayed messages, delayed older Claude snapshots, duplicate stream deltas, incomplete final snapshots, ACP progress/tool/final boundaries, and notification/response plus EOF races.

## Root cause and fix

1. Payload equality was incorrectly used as event identity. Draft events now receive stable per-object IDs from a boot-scoped allocator, while retries of the same draft remain idempotent.
2. OpenAI delta parsing preserves `itemId` and complete `item/completed` snapshots. A full terminal item list selects its provider-ordered last assistant item; when app-server explicitly reports `itemsView: "notLoaded"`, the bridge selects the last completed assistant by first-seen item order, so a delayed older completion cannot replace it. Explicitly incomplete or authoritative full terminal items still fail closed.
3. Claude assistant messages bind to SDK UUID. Complete assistant frames are authoritative snapshots and must match the SDK success `result` byte-for-byte; delayed older completion, cross-message equal text, stream-only replay, or a newer incomplete message cannot replace or fall back to progress.
4. ACP maps native assistant `messageId` values to distinct runtime messages. Anonymous terminal messages fail closed, different native thought identity creates a real message boundary, and late settled progress replay cannot win by arrival order.
5. ACP JSON-RPC notifications and responses are processed FIFO. Stdin close/error is treated as a write-side half-close, while accepted and later stdout frames continue to drain through EOF/error.
6. OpenAI, Claude, and capable ACP completions carry `finalMessageId` and `finalMessageText`, so the API does not infer canonical output from stream fragments.

## Verification

```text
env -u ANTHROPIC_API_KEY -u AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY \
  -u OPENAI_API_KEY -u AGENT_DRIVER_LIVE_OPENAI_API_KEY \
  -u AGENT_DRIVER_LIVE_OPENCODE_API_KEY -u AGENT_DRIVER_LIVE_OPENCODE \
  bun run test
# 186 pass, 4 skipped, 0 fail

bun run lint
bun run tc
bun run build
git diff --check

bun test tests/openai-app-server-live.test.ts
# 1 pass, including exact run.completed.finalMessageId/finalMessageText assertions
```

The skipped tests require an external live provider or OpenCode ACP process; all deterministic tests passed.

## Generated and schema changes

- Generated files: yes — OpenAI app-server protocol parser/types now preserve the required assistant `itemId` and terminal `itemsView`
- GraphQL codegen: none
- DB migrations or baseline updates: none

The parent Mosoo API projection and Public Thread API fix is tracked in the companion PR from `fix/runtime-final-output-aggregation`.
