### PR TITLE
fix(runtime): preserve long final output text

### DIFF
--- a/src/infrastructure/runtime/driver-instance-socket.ts
+++ b/src/infrastructure/runtime/driver-instance-socket.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/websocket";
 
@@ -29,6 +27,7 @@ interface DriverInstanceSocketHandlers {
 export class DriverInstanceSocket {
   #activeRunId: RunId | null = null;
   #client: DriverRuntimeClient | null = null;
+  readonly #sourceEventIdAllocator: DriverEventSourceIdAllocator;
   private readonly handlers: DriverInstanceSocketHandlers;
   private readonly payload: DriverBootPayload;
   #socket: DriverWireSocket | null = null;
@@ -36,6 +35,7 @@ export class DriverInstanceSocket {
   constructor(payload: DriverBootPayload, handlers: DriverInstanceSocketHandlers) {
     this.handlers = handlers;
     this.payload = payload;
+    this.#sourceEventIdAllocator = new DriverEventSourceIdAllocator(payload.driverInstanceId);
   }
 
   async connect(): Promise<void> {
@@ -125,11 +125,15 @@ export class DriverInstanceSocket {
   }
 
   async pushEvents(input: { events: DriverEventInput[] }): Promise<DriverEventBatchOutput> {
-    const sourceEventIdOccurrences = new Map<string, number>();
     return this.#requireClient().driver.pushEvents({
       driverInstanceId: this.payload.driverInstanceId,
       events: input.events.flatMap((event) =>
-        toDriverEventEnvelopes(this.payload, event, this.#activeRunId, sourceEventIdOccurrences),
+        toDriverEventEnvelopes(
+          this.payload,
+          event,
+          this.#activeRunId,
+          this.#sourceEventIdAllocator.sourceEventIdFor(event),
+        ),
       ),
     });
   }
@@ -170,49 +174,65 @@ export class DriverInstanceSocket {
   }
 }
 
+/**
+ * Assigns a stable source identity to draft events that do not already carry
+ * one. A publisher retries the same draft object after a transport failure, so
+ * the WeakMap keeps that retry idempotent. A distinct later draft with identical
+ * text receives a new identity instead of being mistaken for a replay. The boot
+ * identity prevents a replacement process from restarting the sequence in the
+ * same driver-instance namespace.
+ */
+export class DriverEventSourceIdAllocator {
+  readonly #sourceEventIds = new WeakMap<object, string>();
+  #nextSourceEventSequence = 0;
+  private readonly prefix: string;
+
+  constructor(driverInstanceId: DriverInstanceId, bootId: string = createDriverId()) {
+    this.prefix = `driver:${driverInstanceId}:${bootId}:event`;
+  }
+
+  sourceEventIdFor(event: DriverEventInput): string | undefined {
+    if (isRuntimeEventEnvelope(event) || readExplicitSourceEventId(event) !== undefined) {
+      return undefined;
+    }
+
+    const existing = this.#sourceEventIds.get(event);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    this.#nextSourceEventSequence += 1;
+    const sourceEventId = `${this.prefix}:${this.#nextSourceEventSequence}`;
+    this.#sourceEventIds.set(event, sourceEventId);
+    return sourceEventId;
+  }
+}
+
+function readExplicitSourceEventId(event: DriverEventInput): string | undefined {
+  return typeof event.sourceEventId === "string" && event.sourceEventId.length > 0
+    ? event.sourceEventId
+    : undefined;
+}
+
 function readEventOccurredAt(event: DriverEventInput): number {
   const occurredAt = isRuntimeEventEnvelope(event) ? event.occurredAt : event.occurredAt;
   const timestamp = occurredAt === undefined ? Date.now() : Date.parse(occurredAt);
   return Number.isFinite(timestamp) ? timestamp : Date.now();
 }
 
-function readSourceEventId(event: DriverEventInput): string {
+function readSourceEventId(event: DriverEventInput, generatedSourceEventId?: string): string {
   if (isRuntimeEventEnvelope(event)) {
-    return event.sourceEventId ?? event.id;
+    return readExplicitSourceEventId(event) ?? event.id;
   }
 
-  return event.sourceEventId ?? createDeterministicSourceEventId(event);
-}
+  const sourceEventId = readExplicitSourceEventId(event) ?? generatedSourceEventId;
 
-function addSourceEventIdOccurrence(
-  sourceEventId: string,
-  occurrences: Map<string, number>,
-): string {
-  const nextOccurrence = (occurrences.get(sourceEventId) ?? 0) + 1;
-  occurrences.set(sourceEventId, nextOccurrence);
-
-  return nextOccurrence === 1 ? sourceEventId : `${sourceEventId}:${nextOccurrence}`;
-}
-
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
+  if (sourceEventId === undefined) {
+    throw new Error("Driver draft event must have an allocated source event ID.");
   }
 
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`;
-  }
-
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .filter((key) => record[key] !== undefined)
-    .toSorted()
-    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
-    .join(",")}}`;
-}
-
-function createDeterministicSourceEventId(event: DriverEventInput): string {
-  return `sha256:${createHash("sha256").update(stableJson(event)).digest("hex")}`;
+  return sourceEventId;
 }
 
 function parseRunId(value: string): RunId {
@@ -233,13 +253,10 @@ export function toDriverEventEnvelopes(
   payload: DriverBootPayload,
   event: DriverEventInput,
   activeRunId: RunId | null,
-  sourceEventIdOccurrences = new Map<string, number>(),
+  generatedSourceEventId?: string,
 ): DriverEventEnvelope[] {
   const occurredAtMs = readEventOccurredAt(event);
-  const sourceEventId = addSourceEventIdOccurrence(
-    readSourceEventId(event),
-    sourceEventIdOccurrences,
-  );
+  const sourceEventId = readSourceEventId(event, generatedSourceEventId);
   const occurredAt = new Date(occurredAtMs).toISOString();
   const runId = readEventRunId(event, activeRunId);
 

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -355,6 +355,11 @@ export class OpenAiAppServerEventBridge {
 
     await this.publishRunStarted(context, { runId, turnId });
     await this.#itemEvents.handleTurnCompletedItems(context, params, turnId);
+    const authoritativeFinalMessage = await this.#itemEvents.resolveTurnFinalAssistantSnapshot(
+      context,
+      params,
+      turnId,
+    );
     const status = turn ? readString(turn, "status") : null;
     const error = turn ? readRecord(turn, "error") : null;
     const cancellationReason = this.#turns.takeCancellationReason(turnId);
@@ -402,6 +407,12 @@ export class OpenAiAppServerEventBridge {
         }),
         kind: "run.completed",
         payload: {
+          ...(authoritativeFinalMessage === null
+            ? {}
+            : {
+                finalMessageId: authoritativeFinalMessage.id,
+                finalMessageText: authoritativeFinalMessage.text,
+              }),
           stopReason: "end_turn",
         },
       },

--- a/src/runtimes/openai/app-server-event-state.ts
+++ b/src/runtimes/openai/app-server-event-state.ts
@@ -10,15 +10,31 @@ export type OpenAiEventPush = (
 ) => Promise<void>;
 
 export class OpenAiMessageState {
+  readonly #completedSnapshots = new Map<
+    string,
+    {
+      itemId: string;
+      messageId: MessageId;
+      sequence: number;
+      text: string;
+      turnId: string;
+    }
+  >();
   readonly #ended = new Set<string>();
+  readonly #itemSequences = new Map<string, number>();
+  readonly #itemByMessageId = new Map<MessageId, string>();
+  readonly #itemMessageIds = new Map<string, MessageId>();
   readonly #reasoningStarted = new Set<string>();
   readonly #started = new Set<string>();
   readonly #textById = new Map<string, string>();
+  readonly #turnByMessageId = new Map<MessageId, string>();
   readonly #turnMessages = new RuntimeAssistantMessageIdIndex<string>();
   readonly #turnMessageIds = new Map<string, MessageId>();
+  readonly #turnMessageSequences = new Map<string, number>();
+  readonly #turnNextItemSequences = new Map<string, number>();
 
   appendText(messageId: string, delta: string): void {
-    if (delta.length === 0) {
+    if (delta.length === 0 || this.#ended.has(messageId)) {
       return;
     }
 
@@ -27,6 +43,10 @@ export class OpenAiMessageState {
 
   currentText(messageId: string): string {
     return this.#textById.get(messageId) ?? "";
+  }
+
+  setText(messageId: string, text: string): void {
+    this.#textById.set(messageId, text);
   }
 
   ensureReasoningStarted(messageId: string, events: DriverEventInput[]): void {
@@ -56,10 +76,83 @@ export class OpenAiMessageState {
       return existing;
     }
 
-    const generated = this.#turnMessages.getOrCreate(turnId);
+    const nextSequence = (this.#turnMessageSequences.get(turnId) ?? 0) + 1;
+    this.#turnMessageSequences.set(turnId, nextSequence);
+    const generated = this.#turnMessages.getOrCreate(`${turnId}:${nextSequence}`);
     this.#turnMessageIds.set(turnId, generated);
+    this.#turnByMessageId.set(generated, turnId);
     await this.ensureMessageStarted(context, generated, push);
     return generated;
+  }
+
+  async ensureItemMessage(
+    context: AgentDriverContext,
+    input: { itemId: string; turnId: string },
+    push: OpenAiEventPush,
+  ): Promise<MessageId> {
+    const itemKey = `${input.turnId}:${input.itemId}`;
+    this.#observeItem(itemKey, input.turnId);
+    const existing = this.#itemMessageIds.get(itemKey);
+
+    if (existing !== undefined) {
+      if (!this.#ended.has(existing)) {
+        this.#turnMessageIds.set(input.turnId, existing);
+      }
+      await this.ensureMessageStarted(context, existing, push);
+      return existing;
+    }
+
+    const activeMessageId = this.#turnMessageIds.get(input.turnId);
+    const messageId =
+      activeMessageId !== undefined &&
+      !this.#ended.has(activeMessageId) &&
+      !this.#itemByMessageId.has(activeMessageId)
+        ? activeMessageId
+        : this.#turnMessages.getOrCreate(`item:${itemKey}`);
+
+    this.#itemMessageIds.set(itemKey, messageId);
+    this.#itemByMessageId.set(messageId, itemKey);
+    this.#turnMessageIds.set(input.turnId, messageId);
+    this.#turnByMessageId.set(messageId, input.turnId);
+    await this.ensureMessageStarted(context, messageId, push);
+    return messageId;
+  }
+
+  recordCompletedSnapshot(input: {
+    itemId: string;
+    messageId: MessageId;
+    text: string;
+    turnId: string;
+  }): void {
+    const itemKey = `${input.turnId}:${input.itemId}`;
+    const sequence = this.#observeItem(itemKey, input.turnId);
+
+    this.#completedSnapshots.set(itemKey, { ...input, sequence });
+  }
+
+  finalCompletedSnapshotForTurn(turnId: string): { id: MessageId; text: string } | null {
+    let finalSnapshot:
+      | {
+          itemId: string;
+          messageId: MessageId;
+          sequence: number;
+          text: string;
+          turnId: string;
+        }
+      | undefined;
+
+    for (const snapshot of this.#completedSnapshots.values()) {
+      if (
+        snapshot.turnId === turnId &&
+        (finalSnapshot === undefined || snapshot.sequence > finalSnapshot.sequence)
+      ) {
+        finalSnapshot = snapshot;
+      }
+    }
+
+    return finalSnapshot === undefined
+      ? null
+      : { id: finalSnapshot.messageId, text: finalSnapshot.text };
   }
 
   async ensureMessageStarted(
@@ -83,17 +176,44 @@ export class OpenAiMessageState {
     ]);
   }
 
-  markEnded(messageId: string): boolean {
+  markEnded(messageId: MessageId): boolean {
     if (this.#ended.has(messageId)) {
       return false;
     }
 
     this.#ended.add(messageId);
+    const turnId = this.#turnByMessageId.get(messageId);
+
+    if (turnId !== undefined) {
+      this.#turnByMessageId.delete(messageId);
+
+      if (this.#turnMessageIds.get(turnId) === messageId) {
+        this.#turnMessageIds.delete(turnId);
+      }
+    }
+
     return true;
+  }
+
+  isEnded(messageId: MessageId): boolean {
+    return this.#ended.has(messageId);
   }
 
   messageForTurn(turnId: string): MessageId | null {
     return this.#turnMessageIds.get(turnId) ?? null;
+  }
+
+  #observeItem(itemKey: string, turnId: string): number {
+    const existing = this.#itemSequences.get(itemKey);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const sequence = (this.#turnNextItemSequences.get(turnId) ?? 0) + 1;
+    this.#turnNextItemSequences.set(turnId, sequence);
+    this.#itemSequences.set(itemKey, sequence);
+    return sequence;
   }
 }
 

--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -39,13 +39,23 @@ export class OpenAiAppServerItemEventBridge {
 
   async handleAgentMessageDelta(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const turnId = readNonEmptyString(params, "turnId");
+    const itemId = readNonEmptyString(params, "itemId");
     const delta = readNonEmptyString(params, "delta");
 
-    if (turnId === null || delta === null) {
+    if (turnId === null || itemId === null || delta === null) {
       return;
     }
 
-    const messageId = await this.#messages.ensureTurnMessage(context, turnId, this.#push);
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
+
+    if (this.#messages.isEnded(messageId)) {
+      return;
+    }
+
     this.#messages.appendText(messageId, delta);
     await this.#push(context, "driver.openai.agent.delta", [
       {
@@ -249,6 +259,55 @@ export class OpenAiAppServerItemEventBridge {
     }
   }
 
+  async resolveTurnFinalAssistantSnapshot(
+    context: AgentDriverContext,
+    params: JsonObject,
+    turnId: string,
+  ): Promise<{ id: string; text: string } | null> {
+    const turn = readRecord(params, "turn");
+
+    if (turn === null) {
+      return null;
+    }
+
+    const items = readArray(turn, "items");
+    const itemsView = readString(turn, "itemsView");
+
+    const finalAssistantItem = items.findLast(
+      (item) => isRecord(item) && readString(item, "type") === "agentMessage",
+    );
+
+    if (!isRecord(finalAssistantItem)) {
+      // Terminal notifications commonly use `itemsView: "notLoaded"` with an
+      // empty items list. The provider's item/completed frames are complete
+      // snapshots; first-seen item order remains stable when older completion
+      // frames arrive late. A full or legacy non-empty list stays authoritative.
+      if (itemsView === "full" || (itemsView === null && items.length > 0)) {
+        return null;
+      }
+
+      return this.#messages.finalCompletedSnapshotForTurn(turnId);
+    }
+
+    const itemId = readNonEmptyString(finalAssistantItem, "id");
+    const text = readString(finalAssistantItem, "text");
+
+    // The provider's ordered turn snapshot is the only authoritative final
+    // identity. If its final assistant item is incomplete, fail closed instead
+    // of selecting an earlier progress item or an arrival-ordered stream item.
+    if (itemId === null || text === null) {
+      return null;
+    }
+
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
+    this.#messages.setText(messageId, text);
+    return { id: messageId, text };
+  }
+
   async handleTurnPlanUpdated(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const plan = readArray(params, "plan").flatMap((entry) => {
       if (!isRecord(entry)) {
@@ -293,7 +352,11 @@ export class OpenAiAppServerItemEventBridge {
     }
 
     const finalText = readString(item, "text");
-    const messageId = await this.#messages.ensureTurnMessage(context, turnId, this.#push);
+    const messageId = await this.#messages.ensureItemMessage(
+      context,
+      { itemId, turnId },
+      this.#push,
+    );
     const currentText = this.#messages.currentText(messageId);
 
     if (finalText !== null && finalText.length > currentText.length) {
@@ -327,6 +390,19 @@ export class OpenAiAppServerItemEventBridge {
           itemId,
         });
       }
+    }
+
+    if (finalText !== null) {
+      // item/completed is the provider's authoritative snapshot. Streaming
+      // deltas may be missing or replayed, so canonical completion must not
+      // inherit a corrupted accumulator even when live deltas cannot be undone.
+      this.#messages.setText(messageId, finalText);
+      this.#messages.recordCompletedSnapshot({
+        itemId,
+        messageId,
+        text: finalText,
+        turnId,
+      });
     }
 
     if (this.#messages.markEnded(messageId)) {

--- a/src/runtimes/openai/generated/app-server-protocol-common.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-common.ts
@@ -11,6 +11,7 @@ import type {
   ThreadTokenUsage,
   TokenUsageBreakdown,
   Turn,
+  TurnItemsView,
   TurnPlanStep,
   TurnPlanStepStatus,
   TurnStatus,
@@ -359,6 +360,18 @@ function parseTurnStatus(value: unknown, label: string): TurnStatus | undefined 
   throw new Error(`${label} is unsupported.`);
 }
 
+function parseTurnItemsView(value: unknown, label: string): TurnItemsView | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === "notLoaded" || value === "summary" || value === "full") {
+    return value;
+  }
+
+  throw new Error(`${label} is unsupported.`);
+}
+
 export function parseTurn(value: unknown, label: string): Turn {
   const record = expectRecord(value, label);
   const id = readString(record, "id");
@@ -372,6 +385,7 @@ export function parseTurn(value: unknown, label: string): Turn {
     error === undefined || error === null ? null : expectRecord(error, `${label}.error`);
   const errorMessage = parsedError === null ? null : readString(parsedError, "message");
   const items = parseOptionalThreadItems(record["items"], `${label}.items`);
+  const itemsView = parseTurnItemsView(record["itemsView"], `${label}.itemsView`);
   const startedAt = readOptionalNullableNumber(record, "startedAt", label);
   const completedAt = readOptionalNullableNumber(record, "completedAt", label);
   const durationMs = readOptionalNullableNumber(record, "durationMs", label);
@@ -383,6 +397,7 @@ export function parseTurn(value: unknown, label: string): Turn {
     ...(durationMs === undefined ? {} : { durationMs }),
     ...(errorMessage === null ? {} : { error: { message: errorMessage } }),
     ...(items === undefined ? {} : { items }),
+    ...(itemsView === undefined ? {} : { itemsView }),
     ...(startedAt === undefined ? {} : { startedAt }),
     ...(status === undefined ? {} : { status }),
   };

--- a/src/runtimes/openai/generated/app-server-protocol-server.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-server.ts
@@ -16,6 +16,7 @@ import {
   readRequiredString,
 } from "./app-server-protocol-common";
 import type {
+  AgentMessageDeltaNotification,
   ConfigWarningNotification,
   ErrorNotification,
   FileChangePatchUpdatedNotification,
@@ -124,16 +125,15 @@ function parseThreadSettingsUpdatedNotification(value: unknown): ThreadSettingsU
   };
 }
 
-function parseOptionalDeltaNotification(
-  value: unknown,
-  method: string,
-): { delta?: string; threadId?: string; turnId?: string } {
-  const record = readParams(value, method);
+function parseAgentMessageDeltaNotification(value: unknown): AgentMessageDeltaNotification {
+  const label = "item/agentMessage/delta params";
+  const record = readParams(value, "item/agentMessage/delta");
 
   return {
-    ...parseOptionalNotificationString(record, "delta", `${method} params`),
-    ...parseOptionalNotificationString(record, "threadId", `${method} params`),
-    ...parseOptionalNotificationString(record, "turnId", `${method} params`),
+    delta: readRequiredString(record, "delta", label),
+    itemId: readRequiredString(record, "itemId", label),
+    threadId: readRequiredString(record, "threadId", label),
+    turnId: readRequiredString(record, "turnId", label),
   };
 }
 
@@ -301,8 +301,7 @@ const SERVER_NOTIFICATION_PARAM_PARSERS: {
 } = {
   configWarning: parseConfigWarningNotification,
   error: parseErrorNotification,
-  "item/agentMessage/delta": (value) =>
-    parseOptionalDeltaNotification(value, "item/agentMessage/delta"),
+  "item/agentMessage/delta": parseAgentMessageDeltaNotification,
   "item/commandExecution/outputDelta": (value) =>
     parseOptionalToolDeltaNotification(value, "item/commandExecution/outputDelta"),
   "item/completed": (value) => parseItemNotificationBase(value, "item/completed"),

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -91,6 +91,7 @@ export interface TurnStartParams {
 }
 
 export type TurnStatus = "completed" | "interrupted" | "failed" | "inProgress";
+export type TurnItemsView = "notLoaded" | "summary" | "full";
 
 export type PatchChangeKind =
   | { type: "add" }
@@ -121,6 +122,7 @@ export interface Turn {
   error?: { message?: string } | null;
   id: string;
   items?: ThreadItem[];
+  itemsView?: TurnItemsView;
   startedAt?: number | null;
   status?: TurnStatus;
 }
@@ -257,10 +259,17 @@ export interface ThreadSettingsUpdatedNotification {
   threadSettings: JsonObject;
 }
 
+export interface AgentMessageDeltaNotification {
+  delta: string;
+  itemId: string;
+  threadId: string;
+  turnId: string;
+}
+
 export interface ServerNotificationParams {
   configWarning: ConfigWarningNotification;
   error: ErrorNotification;
-  "item/agentMessage/delta": { delta?: string; threadId?: string; turnId?: string };
+  "item/agentMessage/delta": AgentMessageDeltaNotification;
   "item/commandExecution/outputDelta": {
     delta?: string;
     itemId?: string;

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
+import {
+  DriverEventSourceIdAllocator,
+  toDriverEventEnvelopes,
+} from "../src/infrastructure/runtime/driver-instance-socket";
 import type { DriverEventInput } from "../src/protocol/events";
 import {
   AcpTurnEventState,
@@ -117,8 +120,17 @@ describe("ACP runtime event translation", () => {
     });
     expect(eventPayload(toolEvent as DriverEventInput)).not.toHaveProperty("rawInput");
 
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "acp-empty-input-test",
+    );
     const envelopes = events.flatMap((event) =>
-      toDriverEventEnvelopes(driverBootPayload, event, DRIVER_TEST_IDS.runId),
+      toDriverEventEnvelopes(
+        driverBootPayload,
+        event,
+        DRIVER_TEST_IDS.runId,
+        sourceIds.sourceEventIdFor(event),
+      ),
     );
     const canonicalToolEvent = envelopes
       .map((envelope) => envelope.event)

--- a/tests/driver-runtime-boundary.test.ts
+++ b/tests/driver-runtime-boundary.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import { DriverRuntimeStateMachine } from "../src/core/driver-runtime-state";
 import { createDriverRuntimeTimingEvent } from "../src/core/driver-runtime-timing";
-import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
+import {
+  DriverEventSourceIdAllocator,
+  toDriverEventEnvelopes,
+} from "../src/infrastructure/runtime/driver-instance-socket";
 import { createPromiseDeferred } from "../src/utils/async";
 import { DRIVER_TEST_IDS, driverBootPayload } from "./driver-boot-payload-fixture";
 import {
   FakeDriverRuntimeIo,
-  bootPayload,
   createBackend,
   createDispatcher,
   waitForUpdate,
@@ -36,79 +38,191 @@ describe("driver runtime boundary", () => {
   });
 
   test("driver socket stamps warm turn events with the active run id", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "warm-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: "sdk-internal-run",
+    } as const;
     const [event] = toDriverEventEnvelopes(
       driverBootPayload,
-      {
-        kind: "run.started",
-        payload: {
-          startedAt: new Date(1_000).toISOString(),
-        },
-        runId: "sdk-internal-run",
-      },
+      draft,
       DRIVER_TEST_IDS.secondRunId,
+      sourceIds.sourceEventIdFor(draft),
     );
 
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.secondRunId);
   });
 
   test("driver socket rejects provider turn ids outside an active platform run", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "invalid-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: "provider-turn-1",
+    } as const;
+
     expect(() =>
-      toDriverEventEnvelopes(
-        driverBootPayload,
-        {
-          kind: "run.started",
-          payload: {
-            startedAt: new Date(1_000).toISOString(),
-          },
-          runId: "provider-turn-1",
-        },
-        null,
-      ),
+      toDriverEventEnvelopes(driverBootPayload, draft, null, sourceIds.sourceEventIdFor(draft)),
     ).toThrow("Run ID must be a valid ULID.");
   });
 
   test("driver socket preserves explicit event run ids outside active turns", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "explicit-turn-test",
+    );
+    const draft = {
+      kind: "run.started",
+      payload: {
+        startedAt: new Date(1_000).toISOString(),
+      },
+      runId: DRIVER_TEST_IDS.thirdRunId,
+    } as const;
     const [event] = toDriverEventEnvelopes(
       driverBootPayload,
-      {
-        kind: "run.started",
-        payload: {
-          startedAt: new Date(1_000).toISOString(),
-        },
-        runId: DRIVER_TEST_IDS.thirdRunId,
-      },
+      draft,
       null,
+      sourceIds.sourceEventIdFor(draft),
     );
 
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.thirdRunId);
   });
 
-  test("driver socket creates deterministic source ids for draft event replay", () => {
+  test("driver socket keeps retries idempotent without aliasing equal draft events", () => {
     const draft = {
-      kind: "message.started",
+      delivery: "best_effort",
+      kind: "message.delta",
       payload: {
+        contentDelta: "的",
         messageId: "message-1",
         role: "agent",
       },
     } as const;
-    const occurrences = new Map<string, number>();
+    const laterEqualDraft = {
+      ...draft,
+      payload: { ...draft.payload },
+    };
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "retry-test",
+    );
     const [first] = toDriverEventEnvelopes(
       driverBootPayload,
       draft,
       DRIVER_TEST_IDS.runId,
-      occurrences,
+      sourceIds.sourceEventIdFor(draft),
     );
-    const [second] = toDriverEventEnvelopes(
+    const [retry] = toDriverEventEnvelopes(
       driverBootPayload,
       draft,
       DRIVER_TEST_IDS.runId,
-      occurrences,
+      sourceIds.sourceEventIdFor(draft),
     );
-    const [retry] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
+    const [laterEqual] = toDriverEventEnvelopes(
+      driverBootPayload,
+      laterEqualDraft,
+      DRIVER_TEST_IDS.runId,
+      sourceIds.sourceEventIdFor(laterEqualDraft),
+    );
 
-    expect(first?.event.sourceEventId).toMatch(/^sha256:/);
-    expect(second?.event.sourceEventId).toBe(`${first?.event.sourceEventId}:2`);
+    expect(first?.event.sourceEventId).toBe(
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:retry-test:event:1`,
+    );
     expect(retry?.event.sourceEventId).toBe(first?.event.sourceEventId);
+    expect(laterEqual?.event.sourceEventId).toBe(
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:retry-test:event:2`,
+    );
+  });
+
+  test("driver socket assigns unique identities to repeated Unicode stream chunks", () => {
+    const sourceIds = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "unicode-test",
+    );
+    const chunks = [
+      "001|中文长文本校验-Aa0-表格字符|END001\\n",
+      "002|中文长文本校验-Aa1-表格字符|END002\\n",
+      "的",
+      "的",
+      "| ✅ 😀 | https://example.test/final |",
+    ];
+    const drafts = chunks.map((contentDelta) => ({
+      delivery: "best_effort" as const,
+      kind: "message.delta" as const,
+      payload: {
+        contentDelta,
+        messageId: "message-unicode",
+        role: "agent" as const,
+      },
+    }));
+    const envelopes = drafts.map(
+      (draft) =>
+        toDriverEventEnvelopes(
+          driverBootPayload,
+          draft,
+          DRIVER_TEST_IDS.runId,
+          sourceIds.sourceEventIdFor(draft),
+        )[0],
+    );
+
+    expect(envelopes.map((event) => event?.event.sourceEventId)).toEqual([
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:1`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:2`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:3`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:4`,
+      `driver:${DRIVER_TEST_IDS.driverInstanceId}:unicode-test:event:5`,
+    ]);
+    expect(
+      envelopes
+        .map((event) => {
+          const payload = event?.event.payload;
+          if (
+            typeof payload === "object" &&
+            payload !== null &&
+            "contentDelta" in payload &&
+            typeof payload.contentDelta === "string"
+          ) {
+            return payload.contentDelta;
+          }
+
+          return null;
+        })
+        .join(""),
+    ).toBe(chunks.join(""));
+  });
+
+  test("driver socket separates source identities across process boots", () => {
+    const firstBoot = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "boot-one",
+    );
+    const secondBoot = new DriverEventSourceIdAllocator(
+      DRIVER_TEST_IDS.driverInstanceId,
+      "boot-two",
+    );
+    const firstDraft = {
+      kind: "message.delta",
+      payload: { contentDelta: "相同内容", messageId: "message-1", role: "agent" },
+    } as const;
+    const secondDraft = {
+      ...firstDraft,
+      payload: { ...firstDraft.payload },
+    };
+
+    expect(firstBoot.sourceEventIdFor(firstDraft)).not.toBe(
+      secondBoot.sourceEventIdFor(secondDraft),
+    );
   });
 
   test("runs input commands through the backend and reports completion to API", async () => {

--- a/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
+++ b/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
@@ -66,6 +66,8 @@
         "turnId": "turn-1"
       },
       "payload": {
+        "finalMessageId": "<driver-id>",
+        "finalMessageText": "pong",
         "stopReason": "end_turn"
       },
       "sourceEventId": "openai.turn.completed:turn-1"

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -181,6 +181,234 @@ describe("OpenAi app-server event bridge", () => {
     ]);
   });
 
+  test("uses item completion text as the authoritative final snapshot", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "损坏的流式片段",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          {
+            id: "message-final",
+            text: "完整最终回答：中文 Markdown ✅",
+            type: "agentMessage",
+          },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe(
+      "完整最终回答：中文 Markdown ✅",
+    );
+  });
+
+  test("does not fall back to progress when the final turn item is incomplete", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-progress",
+        text: "PROGRESS",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+          { id: "message-final", type: "agentMessage" },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageId")).toBeNull();
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBeNull();
+  });
+
+  test("uses the last completed assistant snapshot when turn items are omitted", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "PROGRESS",
+      itemId: "message-progress",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-progress",
+        text: "PROGRESS",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "最终回答：中文 Markdown ✅",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: "最终回答：中文 Markdown ✅",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageId")).not.toBeNull();
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe(
+      "最终回答：中文 Markdown ✅",
+    );
+  });
+
+  test("uses completed snapshots when terminal items are not loaded", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-final", text: "FINAL", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "notLoaded",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("FINAL");
+  });
+
+  test("does not fall back when a full terminal item list has no assistant", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "full",
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBeNull();
+  });
+
+  test("uses first-seen item order when older completions arrive late", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    for (const [itemId, delta] of [
+      ["message-progress", "PROGRESS"],
+      ["message-final", "FINAL"],
+    ] as const) {
+      await bridge.handleNotification(context, "item/agentMessage/delta", {
+        delta,
+        itemId,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    }
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-final", text: "FINAL", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-progress", text: "PROGRESS", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: { id: "turn-1", status: "completed" },
+    });
+    await logger.destroy();
+
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("FINAL");
+  });
+
   test("completed turns app final items before run finish", async () => {
     const { bridge, context, events, logger } = createHarness();
 
@@ -306,6 +534,184 @@ describe("OpenAi app-server event bridge", () => {
         },
       },
     ]);
+  });
+
+  test("rotates assistant message identity after each completed agent item", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    const progressMessages = [
+      "进度 1：已完成读取。",
+      "进度 2：已完成工具准备。",
+      "进度 3：准备最终总结。",
+    ];
+
+    for (const [index, progressMessage] of progressMessages.entries()) {
+      await bridge.handleNotification(context, "item/agentMessage/delta", {
+        delta: progressMessage,
+        itemId: `message-progress-${index + 1}`,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+      await bridge.handleNotification(context, "item/completed", {
+        item: {
+          id: `message-progress-${index + 1}`,
+          text: progressMessage,
+          type: "agentMessage",
+        },
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    }
+    await bridge.handleNotification(context, "item/started", {
+      item: {
+        id: "artifact-tool",
+        type: "commandExecution",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        aggregatedOutput: "artifact 已创建。",
+        id: "artifact-tool",
+        type: "commandExecution",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "| 最终：表格 | `代码` | https://example.test/😀",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: "| 最终：表格 | `代码` | https://example.test/😀",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          ...progressMessages.map((text, index) => ({
+            id: `message-progress-${index + 1}`,
+            text,
+            type: "agentMessage",
+          })),
+          {
+            aggregatedOutput: "artifact 已创建。",
+            id: "artifact-tool",
+            type: "commandExecution",
+          },
+          {
+            id: "message-final",
+            text: "| 最终：表格 | `代码` | https://example.test/😀",
+            type: "agentMessage",
+          },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const assistantMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta") {
+        return [];
+      }
+
+      const messageId = readEventPayloadString(event, "messageId");
+      const contentDelta = readEventPayloadString(event, "contentDelta");
+      return messageId === null || contentDelta === null ? [] : [{ contentDelta, messageId }];
+    });
+
+    expect(assistantMessages.map((message) => message.contentDelta)).toEqual([
+      ...progressMessages,
+      "| 最终：表格 | `代码` | https://example.test/😀",
+    ]);
+    expect(new Set(assistantMessages.map((message) => message.messageId)).size).toBe(4);
+    const toolParentMessageId = events()
+      .filter((event) => event.kind === "item.started")
+      .map((event) => readEventPayloadString(event, "parentMessageId"))
+      .find((messageId): messageId is string => messageId !== null);
+
+    expect(toolParentMessageId).toBe(assistantMessages.at(-1)?.messageId);
+    expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(4);
+    expect(events().filter((event) => event.kind === "run.completed")).toHaveLength(1);
+  });
+
+  test("keeps interleaved assistant item identities isolated and ignores late replay", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息甲",
+      itemId: "message-a",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息乙",
+      itemId: "message-b",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-b", text: "消息乙", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: { id: "message-a", text: "消息甲", type: "agentMessage" },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "消息甲",
+      itemId: "message-a",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          { id: "message-a", text: "消息甲", type: "agentMessage" },
+          { id: "message-b", text: "消息乙", type: "agentMessage" },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const deltas = events().flatMap((event) => {
+      if (event.kind !== "message.delta") {
+        return [];
+      }
+
+      const messageId = readEventPayloadString(event, "messageId");
+      const contentDelta = readEventPayloadString(event, "contentDelta");
+      return messageId === null || contentDelta === null ? [] : [{ contentDelta, messageId }];
+    });
+
+    expect(deltas.map((entry) => entry.contentDelta)).toEqual(["消息甲", "消息乙"]);
+    expect(new Set(deltas.map((entry) => entry.messageId)).size).toBe(2);
+    expect(events().filter((event) => event.kind === "message.completed")).toHaveLength(2);
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+
+    if (runCompleted === undefined) {
+      throw new Error("Expected a run.completed event.");
+    }
+
+    const finalMessageId = readEventPayloadString(runCompleted, "finalMessageId");
+
+    expect(finalMessageId).toBe(deltas.find((entry) => entry.contentDelta === "消息乙")?.messageId);
+    expect(readEventPayloadString(runCompleted, "finalMessageText")).toBe("消息乙");
   });
 
   test("command output streams as tool result content", async () => {

--- a/tests/openai-app-server-live.test.ts
+++ b/tests/openai-app-server-live.test.ts
@@ -164,6 +164,7 @@ describe("OpenAI app-server live provider", () => {
           timeoutMs: LIVE_TURN_TIMEOUT_MS,
         });
         const outputText = turnEvents.map(textDeltaFrom).join("").trim().toLowerCase();
+        const completedEvent = turnEvents.find((event) => event.kind === "run.completed");
         logLiveStatus("received output", {
           text: outputText,
         });
@@ -175,6 +176,10 @@ describe("OpenAI app-server live provider", () => {
           outputChars: outputText.length,
         });
         expect(outputText).toContain("pong");
+        expect(completedEvent?.payload).toMatchObject({
+          finalMessageId: expect.any(String),
+          finalMessageText: expect.stringContaining("pong"),
+        });
       } finally {
         if (kernelStarted) {
           logLiveStatus("stopping driver kernel");

--- a/tests/openai-app-server-provider-fixtures.test.ts
+++ b/tests/openai-app-server-provider-fixtures.test.ts
@@ -232,6 +232,50 @@ async function assertTrackTurnFixture(
 }
 
 describe("OpenAI app-server provider fixtures", () => {
+  test("preserves the assistant item identity on text deltas", () => {
+    expect(
+      parseServerNotificationParams("item/agentMessage/delta", {
+        delta: "中文 delta",
+        itemId: "message-1",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    ).toEqual({
+      delta: "中文 delta",
+      itemId: "message-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(() =>
+      parseServerNotificationParams("item/agentMessage/delta", {
+        delta: "missing identity",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    ).toThrow("itemId");
+  });
+
+  test("preserves the terminal turn item loading state", () => {
+    expect(
+      parseServerNotificationParams("turn/completed", {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          items: [],
+          itemsView: "notLoaded",
+          status: "completed",
+        },
+      }),
+    ).toMatchObject({
+      turn: {
+        id: "turn-1",
+        items: [],
+        itemsView: "notLoaded",
+        status: "completed",
+      },
+    });
+  });
+
   test.each(providerFixtureNames)("apps provider-native fixture %s", async (name) => {
     const fixture = readProviderFixtureCase(
       `./fixtures/providers/openai-app-server/cases/${name}.json`,


### PR DESCRIPTION
## Scope

This is the minimal driver dependency for the Mosoo P1 final-output corruption fix. It covers the reproduced OpenAI app-server path and the shared runtime event identity invariant only.

It deliberately excludes the Claude and ACP final-message hardening; that follow-up will be a stacked, separately reviewable PR.

## Root cause and fix

- Equal streamed draft events were assigned a content-derived identity, so distinct repeated chunks could be treated as replays.
- The OpenAI bridge treated a turn as one assistant message and did not project the terminal assistant item identity/text into `run.completed`.
- Draft events now receive a stable per-object, per-boot source ID; OpenAI text is tracked by item identity; and `run.completed` carries the authoritative completed assistant item snapshot.

## Verification

- `bun run lint`
- `bun run tc`
- `bun run build`
- `env -u ANTHROPIC_API_KEY -u AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY -u OPENAI_API_KEY -u AGENT_DRIVER_LIVE_OPENAI_API_KEY bun run test`
  - 167 passed, 4 credential-gated live tests skipped

## Generated and baseline changes

- Generated files: yes — OpenAI app-server protocol parser/types updated for `itemId` and terminal item loading state.
- GraphQL codegen: no.
- DB baseline/migrations: no.
