### PR TITLE
fix(runtime): block private citation markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/types/orpc.d.ts",
       "default": "./src/orpc.ts"
     },
+    "./provider-output": {
+      "types": "./dist/types/provider-output.d.ts",
+      "default": "./src/provider-output.ts"
+    },
     "./cma-http": {
       "types": "./dist/types/cma-http.d.ts",
       "default": "./src/cma-http.ts"

--- a/src/provider-output.ts
+++ b/src/provider-output.ts
@@ -1,0 +1,5 @@
+export {
+  filterOpenAiPrivateCitations,
+  OpenAiPrivateCitationStreamFilter,
+} from "./runtimes/openai/private-citation-filter";
+export type { OpenAiPrivateCitationFilterResult } from "./runtimes/openai/private-citation-filter";

--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -15,8 +15,14 @@ import {
   toOpenAiToolName,
   toOpenAiToolResultText,
 } from "./event-translator";
+import {
+  filterOpenAiPrivateCitations,
+  OpenAiPrivateCitationStreamFilter,
+} from "./private-citation-filter";
 
 export class OpenAiAppServerItemEventBridge {
+  readonly #citationDiagnosticsEmitted = new Set<string>();
+  readonly #citationFilters = new Map<string, OpenAiPrivateCitationStreamFilter>();
   readonly #items: OpenAiItemState;
   readonly #messages: OpenAiMessageState;
   readonly #plans: OpenAiPlanState;
@@ -56,13 +62,19 @@ export class OpenAiAppServerItemEventBridge {
       return;
     }
 
-    this.#messages.appendText(messageId, delta);
+    const filteredDelta = this.#filterCitationDelta(messageId, delta);
+
+    if (filteredDelta.length === 0) {
+      return;
+    }
+
+    this.#messages.appendText(messageId, filteredDelta);
     await this.#push(context, "driver.openai.agent.delta", [
       {
         delivery: "best_effort",
         kind: "message.delta",
         payload: {
-          contentDelta: delta,
+          contentDelta: filteredDelta,
           messageId,
           role: "agent",
         },
@@ -286,7 +298,13 @@ export class OpenAiAppServerItemEventBridge {
         return null;
       }
 
-      return this.#messages.finalCompletedSnapshotForTurn(turnId);
+      const completedSnapshot = this.#messages.finalCompletedSnapshotForTurn(turnId);
+
+      if (completedSnapshot !== null) {
+        this.#releaseCitationState(completedSnapshot.id);
+      }
+
+      return completedSnapshot;
     }
 
     const itemId = readNonEmptyString(finalAssistantItem, "id");
@@ -304,8 +322,11 @@ export class OpenAiAppServerItemEventBridge {
       { itemId, turnId },
       this.#push,
     );
-    this.#messages.setText(messageId, text);
-    return { id: messageId, text };
+    const filteredText = filterOpenAiPrivateCitations(text);
+    await this.#reportPrivateCitations(context, messageId, filteredText.privateCitationCount);
+    this.#messages.setText(messageId, filteredText.text);
+    this.#releaseCitationState(messageId);
+    return { id: messageId, text: filteredText.text };
   }
 
   async handleTurnPlanUpdated(context: AgentDriverContext, params: JsonObject): Promise<void> {
@@ -357,11 +378,37 @@ export class OpenAiAppServerItemEventBridge {
       { itemId, turnId },
       this.#push,
     );
+    const filteredFinalText = finalText === null ? null : filterOpenAiPrivateCitations(finalText);
     const currentText = this.#messages.currentText(messageId);
 
-    if (finalText !== null && finalText.length > currentText.length) {
-      if (finalText.startsWith(currentText)) {
-        const delta = finalText.slice(currentText.length);
+    if (filteredFinalText === null) {
+      const trailingText = this.#citationFilters.get(messageId)?.finish().text ?? "";
+
+      if (trailingText.length > 0) {
+        this.#messages.appendText(messageId, trailingText);
+        events.push({
+          delivery: "best_effort",
+          kind: "message.delta",
+          payload: {
+            contentDelta: trailingText,
+            messageId,
+            role: "agent",
+          },
+        });
+      }
+    }
+
+    if (filteredFinalText !== null) {
+      this.#appendPrivateCitationDiagnostic(
+        events,
+        messageId,
+        filteredFinalText.privateCitationCount,
+      );
+    }
+
+    if (filteredFinalText !== null && filteredFinalText.text.length > currentText.length) {
+      if (filteredFinalText.text.startsWith(currentText)) {
+        const delta = filteredFinalText.text.slice(currentText.length);
         this.#messages.appendText(messageId, delta);
         events.push({
           delivery: "best_effort",
@@ -373,12 +420,12 @@ export class OpenAiAppServerItemEventBridge {
           },
         });
       } else if (currentText.length === 0) {
-        this.#messages.appendText(messageId, finalText);
+        this.#messages.appendText(messageId, filteredFinalText.text);
         events.push({
           delivery: "best_effort",
           kind: "message.delta",
           payload: {
-            contentDelta: finalText,
+            contentDelta: filteredFinalText.text,
             messageId,
             role: "agent",
           },
@@ -386,24 +433,26 @@ export class OpenAiAppServerItemEventBridge {
       } else {
         context.logger.warn("driver.openai.agent.final_text.mismatch", {
           currentLength: currentText.length,
-          finalLength: finalText.length,
+          finalLength: filteredFinalText.text.length,
           itemId,
         });
       }
     }
 
-    if (finalText !== null) {
+    if (filteredFinalText !== null) {
       // item/completed is the provider's authoritative snapshot. Streaming
       // deltas may be missing or replayed, so canonical completion must not
       // inherit a corrupted accumulator even when live deltas cannot be undone.
-      this.#messages.setText(messageId, finalText);
+      this.#messages.setText(messageId, filteredFinalText.text);
       this.#messages.recordCompletedSnapshot({
         itemId,
         messageId,
-        text: finalText,
+        text: filteredFinalText.text,
         turnId,
       });
     }
+
+    this.#citationFilters.delete(messageId);
 
     if (this.#messages.markEnded(messageId)) {
       events.push({
@@ -414,6 +463,60 @@ export class OpenAiAppServerItemEventBridge {
         },
       });
     }
+  }
+
+  #appendPrivateCitationDiagnostic(
+    events: DriverEventInput[],
+    messageId: string,
+    privateCitationCount: number,
+  ): void {
+    if (privateCitationCount === 0 || this.#citationDiagnosticsEmitted.has(messageId)) {
+      return;
+    }
+
+    this.#citationDiagnosticsEmitted.add(messageId);
+    events.push({
+      kind: "diagnostic.reported",
+      payload: {
+        code: "openai.private_citation_markup_removed",
+        details: {
+          count: privateCitationCount,
+        },
+        message: "OpenAI private citation markup was removed from public assistant text.",
+        severity: "warn",
+        source: "openai",
+      },
+      visibility: "owner_debug",
+    });
+  }
+
+  #filterCitationDelta(messageId: string, delta: string): string {
+    let filter = this.#citationFilters.get(messageId);
+
+    if (filter === undefined) {
+      filter = new OpenAiPrivateCitationStreamFilter();
+      this.#citationFilters.set(messageId, filter);
+    }
+
+    return filter.push(delta).text;
+  }
+
+  async #reportPrivateCitations(
+    context: AgentDriverContext,
+    messageId: string,
+    privateCitationCount: number,
+  ): Promise<void> {
+    const events: DriverEventInput[] = [];
+    this.#appendPrivateCitationDiagnostic(events, messageId, privateCitationCount);
+
+    if (events.length > 0) {
+      await this.#push(context, "driver.openai.private_citation_markup_removed", events);
+    }
+  }
+
+  #releaseCitationState(messageId: string): void {
+    this.#citationDiagnosticsEmitted.delete(messageId);
+    this.#citationFilters.delete(messageId);
   }
 
   #appendCompletedPlanEvents(events: DriverEventInput[], item: JsonObject, itemId: string): void {

--- a/src/runtimes/openai/private-citation-filter.ts
+++ b/src/runtimes/openai/private-citation-filter.ts
@@ -1,0 +1,125 @@
+const OPENAI_PRIVATE_MARKUP_START = "\uE200";
+const OPENAI_PRIVATE_MARKUP_END = "\uE201";
+const OPENAI_PRIVATE_CITATION_PREFIX = `${OPENAI_PRIVATE_MARKUP_START}cite\uE202`;
+
+export interface OpenAiPrivateCitationFilterResult {
+  readonly privateCitationCount: number;
+  readonly text: string;
+}
+
+interface OpenAiPrivateCitationScanResult extends OpenAiPrivateCitationFilterResult {
+  readonly hasPendingMarkup: boolean;
+}
+
+function scanOpenAiPrivateCitations(
+  text: string,
+  options: { readonly preserveIncompleteMarkup: boolean },
+): OpenAiPrivateCitationScanResult {
+  let cursor = 0;
+  let privateCitationCount = 0;
+  let sanitizedText = "";
+
+  while (cursor < text.length) {
+    const markupStart = text.indexOf(OPENAI_PRIVATE_MARKUP_START, cursor);
+
+    if (markupStart === -1) {
+      sanitizedText += text.slice(cursor);
+      break;
+    }
+
+    sanitizedText += text.slice(cursor, markupStart);
+    const remainingText = text.slice(markupStart);
+
+    if (
+      options.preserveIncompleteMarkup &&
+      OPENAI_PRIVATE_CITATION_PREFIX.startsWith(remainingText)
+    ) {
+      return {
+        hasPendingMarkup: true,
+        privateCitationCount,
+        text: sanitizedText,
+      };
+    }
+
+    if (!text.startsWith(OPENAI_PRIVATE_CITATION_PREFIX, markupStart)) {
+      sanitizedText += OPENAI_PRIVATE_MARKUP_START;
+      cursor = markupStart + OPENAI_PRIVATE_MARKUP_START.length;
+      continue;
+    }
+
+    const markupEnd = text.indexOf(
+      OPENAI_PRIVATE_MARKUP_END,
+      markupStart + OPENAI_PRIVATE_CITATION_PREFIX.length,
+    );
+
+    if (markupEnd === -1) {
+      if (options.preserveIncompleteMarkup) {
+        return {
+          hasPendingMarkup: true,
+          privateCitationCount,
+          text: sanitizedText,
+        };
+      }
+
+      sanitizedText += remainingText;
+      break;
+    }
+
+    privateCitationCount += 1;
+    cursor = markupEnd + OPENAI_PRIVATE_MARKUP_END.length;
+  }
+
+  return {
+    hasPendingMarkup: false,
+    privateCitationCount,
+    text: sanitizedText,
+  };
+}
+
+export function filterOpenAiPrivateCitations(text: string): OpenAiPrivateCitationFilterResult {
+  const result = scanOpenAiPrivateCitations(text, { preserveIncompleteMarkup: false });
+
+  return {
+    privateCitationCount: result.privateCitationCount,
+    text: result.text,
+  };
+}
+
+export class OpenAiPrivateCitationStreamFilter {
+  #emittedTextLength = 0;
+  #privateCitationCount = 0;
+  #rawText = "";
+
+  push(delta: string): OpenAiPrivateCitationFilterResult {
+    this.#rawText += delta;
+    const result = scanOpenAiPrivateCitations(this.#rawText, {
+      preserveIncompleteMarkup: true,
+    });
+    const emittedText = result.text.slice(this.#emittedTextLength);
+    const newlyDetectedCitations = result.privateCitationCount - this.#privateCitationCount;
+
+    this.#emittedTextLength = result.text.length;
+    this.#privateCitationCount = result.privateCitationCount;
+
+    return {
+      privateCitationCount: newlyDetectedCitations,
+      text: emittedText,
+    };
+  }
+
+  finish(): OpenAiPrivateCitationFilterResult {
+    const result = scanOpenAiPrivateCitations(this.#rawText, {
+      preserveIncompleteMarkup: false,
+    });
+    const emittedText = result.text.slice(this.#emittedTextLength);
+    const newlyDetectedCitations = result.privateCitationCount - this.#privateCitationCount;
+
+    this.#emittedTextLength = result.text.length;
+    this.#privateCitationCount = result.privateCitationCount;
+
+    return {
+      privateCitationCount: newlyDetectedCitations,
+      text: emittedText,
+    };
+  }
+}

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -33,6 +33,7 @@ const PUBLIC_EXPORTS = [
   "./events",
   "./orpc",
   "./paths",
+  "./provider-output",
   "./runtime",
 ] as const;
 

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -225,6 +225,98 @@ describe("OpenAi app-server event bridge", () => {
     );
   });
 
+  test("removes OpenAI private citation markup from streamed and final assistant text", async () => {
+    const { bridge, context, events, logger } = createHarness();
+    const privateCitation = "\uE200cite\uE202turn7search12\uE202turn8view0\uE201";
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "before\uE200ci",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "te\uE202turn7search12\uE202turn8view0",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "\uE201after",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        text: `before${privateCitation}after`,
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        items: [
+          {
+            id: "message-final",
+            text: `before${privateCitation}after`,
+            type: "agentMessage",
+          },
+        ],
+        status: "completed",
+      },
+    });
+    await logger.destroy();
+
+    const allEvents = events();
+    const streamedText = allEvents
+      .filter((event) => event.kind === "message.delta")
+      .map((event) => readEventPayloadString(event, "contentDelta") ?? "")
+      .join("");
+    const runCompleted = allEvents.find((event) => event.kind === "run.completed");
+    const diagnostics = allEvents.filter(
+      (event) =>
+        event.kind === "diagnostic.reported" &&
+        readEventPayloadString(event, "code") === "openai.private_citation_markup_removed",
+    );
+
+    expect(streamedText).toBe("beforeafter");
+    expect(runCompleted).toBeDefined();
+    expect(readEventPayloadString(runCompleted!, "finalMessageText")).toBe("beforeafter");
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test("flushes incomplete private markup when an item completes without a text snapshot", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "before\uE200cite\uE202turn7search12",
+      itemId: "message-final",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-final",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await logger.destroy();
+
+    const streamedText = events()
+      .filter((event) => event.kind === "message.delta")
+      .map((event) => readEventPayloadString(event, "contentDelta") ?? "")
+      .join("");
+
+    expect(streamedText).toBe("before\uE200cite\uE202turn7search12");
+  });
+
   test("does not fall back to progress when the final turn item is incomplete", async () => {
     const { bridge, context, events, logger } = createHarness();
 

--- a/tests/openai-private-citation-filter.test.ts
+++ b/tests/openai-private-citation-filter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  filterOpenAiPrivateCitations,
+  OpenAiPrivateCitationStreamFilter,
+} from "../src/runtimes/openai/private-citation-filter";
+
+const CITATION_ONE = "\uE200cite\uE202turn7search12\uE201";
+const CITATION_MANY = "\uE200cite\uE202turn2view0\uE202turn8view0\uE201";
+
+describe("OpenAI private citation filter", () => {
+  test("removes complete private citation markup without changing surrounding text", () => {
+    expect(filterOpenAiPrivateCitations(`before${CITATION_ONE}after`)).toEqual({
+      privateCitationCount: 1,
+      text: "beforeafter",
+    });
+  });
+
+  test("counts citation envelopes rather than provider references", () => {
+    expect(filterOpenAiPrivateCitations(`a${CITATION_MANY}b${CITATION_ONE}`)).toEqual({
+      privateCitationCount: 2,
+      text: "ab",
+    });
+  });
+
+  test("preserves unrelated private-use characters and malformed markup", () => {
+    expect(filterOpenAiPrivateCitations("before\uE200other\uE201after")).toEqual({
+      privateCitationCount: 0,
+      text: "before\uE200other\uE201after",
+    });
+    expect(filterOpenAiPrivateCitations("before\uE200cite\uE202turn7search12")).toEqual({
+      privateCitationCount: 0,
+      text: "before\uE200cite\uE202turn7search12",
+    });
+  });
+
+  test("holds citation markup split across streaming deltas", () => {
+    const filter = new OpenAiPrivateCitationStreamFilter();
+
+    expect(filter.push("before\uE200ci")).toEqual({
+      privateCitationCount: 0,
+      text: "before",
+    });
+    expect(filter.push("te\uE202turn7search")).toEqual({
+      privateCitationCount: 0,
+      text: "",
+    });
+    expect(filter.push("12\uE201after")).toEqual({
+      privateCitationCount: 1,
+      text: "after",
+    });
+    expect(filter.finish()).toEqual({
+      privateCitationCount: 0,
+      text: "",
+    });
+  });
+
+  test("flushes incomplete markup when the stream ends", () => {
+    const filter = new OpenAiPrivateCitationStreamFilter();
+
+    expect(filter.push("before\uE200cite\uE202turn7search12")).toEqual({
+      privateCitationCount: 0,
+      text: "before",
+    });
+    expect(filter.finish()).toEqual({
+      privateCitationCount: 0,
+      text: "\uE200cite\uE202turn7search12",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- filter OpenAI private citation envelopes from streamed and terminal assistant text
- handle citation markup split across provider deltas without leaking partial tokens
- emit one owner-debug diagnostic per affected message without logging provider references
- export the pure provider-output sanitizer for host-side defense in depth

## Validation
- 193 non-live tests passed, 1 skipped
- `bun run lint`
- `bun run tc`
- `bun run build:types`

## Notes
- no generated files
- no database or GraphQL changes
- live provider tests are not part of this PR validation; local full-suite attempts reached upstream OpenAI/Anthropic failures before the change path