### PR TITLE
feat(contract): add Driver Contract v2 and refresh all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Different model vendors ship different agent runtimes — the Claude Agent SDK, 
 - `agent-driver/runtime`: runtime-neutral runtime, transport, and native resume contracts.
 - `agent-driver/paths`: sandbox path constants and path normalization helpers shared by host integrations.
 - `agent-driver/events`: canonical driver event envelope contracts.
+- `agent-driver/contract`: Driver Contract v2 — session events, items, commands, and the coalescing buffer (see `docs/contract.md`).
 - `agent-driver/orpc`: Driver-to-`DriverInstance` ORPC wire input/output contracts.
 - `agent-driver/cma-http`: experimental, unsupported CMA-shaped HTTP handler.
 - `agent-driver/cma-sdk`: experimental, unsupported CMA-shaped client.

--- a/bun.lock
+++ b/bun.lock
@@ -5,43 +5,49 @@
     "": {
       "name": "agent-driver",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.205",
-        "@anthropic-ai/sdk": "^0.100.1",
-        "@modelcontextprotocol/client": "^2.0.0-alpha.2",
-        "@orpc/client": "^1.14.3",
-        "fflate": "^0.8.3",
-        "vestig": "^0.23.0",
-        "zod": "^4.4.3",
+        "@anthropic-ai/claude-agent-sdk": "latest",
+        "@anthropic-ai/sdk": "latest",
+        "@modelcontextprotocol/client": "latest",
+        "@orpc/client": "latest",
+        "fflate": "latest",
+        "vestig": "latest",
+        "zod": "latest",
       },
       "devDependencies": {
-        "@types/node": "^25.8.0",
-        "typescript": "^6.0.3",
-        "vite-plus": "^0.1.23",
+        "@types/node": "latest",
+        "typescript": "latest",
+        "vite-plus": "latest",
       },
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.205", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.205", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.205", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.205", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.205", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.205", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.205", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.205", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.205" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.207", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.205", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.207", "", { "os": "darwin", "cpu": "arm64" }, "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.205", "", { "os": "darwin", "cpu": "x64" }, "sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.207", "", { "os": "darwin", "cpu": "x64" }, "sha512-1o7K4EYqyCixZ/oeOZSh7AzSy6TM86xoOuf4VuORjPSS31hBnoqY0NGZd27+2VDs9LGtsdksmsTqcNGx9xd1hA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.205", "", { "os": "linux", "cpu": "arm64" }, "sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.207", "", { "os": "linux", "cpu": "arm64" }, "sha512-X4uezYOifDiNTTmmugfRCdg3nNamrr1LFRY9hg30vWYTShL+bbN+nfC3KaFfSYCl4GTtsEEUbYdOTC2F3bBpcA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.205", "", { "os": "linux", "cpu": "arm64" }, "sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.207", "", { "os": "linux", "cpu": "arm64" }, "sha512-oPj+g2DslhH4Y9nCTs7al4t9wZv78FZwLFQwOCg99BXuz1o0ZOpKmxyvR7J9eBR+GPszeMMS8gYplQTiZC9o2w=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.205", "", { "os": "linux", "cpu": "x64" }, "sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.207", "", { "os": "linux", "cpu": "x64" }, "sha512-Kg6BPH8Ee0ny/oEUWJmvT1jCRBne4jVpRSOMsJcYp1Fav1rMEgpU219oJJs+LWwx4ifuuLtNWedqJNnVw7mnKg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.205", "", { "os": "linux", "cpu": "x64" }, "sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.207", "", { "os": "linux", "cpu": "x64" }, "sha512-uRv+D5oG/7EYr41FAJ9IPo2pZYBe2ZMaA6nSHCeizsgPxCSMtl5bNppmU21+jZJvo4hivObEgkGFERAhdGqygg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.205", "", { "os": "win32", "cpu": "arm64" }, "sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.207", "", { "os": "win32", "cpu": "arm64" }, "sha512-9fWpUzfkXlPAg2tf8JpQe7w9avFaomAUbfAwyAmykQgSIf66LwaJjvI5hNqhNqczRKyfsXPn3ei2S5HKlmFP+Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205", "", { "os": "win32", "cpu": "x64" }, "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.207", "", { "os": "win32", "cpu": "x64" }, "sha512-YPjVT0q6aXEM2MgN4CI6/9fqiTXwETji+4NoPOzCYuqAkhXZqp30Jsk7/NHqYGNNSfURKrsuAoliKB0rsbpbjg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.100.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.111.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
@@ -53,115 +59,117 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
-    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0-alpha.2", "", { "dependencies": { "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-FxlR5QyBPeCDEDPH2Kx20uygmuy9k2jh6ahUeEYtmVfUxboZZlUEUhn6w0XxnbxpkELcT1qyzTXC8Bqh3c8QUA=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0-beta.3", "", { "dependencies": { "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-o9z9YCGNxWNdklPdjcD0tr8pocC9OgjdArqgx3OjPMlTe0M/SSPC2olOJs5ueq77HSpz36mND0f0KteqEhKF3A=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
-    "@orpc/client": ["@orpc/client@1.14.6", "", { "dependencies": { "@orpc/shared": "1.14.6", "@orpc/standard-server": "1.14.6", "@orpc/standard-server-fetch": "1.14.6", "@orpc/standard-server-peer": "1.14.6" } }, "sha512-Y03NcTtmEJdxcqkKBkdGxqe1IHVpD9IorshG4PaTnz9dQIW+RYI8anRo7o0IlbBlzBICN+Ubo1rnw6bpkhagCQ=="],
+    "@orpc/client": ["@orpc/client@1.14.7", "", { "dependencies": { "@orpc/shared": "1.14.7", "@orpc/standard-server": "1.14.7", "@orpc/standard-server-fetch": "1.14.7", "@orpc/standard-server-peer": "1.14.7" } }, "sha512-/yloM96/6Z3qlmEgW4/VMYUnhxXbCr6lIJiKSHmsvhgKcwrUPOPJrL3p0ZpItz5SKVtQSwXIhT5KcT/3va/Aew=="],
 
-    "@orpc/shared": ["@orpc/shared@1.14.6", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-P2W+DdrUq18kUiF7nIw5wDOA0SR41mM/NsVKDVRsdyhdHk9V9KDuW1JRymyMl+7Wo5SDeSr1Rm/VjA5v08+PHw=="],
+    "@orpc/shared": ["@orpc/shared@1.14.7", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.4.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uEvbm+IGxUyQMpVYufU5mEPflyZoF1Nh2yFBqHgmu5QycXZ5GGb5GdwtMa+IE8WXZSHQ4wOgftBNtzGfX/rBIg=="],
 
-    "@orpc/standard-server": ["@orpc/standard-server@1.14.6", "", { "dependencies": { "@orpc/shared": "1.14.6" } }, "sha512-75Oh4rAZb8K7P46d6v7R2JhjqjLLEo7Qs4+ABdF+f0m0uKM1oaykJWy7leqTJ+WaYm+uDbsZl/3nyWie9aeJTg=="],
+    "@orpc/standard-server": ["@orpc/standard-server@1.14.7", "", { "dependencies": { "@orpc/shared": "1.14.7" } }, "sha512-N+7I4SzYoSVyf5lRbANGz9oBVmZSM/nm2JlxAP+UPSbWnqrjltSFFHVlSdp4wXSb39LVjT74uSLZ9Da1wOyLeg=="],
 
-    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.14.6", "", { "dependencies": { "@orpc/shared": "1.14.6", "@orpc/standard-server": "1.14.6" } }, "sha512-XnwEnHaKMMBoilK0QVwgMsUvDbCXyz6CDoLgMN51v+p3VSnwjIkrMdOwbc/sj43z6T4irQDu9Zm8T1pxxh1L8w=="],
+    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.14.7", "", { "dependencies": { "@orpc/shared": "1.14.7", "@orpc/standard-server": "1.14.7" } }, "sha512-bkp9pDDX36enqVC5Q2+o4fofPFR9COI9FpdhLI3mGlQuV6NT9ZBjrscXv57hUPTc7g0aKDOzjiAo0NHoCfZc+g=="],
 
-    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.14.6", "", { "dependencies": { "@orpc/shared": "1.14.6", "@orpc/standard-server": "1.14.6" } }, "sha512-jwVGc5yRA5hk1F/W4yw45P2H4fbu4Tfsk62XijJBXRvtlSNKvvPAuwAd6jFv/fxnq2SH/uskgi91Ja9wgfnYDQ=="],
+    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.14.7", "", { "dependencies": { "@orpc/shared": "1.14.7", "@orpc/standard-server": "1.14.7" } }, "sha512-5YzX7goqeg5cZv+R58SCZHKo0Jk9CiHgepzJYM5oQYoLbdqoxGC4yZG12sqwN/CTX7nZkE2nnbfk6l3+YD/reg=="],
 
-    "@oxc-project/runtime": ["@oxc-project/runtime@0.133.0", "", {}, "sha512-PkvjA1Lq5++V5S1E6Patr92ZVcieE6EalDr1VJTqv4BnjZdOUC4W3p8k1wMXSd5/2aFP4b/A6N5sg2Bkzcr9vQ=="],
+    "@oxc-project/runtime": ["@oxc-project/runtime@0.138.0", "", {}, "sha512-yHhoXsN8tYxgdJCdD91PbySNjEEaBX/tH2OQRDXJpsQv5b184oC4/qVbU7qlblvfil/JP15Lh2HW7+HN5DS90Q=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.52.0", "", { "os": "android", "cpu": "arm" }, "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.52.0", "", { "os": "android", "cpu": "arm64" }, "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.57.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.52.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.57.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.52.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.57.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.52.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.57.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.52.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.57.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.52.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.57.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.52.0", "", { "os": "none", "cpu": "arm64" }, "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.57.0", "", { "os": "none", "cpu": "arm64" }, "sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.52.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.57.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.52.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.57.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.24.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.23.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.24.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.23.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.24.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.23.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.24.0", "", { "os": "linux", "cpu": "x64" }, "sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.23.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.24.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.24.0", "", { "os": "win32", "cpu": "x64" }, "sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.67.0", "", { "os": "android", "cpu": "arm" }, "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.72.0", "", { "os": "android", "cpu": "arm" }, "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.67.0", "", { "os": "android", "cpu": "arm64" }, "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.72.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.67.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.72.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.67.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.72.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.67.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.72.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.67.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.72.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.67.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.72.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.67.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.72.0", "", { "os": "none", "cpu": "arm64" }, "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.67.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.72.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.67.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.72.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.67.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.72.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="],
 
-    "@oxlint/plugins": ["@oxlint/plugins@1.61.0", "", {}, "sha512-nkOyZEF1vH527CkdQtOp1HMrVFEM4ResURvI2JFeGoup+h+43J/k/FgdOR9b9Isxg+Yae7qVDa7y3nssE8b3TQ=="],
+    "@oxlint/plugins": ["@oxlint/plugins@1.68.0", "", {}, "sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -201,39 +209,109 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
-    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.24", "", { "dependencies": { "@oxc-project/runtime": "=0.133.0", "@oxc-project/types": "=0.133.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.1", "@tsdown/exe": "0.22.1", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-iXPGBABnQnrDMx89H6MOCGcTZp+QW+3rY4YMVKdE6ydchSvPk2O3MI2vgaRVfOtWJ2IjnxSnf1n2yjP67ZBRFQ=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
-    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.24", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Hpo9W9piSFlEsJzGkwzfDXhJGrnYByxHXF7NVQZ7g+SLOprddtlfTeM8t+gq9dxcuq0RzM8ddMAhDQP/K3fZQA=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.24", "", { "os": "darwin", "cpu": "x64" }, "sha512-SwnnnZrEFBiU5iKlh/CZAVwn0RFt/Udrvt3kFLtdRxMtN5bKaqTFVA2H8Y/FPCWp1QX9bs4V9ZIAeXAk06zLkw=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-ImM3eqDki4DpRuHjW6dEh4St8zvbcfOMR7KQZJX42ArriCLQ/QdaYhDRRbcDi27XsOBqRxm2eqUUEymPrYIHpA=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-gj4mzbob/ls8Zs7iTuF9Gr0EFFF7tdpDiPxDPBkH8tJP5OkHABlzWUwJhU+9xxcUbTaXqpHDw68Mil7jm5dpMg=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.24", "", { "os": "linux", "cpu": "x64" }, "sha512-x7IYK7lI+WuF1n3jSzEYU6FgJxPX/R0rDmTTsOutooGGCU7uShZvfZqIoiTXK0eFnJU5ij5BfBgenenUfsaT/A=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.24", "", { "os": "linux", "cpu": "x64" }, "sha512-JCy2w0eSVUlWQlggK5T47MnL+j0o4EY7hLskINVI8gi+aixQF4xnYBDobz0lbxkqz3/IfiLyXUx6TcU3thcsGQ=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.24", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.24", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-9NiG6UadG0iOaPL1AMsO5sDKkx6MADHw4/mMOmHWZUhhUwqzfVtnnptMK37vD71e6KyR7yAscx19FrtOWWtjvA=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.24", "", { "os": "win32", "cpu": "arm64" }, "sha512-G+/lhLKVjyn3FmgXX8jeWgq7RcE5O1kdR7QyFayQOdlMX/ZRkvUwQD7bFaqhKzgJM6Oj3a1FH3HQPYk5QOYuCQ=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
 
-    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24", "", { "os": "win32", "cpu": "x64" }, "sha512-b0e5XohEV1w/RdzAtv8/Hm6tvHPXouPtBNsljjW/lDJZq3NCLND5s6lqe8H4IenrgmKSoqakHWtlqJqM36cFbw=="],
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@vitest/browser": ["@vitest/browser@4.1.10", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng=="],
+
+    "@vitest/browser-preview": ["@vitest/browser-preview@4.1.10", "", { "dependencies": { "@testing-library/dom": "^10.4.1", "@testing-library/user-event": "^14.6.1", "@vitest/browser": "4.1.10" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
+    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.2.4", "", { "dependencies": { "@oxc-project/runtime": "=0.138.0", "@oxc-project/types": "=0.138.0", "lightningcss": "^1.32.0", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-AoAYGPwNO56o9TuCR+KaQGA5XpSnTpn2QYHK0DQ0f8j3wvaMmToeWOJF6STo+XMntMDfiaB7sOsSFNE+hPYyjg=="],
+
+    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UQwoLpnBW3qLqj5H3airPQeMCX3kfffVDM2EYGe889Fn5dOS9VhikuWloJlcjwtKwqLbFqkrsGjfb6XRvuLozg=="],
+
+    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-f4XtiA4cBc/Z260QvvXIlBqTb/dZMAioohQDoR5jLG9o9vIOaWE2Ujm/zcWDyNpyZ88RLRrcO8ZwiMrEsdzbJw=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-TUamG9wEehZI4SFG7M6nUKb6z/7x3nNOBbnPdWIpv4C8uWKHwNtsnaaVLeygHIUIJEhbByR3oEFDylYLLr4KRw=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CS9uQ22QFr+lZZp95Huccg3cip3QYVU9GWrhvATqMBXWXb8IRHOulzuXrFxzvhMBITyPaRS9m/eIHmnM4L4h4Q=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-X5XfvftFERjer78SG+QKaJCa9LgIKygx4w13sD1/RS/kYOtaf1+yifrJpOFel+t9TRe/YqGTZa5C8uFrDz3OHw=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2iIWW6JR0UOK4QIFKgUQHjaF/7hZxELePny8R1OIn2jzShRfQhS1cmxksSg8ce/5nhYrfQ9dkg5ZmdLbxhpS/A=="],
+
+    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3yY4FnpvKBxjmHtEcao6Wcs/VBstzC0GhXAPWetbiFEl/sgL66V4Uhws02esfOSWw8abqLrXyPE9vK+newtsuw=="],
+
+    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ERnFrh1O0XZhmGSqND04jtHM7tyKaGAOeT1w/HpVFmL/cQK2vuLl2GKjEwOqkBLd2csNGCcnk3e7C2qDmrNR/Q=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -245,9 +323,13 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -261,7 +343,11 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -273,17 +359,21 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -337,6 +427,8 @@
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -367,6 +459,10 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -395,11 +491,11 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "oxfmt": ["oxfmt@0.52.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.52.0", "@oxfmt/binding-android-arm64": "0.52.0", "@oxfmt/binding-darwin-arm64": "0.52.0", "@oxfmt/binding-darwin-x64": "0.52.0", "@oxfmt/binding-freebsd-x64": "0.52.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0", "@oxfmt/binding-linux-arm-musleabihf": "0.52.0", "@oxfmt/binding-linux-arm64-gnu": "0.52.0", "@oxfmt/binding-linux-arm64-musl": "0.52.0", "@oxfmt/binding-linux-ppc64-gnu": "0.52.0", "@oxfmt/binding-linux-riscv64-gnu": "0.52.0", "@oxfmt/binding-linux-riscv64-musl": "0.52.0", "@oxfmt/binding-linux-s390x-gnu": "0.52.0", "@oxfmt/binding-linux-x64-gnu": "0.52.0", "@oxfmt/binding-linux-x64-musl": "0.52.0", "@oxfmt/binding-openharmony-arm64": "0.52.0", "@oxfmt/binding-win32-arm64-msvc": "0.52.0", "@oxfmt/binding-win32-ia32-msvc": "0.52.0", "@oxfmt/binding-win32-x64-msvc": "0.52.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug=="],
+    "oxfmt": ["oxfmt@0.57.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.57.0", "@oxfmt/binding-android-arm64": "0.57.0", "@oxfmt/binding-darwin-arm64": "0.57.0", "@oxfmt/binding-darwin-x64": "0.57.0", "@oxfmt/binding-freebsd-x64": "0.57.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0", "@oxfmt/binding-linux-arm-musleabihf": "0.57.0", "@oxfmt/binding-linux-arm64-gnu": "0.57.0", "@oxfmt/binding-linux-arm64-musl": "0.57.0", "@oxfmt/binding-linux-ppc64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-musl": "0.57.0", "@oxfmt/binding-linux-s390x-gnu": "0.57.0", "@oxfmt/binding-linux-x64-gnu": "0.57.0", "@oxfmt/binding-linux-x64-musl": "0.57.0", "@oxfmt/binding-openharmony-arm64": "0.57.0", "@oxfmt/binding-win32-arm64-msvc": "0.57.0", "@oxfmt/binding-win32-ia32-msvc": "0.57.0", "@oxfmt/binding-win32-x64-msvc": "0.57.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA=="],
 
-    "oxlint": ["oxlint@1.67.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.67.0", "@oxlint/binding-android-arm64": "1.67.0", "@oxlint/binding-darwin-arm64": "1.67.0", "@oxlint/binding-darwin-x64": "1.67.0", "@oxlint/binding-freebsd-x64": "1.67.0", "@oxlint/binding-linux-arm-gnueabihf": "1.67.0", "@oxlint/binding-linux-arm-musleabihf": "1.67.0", "@oxlint/binding-linux-arm64-gnu": "1.67.0", "@oxlint/binding-linux-arm64-musl": "1.67.0", "@oxlint/binding-linux-ppc64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-musl": "1.67.0", "@oxlint/binding-linux-s390x-gnu": "1.67.0", "@oxlint/binding-linux-x64-gnu": "1.67.0", "@oxlint/binding-linux-x64-musl": "1.67.0", "@oxlint/binding-openharmony-arm64": "1.67.0", "@oxlint/binding-win32-arm64-msvc": "1.67.0", "@oxlint/binding-win32-ia32-msvc": "1.67.0", "@oxlint/binding-win32-x64-msvc": "1.67.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ=="],
+    "oxlint": ["oxlint@1.72.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.72.0", "@oxlint/binding-android-arm64": "1.72.0", "@oxlint/binding-darwin-arm64": "1.72.0", "@oxlint/binding-darwin-x64": "1.72.0", "@oxlint/binding-freebsd-x64": "1.72.0", "@oxlint/binding-linux-arm-gnueabihf": "1.72.0", "@oxlint/binding-linux-arm-musleabihf": "1.72.0", "@oxlint/binding-linux-arm64-gnu": "1.72.0", "@oxlint/binding-linux-arm64-musl": "1.72.0", "@oxlint/binding-linux-ppc64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-musl": "1.72.0", "@oxlint/binding-linux-s390x-gnu": "1.72.0", "@oxlint/binding-linux-x64-gnu": "1.72.0", "@oxlint/binding-linux-x64-musl": "1.72.0", "@oxlint/binding-openharmony-arm64": "1.72.0", "@oxlint/binding-win32-arm64-msvc": "1.72.0", "@oxlint/binding-win32-ia32-msvc": "1.72.0", "@oxlint/binding-win32-x64-msvc": "1.72.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.23.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.23.0", "@oxlint-tsgolint/darwin-x64": "0.23.0", "@oxlint-tsgolint/linux-arm64": "0.23.0", "@oxlint-tsgolint/linux-x64": "0.23.0", "@oxlint-tsgolint/win32-arm64": "0.23.0", "@oxlint-tsgolint/win32-x64": "0.23.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@0.24.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.24.0", "@oxlint-tsgolint/darwin-x64": "0.24.0", "@oxlint-tsgolint/linux-arm64": "0.24.0", "@oxlint-tsgolint/linux-x64": "0.24.0", "@oxlint-tsgolint/win32-arm64": "0.24.0", "@oxlint-tsgolint/win32-x64": "0.24.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -407,17 +503,19 @@
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -428,6 +526,8 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -455,9 +555,13 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
@@ -475,6 +579,8 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
@@ -487,9 +593,9 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -499,9 +605,13 @@
 
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
-    "vite-plus": ["vite-plus@0.1.24", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@oxlint/plugins": "=1.61.0", "@voidzero-dev/vite-plus-core": "0.1.24", "@voidzero-dev/vite-plus-test": "0.1.24", "oxfmt": "=0.52.0", "oxlint": "=1.67.0", "oxlint-tsgolint": "=0.23.0" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.24", "@voidzero-dev/vite-plus-darwin-x64": "0.1.24", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.24", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.24", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.24", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.24", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.24", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.24" }, "bin": { "vp": "bin/vp", "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint" } }, "sha512-b3fr6WtCiEhetjuzW/4KcEMOAMuZxoxZATWaXKmPzOLf1upG+pzKJOFZTb94D6wiPBlwcjxoaUtF7C3uAN+VjQ=="],
+    "vite-plus": ["vite-plus@0.2.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@oxlint/plugins": "=1.68.0", "@vitest/browser": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "@voidzero-dev/vite-plus-core": "0.2.4", "oxfmt": "=0.57.0", "oxlint": "=1.72.0", "oxlint-tsgolint": "=0.24.0", "vitest": "4.1.10" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.2.4", "@voidzero-dev/vite-plus-darwin-x64": "0.2.4", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.4", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.4", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.4", "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.4", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.4", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.4" }, "peerDependencies": { "@vitest/browser-playwright": "4.1.10", "@vitest/browser-webdriverio": "4.1.10" }, "optionalPeers": ["@vitest/browser-playwright", "@vitest/browser-webdriverio"], "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp", "vpr": "bin/vpr" } }, "sha512-gaBBjOXIq9lLRU44oAYdIr99p+JBLX1kxs+l/6LqGgSXwcVKAdDa1boSrOTELqYCkQQ0fpppXUGWi9o6JDT5zw=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -512,6 +622,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,202 @@
+# Driver Contract v2
+
+Status: **canonical spec** for the `agent-driver/contract` module. Contract v2 is a clean,
+deliberately incompatible replacement for the `2026-05-26` runtime-event/command generation
+(`src/runtime-events`, `src/runtime-command`), which stays in place only until the kernel,
+backends, and host migrate.
+
+Design inputs: OpenAI Codex app-server protocol (thread/turn/item, July 2026), Agent Client
+Protocol v2 (`protocolVersion: 2`), Claude Agent SDK, AG-UI, Vercel AI SDK UIMessage streams,
+A2A. The contract must carry **at least** Codex + ACP v2 granularity, because adapters on both
+edges translate it to and from those protocols.
+
+## 1. Shape of the problem
+
+A driver runs exactly one agent session inside a sandbox and speaks to one host over a network
+transport. Everything the contract says fits in one sentence per direction:
+
+- **Events** (driver → host): "here is what happened in the session, in order."
+- **Commands** (host → driver): "do this to the session."
+
+Contract v2 is four planes and nothing else:
+
+| plane       | vocabulary                               | frequency         | loss tolerance                       |
+| ----------- | ---------------------------------------- | ----------------- | ------------------------------------ |
+| session     | `session.*`, `usage.updated`             | low               | lossless                             |
+| turn        | `turn.started`, `turn.completed`         | low               | lossless                             |
+| item        | `item.started/updated/delta/completed`   | **high** (deltas) | deltas droppable, snapshots lossless |
+| interaction | `permission.*`, `input.*`                | low               | lossless                             |
+| ops         | `diagnostic.reported`, `timing.recorded` | low               | lossless                             |
+
+Everything the old contract declared beyond this (86 of 107 kinds were never emitted:
+`realtime.*`, `terminal.*`, `account.*`, `hook.*`, `oauth.*`, …) is deleted. Real future needs
+use the extension rule (§7).
+
+## 2. Envelope
+
+```ts
+interface SessionEvent<K extends SessionEventKind = SessionEventKind> {
+  id: string; // ULID, unique per event — dedup/ack token
+  seq: number; // per-session monotonic counter assigned by the emitter
+  sessionId: string; // ULID
+  turnId?: string; // ULID — present on every turn-scoped event
+  at: string; // ISO-8601 occurrence time
+  kind: K;
+  payload: SessionEventPayloadMap[K];
+  native?: NativeRef; // provenance: provider + native ids (threadId, itemId, eventName, …)
+  traceId?: string; // W3C trace id
+  meta?: Record<string, unknown>; // reserved extension bag, never interpreted by the contract
+}
+```
+
+Deliberate deletions vs the old 18-field envelope:
+
+- `actor`, `origin`, `visibility`, `delivery` — static functions of `kind`, so they are exposed
+  as classification helpers (`deliveryOf(kind)`, `visibilityOf(kind)`) instead of being paid
+  for on every wire event. Message role lives on the message item where it belongs.
+- `schemaVersion` per event — the contract version is negotiated per connection and stamped on
+  batches by transports that need it (`CONTRACT_VERSION = 2`). Persistence layers wrap events
+  with their own storage version if they need one.
+- `correlationId`, `sourceEventId`, `receivedAt`, `runtimeId`, `driverInstanceId` — transport
+  and host bookkeeping, not session semantics. `id` is the only identity an event needs.
+
+Addition: **`seq`**. The old contract had no ordering token on the event itself (receipts
+carried a server-assigned seq). Emitter-assigned `seq` gives receivers ordering, gap detection,
+and an ack high-water mark, and gives the coalescer (§8) a well-defined merge rule.
+
+## 3. Items
+
+An item is one unit of the session transcript. Same lifecycle for every item kind — this is the
+single most load-bearing decision, taken from Codex v2 and confirmed by every peer protocol:
+
+```
+item.started { item }                 // full initial snapshot
+item.delta   { itemId, stream, index?, delta }   // append-only text, droppable
+item.updated { itemId, kind, patch }  // field patch, replace-per-field (LWW)
+item.completed { item }               // full FINAL snapshot — authoritative
+```
+
+`item.completed` is authoritative and may not equal the concatenation of deltas (Codex states
+this explicitly for plan items). That property is what makes deltas safely droppable and
+coalescible: any consumer that misses deltas is healed by the completed snapshot.
+
+Six typed item kinds plus one open kind:
+
+| kind              | covers                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `message`         | ACP user/agent_message, Codex userMessage/agentMessage, Claude assistant turns                  |
+| `reasoning`       | Codex reasoning (summary[] + content[] with indices), ACP agent_thought, Claude thinking        |
+| `plan`            | ACP plan entries, Codex turn/plan + todo lists                                                  |
+| `command`         | Codex commandExecution (command, cwd, parsed actions, output, exitCode), ACP execute tool calls |
+| `file_change`     | Codex fileChange (per-file diff + status), ACP v2 structured Diff                               |
+| `tool_call`       | MCP tool calls, Codex dynamicToolCall, ACP generic tool_call (kind/status/locations/rawIO)      |
+| `x_*` (extension) | Codex webSearch, imageGeneration, collab/subagent, review mode, context compaction, …           |
+
+Item ids (`itemId`) and interaction ids (`requestId`) are opaque non-empty strings so adapters
+can pass vendor ids through without a mapping table. Host-owned ids (`sessionId`, `turnId`,
+event `id`) are ULIDs.
+
+Streams for `item.delta`: `text`, `reasoning`, `reasoning_summary`, `output` (+ open). `index`
+carries Codex's `summaryIndex`/`contentIndex` so parallel reasoning parts survive round-trips.
+
+## 4. Content blocks
+
+`ContentBlock` is the MCP/ACP v2 shape: `text`, `image`, `audio`, `resource_link`, `resource`,
+plus the open rule. Message content, tool output, and turn input all use it. This ends the old
+contract's worst granularity loss (images/resources flattened to `"[image: …]"` strings).
+
+## 5. Interaction plane
+
+Permission requests merge ACP v2's option model (host renders options, unknown outcome ≠
+approval) with Codex's typed subjects (command/file_change/tool_call detail so UIs can render
+rich prompts):
+
+```
+permission.requested { requestId, itemId?, title, description?, options[], detail?, expiresAt? }
+permission.resolved  { requestId, outcome: selected(optionId) | cancelled | timeout }
+```
+
+Decision semantics ride on `PermissionOption.kind` (`allow_once`, `allow_always`,
+`reject_once`, `reject_always`, + open) — Codex's `acceptForSession`/amendment decisions map to
+options with vendor payloads in `option.meta`.
+
+`input.requested` / `input.resolved` carry Codex `request_user_input` and MCP elicitation:
+questions with options, free-form and secret flags, answered by question id.
+
+Both are resolved by the dual commands `permission.resolve` / `input.resolve`. A driver that
+receives an outcome it does not understand must treat it as a rejection, never an approval.
+
+## 6. Commands
+
+Flat discriminated union — commands are few, small, and host-issued:
+
+| kind                 | payload                                                   | replaces                                             |
+| -------------------- | --------------------------------------------------------- | ---------------------------------------------------- |
+| `turn.start`         | `turnId`, `input: ContentBlock[]`                         | `input.start` (text-only)                            |
+| `turn.steer`         | `turnId`, `input: ContentBlock[]`                         | — (new; Codex turn/steer, Claude streaming input)    |
+| `turn.cancel`        | `turnId?`, `reason?`                                      | `turn.cancel`                                        |
+| `session.stop`       | `reason`                                                  | `session.stop`                                       |
+| `session.config.set` | `configId`, `value`                                       | — (new; ACP set_config_option, model/mode switching) |
+| `permission.resolve` | `requestId`, `outcome`                                    | binary `allow_once`/`reject_once` decision           |
+| `input.resolve`      | `requestId`, `outcome`                                    | — (new)                                              |
+| `mcp.execute`        | `requestId`, `serverId`, `toolName`, `arguments` (object) | JSON-string `argumentsJson`                          |
+
+Command fate is reported with `CommandUpdate { commandId, status: accepted → completed | failed
+| cancelled, error?, result? }`. Queueing states (`queued`, `delivered`, `expired`) were host
+bookkeeping and are gone from the contract.
+
+## 7. Extension & compatibility rules (normative)
+
+Taken from ACP v2, which has the best-articulated version of what every peer does:
+
+1. Every string enum and discriminated union in this contract is **open**. Parsers preserve
+   unknown values they can represent and never hard-fail on them.
+2. Kinds, item kinds, streams, and detail types beginning with `x_` are implementation
+   extensions. Unknown values **without** the prefix are reserved for future contract versions.
+3. Unknown event kinds pass envelope validation and flow through pipelines untouched
+   (store/forward), but are never projected by default.
+4. `meta` fields are opaque. The contract never assigns meaning to their keys.
+5. `CONTRACT_VERSION` is a single integer, bumped only for breaking changes. Additions ride on
+   capabilities: absence of a capability key means unsupported.
+
+## 8. Transport performance: coalescing and batching
+
+The contract, not the transport, defines merge semantics — so any boundary (oRPC batch, DO →
+WebSocket fan-out, SSE replay) can buffer safely:
+
+- **Coalescible kinds**: `item.delta` (same `itemId` + `stream` + `index`: concatenate),
+  `item.updated` (same `itemId`: patches merge, later fields win), `usage.updated` (same
+  `turnId`: keep last). Everything else is a barrier.
+- **Adjacency rule**: only adjacent events merge. Coalescing never reorders events across
+  different keys.
+- **Identity rule**: a merged event keeps the **last** member's `id`/`seq`/`at` (the ack
+  high-water mark stays correct); only the payload is combined.
+- `createSessionEventBuffer({ maxCount, maxDelayMs, flush })` implements the reference
+  buffer: coalescible events accumulate up to a deadline; barrier kinds flush the whole buffer
+  in order immediately.
+
+Losing an individual delta is tolerable by design (§3); losing snapshots is not. `deliveryOf`
+encodes exactly that split.
+
+## 9. What the old generation got wrong (and v2's answer)
+
+| debt                                                         | v2 answer                                                |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| 107 declared kinds, ~20 emitted                              | 17 typed kinds + open `x_*`                              |
+| payloads mostly unvalidated pass-through                     | zod schemas for every kind, inferred types               |
+| two parallel lifecycles (`message.*` family vs `item.*`)     | one item lifecycle for everything                        |
+| `tool.call.updated` mega-event (lifecycle by field-sniffing) | typed `tool_call` item + started/updated/delta/completed |
+| content flattened to strings                                 | `ContentBlock` end to end                                |
+| binary permission decision                                   | option model + typed detail                              |
+| no ordering token on events                                  | emitter `seq`                                            |
+| no coalescing anywhere                                       | contract-level coalescer + buffer                        |
+| hand-rolled validators duplicated driver/host                | one zod source of truth, JSON-Schema exportable          |
+
+## 10. Migration boundary
+
+`agent-driver/contract` is self-contained: it does not import from `runtime-events`,
+`runtime-command`, or `protocol/*` except the ULID helpers. The kernel, the three backends, the
+oRPC wire, the CMA projections, and the host's `pkgs/runtime-events` copy migrate in follow-up
+changes; until then both generations coexist and the old modules are the ones actually wired.
+Boot payload (`protocol/boot`, `DRIVER_PROTOCOL_VERSION = 1`) is process bootstrap, not session
+semantics — it is unchanged by this contract.

--- a/package.json
+++ b/package.json
@@ -70,18 +70,18 @@
     "test:live:opencode": "AGENT_DRIVER_LIVE_OPENCODE=1 vp exec bun test tests/opencode-acp-live.test.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.205",
-    "@anthropic-ai/sdk": "^0.100.1",
-    "@modelcontextprotocol/client": "^2.0.0-alpha.2",
-    "@orpc/client": "^1.14.3",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.207",
+    "@anthropic-ai/sdk": "^0.111.0",
+    "@modelcontextprotocol/client": "^2.0.0-beta.3",
+    "@orpc/client": "^1.14.7",
     "fflate": "^0.8.3",
     "vestig": "^0.23.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^25.8.0",
-    "typescript": "^6.0.3",
-    "vite-plus": "^0.1.23"
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2",
+    "vite-plus": "^0.2.4"
   },
   "packageManager": "bun@1.3.14"
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/types/events.d.ts",
       "default": "./src/events.ts"
     },
+    "./contract": {
+      "types": "./dist/types/contract/index.d.ts",
+      "default": "./src/contract/index.ts"
+    },
     "./orpc": {
       "types": "./dist/types/orpc.d.ts",
       "default": "./src/orpc.ts"

--- a/src/contract/buffer.ts
+++ b/src/contract/buffer.ts
@@ -1,0 +1,163 @@
+import type { SessionEvent, SessionEventKind, SessionEventPayloadMap } from "./event";
+
+/**
+ * Contract-level coalescing so any transport boundary (oRPC batch, DO →
+ * WebSocket fan-out, SSE replay) can buffer high-frequency events safely.
+ *
+ * Rules (normative):
+ * - Only ADJACENT events merge; coalescing never reorders across keys.
+ * - A merged event keeps the LAST member's id/seq/at (ack high-water mark
+ *   stays correct); only payloads combine.
+ * - item.delta  (same itemId+stream+index): deltas concatenate.
+ * - item.updated (same itemId): patches merge, later fields win.
+ * - usage.updated (same turnId): payloads are cumulative; keep the last.
+ * - Everything else is a barrier.
+ */
+export function isCoalescibleKind(kind: SessionEventKind): boolean {
+  return kind === "item.delta" || kind === "item.updated" || kind === "usage.updated";
+}
+
+function mergeAdjacent(previous: SessionEvent, next: SessionEvent): SessionEvent | null {
+  if (
+    previous.kind !== next.kind ||
+    previous.sessionId !== next.sessionId ||
+    previous.turnId !== next.turnId
+  ) {
+    return null;
+  }
+
+  if (previous.kind === "item.delta" && next.kind === "item.delta") {
+    const before = previous.payload as SessionEventPayloadMap["item.delta"];
+    const after = next.payload as SessionEventPayloadMap["item.delta"];
+
+    if (
+      before.itemId !== after.itemId ||
+      before.stream !== after.stream ||
+      before.index !== after.index
+    ) {
+      return null;
+    }
+
+    return { ...next, payload: { ...after, delta: before.delta + after.delta } };
+  }
+
+  if (previous.kind === "item.updated" && next.kind === "item.updated") {
+    const before = previous.payload as SessionEventPayloadMap["item.updated"];
+    const after = next.payload as SessionEventPayloadMap["item.updated"];
+
+    if (before.itemId !== after.itemId || before.kind !== after.kind) {
+      return null;
+    }
+
+    return { ...next, payload: { ...after, patch: { ...before.patch, ...after.patch } } };
+  }
+
+  if (previous.kind === "usage.updated" && next.kind === "usage.updated") {
+    return next;
+  }
+
+  return null;
+}
+
+/** Single-pass adjacent-run coalescing; relative order is preserved. */
+export function coalesceSessionEvents(events: readonly SessionEvent[]): SessionEvent[] {
+  const out: SessionEvent[] = [];
+
+  for (const event of events) {
+    const previous = out[out.length - 1];
+    const merged = previous === undefined ? null : mergeAdjacent(previous, event);
+
+    if (merged === null) {
+      out.push(event);
+    } else {
+      out[out.length - 1] = merged;
+    }
+  }
+
+  return out;
+}
+
+export interface SessionEventBufferOptions {
+  /** Flush callback; batches are already coalesced and in order. */
+  readonly flush: (events: SessionEvent[]) => void | Promise<void>;
+  /** Coalescible events buffered at most this long. Default 25ms. */
+  readonly maxDelayMs?: number | undefined;
+  /** Buffer flushes when it holds this many events. Default 64. */
+  readonly maxCount?: number | undefined;
+  /** Receives flush errors from timer-driven flushes. Default: rethrow async. */
+  readonly onError?: ((error: unknown, events: SessionEvent[]) => void) | undefined;
+}
+
+export interface SessionEventBuffer {
+  push(event: SessionEvent): void;
+  /** Flush buffered events now; resolves after the flush callback settles. */
+  flush(): Promise<void>;
+  readonly size: () => number;
+}
+
+/**
+ * Reference buffer: coalescible kinds accumulate up to maxDelayMs/maxCount;
+ * barrier kinds flush the whole buffer (in order) immediately. Flushes are
+ * serialized — a flush never starts before the previous one settled.
+ */
+export function createSessionEventBuffer(options: SessionEventBufferOptions): SessionEventBuffer {
+  const maxDelayMs = options.maxDelayMs ?? 25;
+  const maxCount = options.maxCount ?? 64;
+  const onError =
+    options.onError ??
+    ((error: unknown) => {
+      queueMicrotask(() => {
+        throw error;
+      });
+    });
+
+  let buffered: SessionEvent[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let sendGate: Promise<void> = Promise.resolve();
+
+  function clearTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function flushNow(background: boolean): Promise<void> {
+    clearTimer();
+
+    if (buffered.length === 0) {
+      return sendGate;
+    }
+
+    const events = coalesceSessionEvents(buffered);
+    buffered = [];
+    const task = sendGate.then(() => options.flush(events));
+    sendGate = task.catch(() => {});
+
+    if (background) {
+      task.catch((error: unknown) => {
+        onError(error, events);
+      });
+    }
+
+    return task;
+  }
+
+  return {
+    push(event) {
+      buffered.push(event);
+
+      if (!isCoalescibleKind(event.kind) || buffered.length >= maxCount) {
+        void flushNow(true);
+        return;
+      }
+
+      timer ??= setTimeout(() => {
+        timer = null;
+        void flushNow(true);
+      }, maxDelayMs);
+    },
+    flush: () => flushNow(false),
+    size: () => buffered.length,
+  };
+}

--- a/src/contract/command.ts
+++ b/src/contract/command.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+import { contentBlockSchema, metaSchema } from "./content";
+import { inputOutcomeSchema, permissionOutcomeSchema } from "./event";
+import { sessionErrorSchema, toolCallOutputSchema } from "./item";
+
+const ulid = z.ulid();
+const requestId = z.string().min(1);
+
+/**
+ * Host → driver commands. Flat discriminated union: commands are few, small,
+ * and host-issued (ids are ULIDs). The command set is closed per contract
+ * version — a driver must reject kinds it does not know.
+ */
+const turnInput = z.array(contentBlockSchema).min(1);
+
+export const sessionCommandSchema = z.discriminatedUnion("kind", [
+  z.looseObject({
+    kind: z.literal("turn.start"),
+    id: ulid,
+    turnId: ulid,
+    input: turnInput,
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("turn.steer"),
+    id: ulid,
+    turnId: ulid,
+    input: turnInput,
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("turn.cancel"),
+    id: ulid,
+    turnId: ulid.optional(),
+    reason: z.string().optional(),
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("session.stop"),
+    id: ulid,
+    reason: z.string().min(1),
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("session.config.set"),
+    id: ulid,
+    configId: z.string().min(1),
+    value: z.union([
+      z.looseObject({ type: z.literal("select"), valueId: z.string().min(1) }),
+      z.looseObject({ type: z.literal("boolean"), value: z.boolean() }),
+      z.looseObject({ type: z.string().min(1) }),
+    ]),
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("permission.resolve"),
+    id: ulid,
+    requestId,
+    outcome: permissionOutcomeSchema,
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("input.resolve"),
+    id: ulid,
+    requestId,
+    outcome: inputOutcomeSchema,
+    meta: metaSchema.optional(),
+  }),
+  z.looseObject({
+    kind: z.literal("mcp.execute"),
+    id: ulid,
+    requestId,
+    serverId: z.string().min(1),
+    toolName: z.string().min(1),
+    arguments: metaSchema,
+    meta: metaSchema.optional(),
+  }),
+]);
+
+export type SessionCommand = z.infer<typeof sessionCommandSchema>;
+export type SessionCommandKind = SessionCommand["kind"];
+export type SessionCommandOf<K extends SessionCommandKind> = Extract<SessionCommand, { kind: K }>;
+
+export function parseSessionCommand(value: unknown): SessionCommand {
+  return sessionCommandSchema.parse(value);
+}
+
+/** mcp.execute produces an MCP-shaped tool output; other commands none. */
+export type McpExecuteResult = z.infer<typeof toolCallOutputSchema>;
+
+/**
+ * Command fate, reported by the driver: accepted → completed | failed |
+ * cancelled. Host-side queueing states are host bookkeeping, not contract.
+ */
+export const commandUpdateSchema = z
+  .looseObject({
+    commandId: ulid,
+    status: z.enum(["accepted", "completed", "failed", "cancelled"]),
+    error: sessionErrorSchema.optional(),
+    result: toolCallOutputSchema.optional(),
+  })
+  .refine((update) => update.status !== "failed" || update.error !== undefined, {
+    message: "failed command update requires error",
+  });
+
+export type CommandUpdate = z.infer<typeof commandUpdateSchema>;
+
+export function parseCommandUpdate(value: unknown): CommandUpdate {
+  return commandUpdateSchema.parse(value);
+}

--- a/src/contract/content.ts
+++ b/src/contract/content.ts
@@ -1,0 +1,139 @@
+import { z } from "zod";
+
+/**
+ * Open string enum: known values keep literal types for DX, unknown non-empty
+ * strings pass (contract rule: every enum is open; `x_*` is the extension
+ * namespace, bare unknown values are reserved for future contract versions).
+ */
+export type OpenEnum<T extends string> = T | (string & {});
+
+export function openEnum<const T extends readonly [string, ...string[]]>(_values: T) {
+  return z.custom<OpenEnum<T[number]>>(
+    (value) => typeof value === "string" && value.length > 0,
+    "must be a non-empty string",
+  );
+}
+
+export const metaSchema = z.record(z.string(), z.unknown());
+
+const base64 = z.base64();
+const uri = z.string().min(1);
+
+/** MCP/ACP v2 aligned content blocks. Unknown `type` values pass through. */
+export const textContentSchema = z.looseObject({
+  type: z.literal("text"),
+  text: z.string(),
+  meta: metaSchema.optional(),
+});
+
+export const imageContentSchema = z
+  .looseObject({
+    type: z.literal("image"),
+    mimeType: z.string().min(1),
+    data: base64.optional(),
+    uri: uri.optional(),
+    meta: metaSchema.optional(),
+  })
+  .refine((block) => block.data !== undefined || block.uri !== undefined, {
+    message: "image content requires data or uri",
+  });
+
+export const audioContentSchema = z.looseObject({
+  type: z.literal("audio"),
+  mimeType: z.string().min(1),
+  data: base64,
+  meta: metaSchema.optional(),
+});
+
+export const resourceLinkContentSchema = z.looseObject({
+  type: z.literal("resource_link"),
+  uri,
+  name: z.string().min(1),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  mimeType: z.string().optional(),
+  size: z.number().int().nonnegative().optional(),
+  meta: metaSchema.optional(),
+});
+
+export const resourceContentSchema = z.looseObject({
+  type: z.literal("resource"),
+  resource: z.union([
+    z.looseObject({ uri, mimeType: z.string().optional(), text: z.string() }),
+    z.looseObject({ uri, mimeType: z.string().optional(), blob: base64 }),
+  ]),
+  meta: metaSchema.optional(),
+});
+
+const unknownContentSchema = z.looseObject({
+  type: z.string().min(1),
+  meta: metaSchema.optional(),
+});
+
+export type TextContent = z.infer<typeof textContentSchema>;
+export type ImageContent = z.infer<typeof imageContentSchema>;
+export type AudioContent = z.infer<typeof audioContentSchema>;
+export type ResourceLinkContent = z.infer<typeof resourceLinkContentSchema>;
+export type ResourceContent = z.infer<typeof resourceContentSchema>;
+export type UnknownContent = z.infer<typeof unknownContentSchema>;
+
+export type ContentBlock =
+  | AudioContent
+  | ImageContent
+  | ResourceContent
+  | ResourceLinkContent
+  | TextContent
+  | UnknownContent;
+
+const TYPED_CONTENT_SCHEMAS: Record<string, z.ZodType<ContentBlock>> = {
+  audio: audioContentSchema,
+  image: imageContentSchema,
+  resource: resourceContentSchema,
+  resource_link: resourceLinkContentSchema,
+  text: textContentSchema,
+};
+
+/** Strict on known `type` values, open on unknown ones (ACP v2 rule). */
+export const contentBlockSchema: z.ZodType<ContentBlock> = z
+  .looseObject({ type: z.string().min(1) })
+  .transform((value, ctx) => {
+    const schema = TYPED_CONTENT_SCHEMAS[value.type] ?? unknownContentSchema;
+    const result = schema.safeParse(value);
+
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: "custom",
+          message: issue.message,
+          path: [...issue.path],
+          input: value,
+        });
+      }
+
+      return z.NEVER;
+    }
+
+    return result.data;
+  });
+
+/** Best-effort plain-text rendering; non-text blocks become bracket labels. */
+export function contentBlockText(block: ContentBlock): string {
+  if (block.type === "text" && "text" in block && typeof block["text"] === "string") {
+    return block["text"];
+  }
+
+  if (block.type === "resource" && "resource" in block) {
+    const resource = block["resource"];
+
+    if (typeof resource === "object" && resource !== null && "text" in resource) {
+      const text = (resource as { text?: unknown }).text;
+
+      if (typeof text === "string") {
+        return text;
+      }
+    }
+  }
+
+  const name = "name" in block && typeof block["name"] === "string" ? `: ${block["name"]}` : "";
+  return `[${block.type}${name}]`;
+}

--- a/src/contract/event.ts
+++ b/src/contract/event.ts
@@ -1,0 +1,451 @@
+import { z } from "zod";
+
+import { metaSchema, openEnum } from "./content";
+import type { OpenEnum } from "./content";
+import { itemIdSchema, sessionErrorSchema, sessionItemSchema } from "./item";
+import { parseSessionItemPatch } from "./item";
+
+const ulid = z.ulid();
+const isoTime = z.iso.datetime({ offset: true });
+const requestId = z.string().min(1);
+
+/** Provenance pointer back to the native provider event. */
+export const nativeRefSchema = z.looseObject({
+  provider: z.string().min(1),
+  eventName: z.string().optional(),
+  itemId: z.string().optional(),
+  threadId: z.string().optional(),
+  turnId: z.string().optional(),
+  requestId: z.string().optional(),
+  sequence: z.number().optional(),
+});
+export type NativeRef = z.infer<typeof nativeRefSchema>;
+
+// --- session plane ---
+
+const sessionStartedPayload = z.looseObject({
+  resumed: z.boolean(),
+  /** Native session handle the host persists for future resume. */
+  nativeSessionRef: z
+    .looseObject({ provider: z.string().min(1), ref: z.string().min(1) })
+    .nullable()
+    .optional(),
+});
+
+const sessionInfoUpdatedPayload = z.looseObject({
+  title: z.string().nullable().optional(),
+});
+
+/** ACP v2 SessionConfigOption (select/boolean + open). */
+const configOptionBase = {
+  configId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  category: openEnum(["mode", "model", "model_config", "thought_level"]).optional(),
+  meta: metaSchema.optional(),
+};
+
+export const sessionConfigOptionSchema = z.union([
+  z.looseObject({
+    ...configOptionBase,
+    type: z.literal("select"),
+    currentValueId: z.string().min(1),
+    options: z.array(
+      z.looseObject({
+        valueId: z.string().min(1),
+        name: z.string().min(1),
+        description: z.string().optional(),
+      }),
+    ),
+  }),
+  z.looseObject({ ...configOptionBase, type: z.literal("boolean"), currentValue: z.boolean() }),
+  z.looseObject({ ...configOptionBase, type: z.string().min(1) }),
+]);
+export type SessionConfigOption = z.infer<typeof sessionConfigOptionSchema>;
+
+const sessionConfigUpdatedPayload = z.looseObject({
+  options: z.array(sessionConfigOptionSchema),
+});
+
+export const availableCommandSchema = z.looseObject({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  inputHint: z.string().nullable().optional(),
+});
+export type AvailableCommand = z.infer<typeof availableCommandSchema>;
+
+const sessionCommandsUpdatedPayload = z.looseObject({
+  commands: z.array(availableCommandSchema),
+});
+
+export const tokenUsageSchema = z.looseObject({
+  input: z.number().nonnegative(),
+  cachedInput: z.number().nonnegative().optional(),
+  output: z.number().nonnegative(),
+  reasoningOutput: z.number().nonnegative().optional(),
+  total: z.number().nonnegative(),
+});
+export type TokenUsage = z.infer<typeof tokenUsageSchema>;
+
+const usageUpdatedPayload = z.looseObject({
+  /** Session-cumulative usage (Codex total / ACP used). */
+  tokens: tokenUsageSchema.optional(),
+  /** Most recent model call (Codex last). */
+  lastTokens: tokenUsageSchema.optional(),
+  context: z
+    .looseObject({
+      usedTokens: z.number().nonnegative(),
+      maxTokens: z.number().positive().optional(),
+    })
+    .optional(),
+  cost: z.looseObject({ amount: z.number().nonnegative(), currency: z.string().min(1) }).optional(),
+});
+
+// --- turn plane ---
+
+const turnStartedPayload = z.looseObject({});
+
+export const TURN_STOP_REASONS = [
+  "end_turn",
+  "max_tokens",
+  "max_turns",
+  "refusal",
+  "cancelled",
+] as const;
+export type TurnStopReason = OpenEnum<(typeof TURN_STOP_REASONS)[number]>;
+
+const turnCompletedPayload = z
+  .looseObject({
+    status: z.enum(["completed", "cancelled", "failed"]),
+    stopReason: openEnum(TURN_STOP_REASONS).optional(),
+    error: sessionErrorSchema.nullable().optional(),
+  })
+  .refine((payload) => payload.status !== "failed" || payload.error != null, {
+    message: "turn.completed with status failed requires error",
+  });
+
+// --- item plane ---
+
+const itemStartedPayload = z.looseObject({ item: sessionItemSchema });
+const itemCompletedPayload = z.looseObject({ item: sessionItemSchema });
+
+const itemUpdatedPayload = z
+  .looseObject({
+    itemId: itemIdSchema,
+    kind: z.string().min(1),
+    patch: metaSchema,
+  })
+  .transform((payload, ctx) => {
+    try {
+      return { ...payload, patch: parseSessionItemPatch(payload.kind, payload.patch) };
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message: error instanceof Error ? error.message : "invalid item patch",
+        input: payload.patch,
+        path: ["patch"],
+      });
+      return z.NEVER;
+    }
+  });
+
+export const ITEM_DELTA_STREAMS = ["text", "reasoning", "reasoning_summary", "output"] as const;
+export type ItemDeltaStream = OpenEnum<(typeof ITEM_DELTA_STREAMS)[number]>;
+
+const itemDeltaPayload = z.looseObject({
+  itemId: itemIdSchema,
+  stream: openEnum(ITEM_DELTA_STREAMS),
+  /** Parallel part index (Codex reasoning summaryIndex/contentIndex). */
+  index: z.number().int().nonnegative().optional(),
+  delta: z.string(),
+});
+
+// --- interaction plane ---
+
+export const permissionOptionSchema = z.looseObject({
+  optionId: z.string().min(1),
+  name: z.string().min(1),
+  kind: openEnum(["allow_once", "allow_always", "reject_once", "reject_always"]),
+  meta: metaSchema.optional(),
+});
+export type PermissionOption = z.infer<typeof permissionOptionSchema>;
+
+/** Typed subject so hosts can render rich approval prompts (Codex-grade detail). */
+export const permissionDetailSchema = z.union([
+  z.looseObject({
+    type: z.literal("command"),
+    command: z.string(),
+    cwd: z.string().optional(),
+    reason: z.string().optional(),
+  }),
+  z.looseObject({
+    type: z.literal("file_change"),
+    changes: z.array(z.looseObject({ path: z.string().min(1), op: z.string().optional() })),
+    reason: z.string().optional(),
+  }),
+  z.looseObject({
+    type: z.literal("tool_call"),
+    name: z.string().min(1),
+    server: z.string().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.looseObject({ type: z.string().min(1) }),
+]);
+export type PermissionDetail = z.infer<typeof permissionDetailSchema>;
+
+const permissionRequestedPayload = z.looseObject({
+  requestId,
+  itemId: itemIdSchema.optional(),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(permissionOptionSchema).min(1),
+  detail: permissionDetailSchema.optional(),
+  expiresAt: isoTime.optional(),
+});
+
+/**
+ * Open outcome union. Receivers that do not understand an outcome MUST treat
+ * it as a rejection, never an approval.
+ */
+export const permissionOutcomeSchema = z.union([
+  z.looseObject({ type: z.literal("selected"), optionId: z.string().min(1) }),
+  z.looseObject({ type: z.literal("cancelled") }),
+  z.looseObject({ type: z.literal("timeout") }),
+  z.looseObject({ type: z.string().min(1) }),
+]);
+export type PermissionOutcome = z.infer<typeof permissionOutcomeSchema>;
+
+const permissionResolvedPayload = z.looseObject({
+  requestId,
+  outcome: permissionOutcomeSchema,
+});
+
+export const inputQuestionSchema = z.looseObject({
+  questionId: z.string().min(1),
+  question: z.string().min(1),
+  header: z.string().optional(),
+  options: z
+    .array(z.looseObject({ label: z.string().min(1), description: z.string().optional() }))
+    .optional(),
+  allowFreeform: z.boolean().optional(),
+  secret: z.boolean().optional(),
+});
+export type InputQuestion = z.infer<typeof inputQuestionSchema>;
+
+const inputRequestedPayload = z.looseObject({
+  requestId,
+  itemId: itemIdSchema.optional(),
+  questions: z.array(inputQuestionSchema).min(1),
+  expiresAt: isoTime.optional(),
+});
+
+export const inputOutcomeSchema = z.union([
+  z.looseObject({
+    type: z.literal("answered"),
+    answers: z.record(z.string(), z.array(z.string())),
+  }),
+  z.looseObject({ type: z.literal("cancelled") }),
+  z.looseObject({ type: z.string().min(1) }),
+]);
+export type InputOutcome = z.infer<typeof inputOutcomeSchema>;
+
+const inputResolvedPayload = z.looseObject({
+  requestId,
+  outcome: inputOutcomeSchema,
+});
+
+// --- ops plane ---
+
+const diagnosticReportedPayload = z.looseObject({
+  severity: z.enum(["info", "warning", "error"]),
+  code: z.string().min(1),
+  message: z.string(),
+  retryable: z.boolean().optional(),
+  itemId: itemIdSchema.optional(),
+  detail: metaSchema.optional(),
+});
+
+const timingRecordedPayload = z.looseObject({
+  stage: z.string().min(1),
+  path: openEnum(["cold", "warm", "prewarm", "unknown"]).optional(),
+  startedAtMs: z.number().nonnegative(),
+  totalMs: z.number().nonnegative(),
+  phases: z.array(z.looseObject({ name: z.string().min(1), durationMs: z.number().nonnegative() })),
+});
+
+// --- registry ---
+
+export const SESSION_EVENT_PAYLOAD_SCHEMAS = {
+  "diagnostic.reported": diagnosticReportedPayload,
+  "input.requested": inputRequestedPayload,
+  "input.resolved": inputResolvedPayload,
+  "item.completed": itemCompletedPayload,
+  "item.delta": itemDeltaPayload,
+  "item.started": itemStartedPayload,
+  "item.updated": itemUpdatedPayload,
+  "permission.requested": permissionRequestedPayload,
+  "permission.resolved": permissionResolvedPayload,
+  "session.commands.updated": sessionCommandsUpdatedPayload,
+  "session.config.updated": sessionConfigUpdatedPayload,
+  "session.info.updated": sessionInfoUpdatedPayload,
+  "session.started": sessionStartedPayload,
+  "timing.recorded": timingRecordedPayload,
+  "turn.completed": turnCompletedPayload,
+  "turn.started": turnStartedPayload,
+  "usage.updated": usageUpdatedPayload,
+} as const;
+
+export const SESSION_EVENT_KINDS = Object.keys(SESSION_EVENT_PAYLOAD_SCHEMAS).toSorted() as [
+  KnownSessionEventKind,
+  ...KnownSessionEventKind[],
+];
+
+export type KnownSessionEventKind = keyof typeof SESSION_EVENT_PAYLOAD_SCHEMAS;
+export type SessionEventKind = OpenEnum<KnownSessionEventKind>;
+
+export type SessionEventPayloadMap = {
+  [K in KnownSessionEventKind]: z.output<(typeof SESSION_EVENT_PAYLOAD_SCHEMAS)[K]>;
+};
+
+export type SessionEventPayload<K extends SessionEventKind> = K extends KnownSessionEventKind
+  ? SessionEventPayloadMap[K]
+  : Record<string, unknown>;
+
+export interface SessionEvent<K extends SessionEventKind = SessionEventKind> {
+  readonly id: string;
+  /** Per-session monotonic counter assigned by the emitter. */
+  readonly seq: number;
+  readonly sessionId: string;
+  readonly turnId?: string | undefined;
+  readonly at: string;
+  readonly kind: K;
+  readonly payload: SessionEventPayload<K>;
+  readonly native?: NativeRef | undefined;
+  readonly traceId?: string | undefined;
+  readonly meta?: Record<string, unknown> | undefined;
+}
+
+const eventEnvelopeSchema = z.looseObject({
+  id: ulid,
+  seq: z.number().int().nonnegative(),
+  sessionId: ulid,
+  turnId: ulid.optional(),
+  at: isoTime,
+  kind: z.string().min(1),
+  payload: z.unknown(),
+  native: nativeRefSchema.optional(),
+  traceId: z.string().min(1).optional(),
+  meta: metaSchema.optional(),
+});
+
+/** Turn-scoped kinds require `turnId` on the envelope. */
+const TURN_SCOPED_KINDS: ReadonlySet<string> = new Set([
+  "item.completed",
+  "item.delta",
+  "item.started",
+  "item.updated",
+  "permission.requested",
+  "permission.resolved",
+  "turn.completed",
+  "turn.started",
+] satisfies KnownSessionEventKind[]);
+
+export function isKnownSessionEventKind(kind: string): kind is KnownSessionEventKind {
+  return kind in SESSION_EVENT_PAYLOAD_SCHEMAS;
+}
+
+/**
+ * Strict on known kinds, open on unknown kinds: an unknown `kind` (extension
+ * `x_*` or a future contract version) passes envelope validation with a
+ * record payload and flows through pipelines untouched.
+ */
+export function parseSessionEvent(value: unknown): SessionEvent {
+  const envelope = eventEnvelopeSchema.parse(value);
+
+  if (TURN_SCOPED_KINDS.has(envelope.kind) && envelope.turnId === undefined) {
+    throw new Error(`Session event ${envelope.kind} requires turnId.`);
+  }
+
+  const schema = isKnownSessionEventKind(envelope.kind)
+    ? SESSION_EVENT_PAYLOAD_SCHEMAS[envelope.kind]
+    : metaSchema;
+  return { ...envelope, payload: schema.parse(envelope.payload) };
+}
+
+export type SessionEventIngress =
+  | { readonly status: "accepted"; readonly event: SessionEvent }
+  | {
+      readonly status: "rejected";
+      readonly reason: { readonly code: "malformed_event"; readonly message: string };
+    };
+
+/** Non-throwing ingress for network boundaries. */
+export function admitSessionEvent(value: unknown): SessionEventIngress {
+  try {
+    return { status: "accepted", event: parseSessionEvent(value) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "session event is malformed";
+    return { status: "rejected", reason: { code: "malformed_event", message } };
+  }
+}
+
+// --- classification (static functions of kind, not wire fields) ---
+
+/** Only deltas are droppable: the item.completed snapshot heals missed deltas. */
+export function deliveryOf(kind: SessionEventKind): "best_effort" | "lossless" {
+  return kind === "item.delta" ? "best_effort" : "lossless";
+}
+
+export function visibilityOf(kind: SessionEventKind): "owner_debug" | "participant" {
+  return kind === "diagnostic.reported" || kind === "timing.recorded"
+    ? "owner_debug"
+    : "participant";
+}
+
+// --- emitter ---
+
+export interface SessionEventFactoryOptions {
+  readonly sessionId: string;
+  readonly createId: () => string;
+  readonly traceId?: string | undefined;
+}
+
+export interface SessionEventInit {
+  readonly turnId?: string | undefined;
+  readonly at?: string | undefined;
+  readonly native?: NativeRef | undefined;
+  readonly meta?: Record<string, unknown> | undefined;
+}
+
+export interface SessionEventFactory {
+  emit<K extends SessionEventKind>(
+    kind: K,
+    payload: SessionEventPayload<K>,
+    init?: SessionEventInit,
+  ): SessionEvent<K>;
+}
+
+/** Emitter-side constructor: assigns id/seq/at and validates the payload. */
+export function createSessionEventFactory(
+  options: SessionEventFactoryOptions,
+): SessionEventFactory {
+  let seq = 0;
+
+  return {
+    emit(kind, payload, init = {}) {
+      const event = {
+        id: options.createId(),
+        seq: seq++,
+        sessionId: options.sessionId,
+        ...(init.turnId === undefined ? {} : { turnId: init.turnId }),
+        at: init.at ?? new Date().toISOString(),
+        kind,
+        payload,
+        ...(init.native === undefined ? {} : { native: init.native }),
+        ...(options.traceId === undefined ? {} : { traceId: options.traceId }),
+        ...(init.meta === undefined ? {} : { meta: init.meta }),
+      };
+      return parseSessionEvent(event) as SessionEvent<typeof kind>;
+    },
+  };
+}

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -1,0 +1,151 @@
+/**
+ * Driver Contract v2 — the canonical agent-session event/command contract.
+ * Spec: docs/contract.md. Replaces the 2026-05-26 runtime-event generation;
+ * the old modules remain wired until kernel/backends/host migrate.
+ */
+
+/**
+ * Single integer, bumped only for breaking changes. Additions ride on
+ * capabilities: absence of a capability key means unsupported.
+ */
+export const CONTRACT_VERSION = 2 as const;
+
+/**
+ * Capability advertisement: key → open detail object (ACP v2 style object
+ * markers — presence means supported, details may grow without breakage).
+ */
+export type SessionCapabilities = Record<string, Record<string, unknown>>;
+
+/** Capability keys with real variance across today's backends. */
+export const KNOWN_CAPABILITY_KEYS = [
+  "input.request",
+  "item.delta",
+  "mcp.execute",
+  "native_resume",
+  "permission.request",
+  "session.config.set",
+  "turn.steer",
+] as const;
+export type KnownCapabilityKey = (typeof KNOWN_CAPABILITY_KEYS)[number];
+
+export {
+  audioContentSchema,
+  contentBlockSchema,
+  contentBlockText,
+  imageContentSchema,
+  metaSchema,
+  openEnum,
+  resourceContentSchema,
+  resourceLinkContentSchema,
+  textContentSchema,
+} from "./content";
+export type {
+  AudioContent,
+  ContentBlock,
+  ImageContent,
+  OpenEnum,
+  ResourceContent,
+  ResourceLinkContent,
+  TextContent,
+} from "./content";
+
+export {
+  ITEM_STATUSES,
+  applySessionItemPatch,
+  commandActionSchema,
+  commandItemSchema,
+  extensionItemSchema,
+  fileChangeItemSchema,
+  fileChangeSchema,
+  itemIdSchema,
+  messageItemSchema,
+  parseSessionItem,
+  parseSessionItemPatch,
+  planEntrySchema,
+  planItemSchema,
+  reasoningItemSchema,
+  sessionErrorSchema,
+  sessionItemSchema,
+  toolCallItemSchema,
+  toolCallLocationSchema,
+  toolCallOutputSchema,
+} from "./item";
+export type {
+  CommandAction,
+  CommandItem,
+  ExtensionItem,
+  FileChange,
+  FileChangeItem,
+  ItemStatus,
+  MessageItem,
+  PlanEntry,
+  PlanItem,
+  ReasoningItem,
+  SessionError,
+  SessionItem,
+  SessionItemKind,
+  SessionItemPatch,
+  ToolCallItem,
+  ToolCallOutput,
+} from "./item";
+
+export {
+  ITEM_DELTA_STREAMS,
+  SESSION_EVENT_KINDS,
+  SESSION_EVENT_PAYLOAD_SCHEMAS,
+  TURN_STOP_REASONS,
+  admitSessionEvent,
+  availableCommandSchema,
+  createSessionEventFactory,
+  deliveryOf,
+  inputOutcomeSchema,
+  inputQuestionSchema,
+  isKnownSessionEventKind,
+  nativeRefSchema,
+  parseSessionEvent,
+  permissionDetailSchema,
+  permissionOptionSchema,
+  permissionOutcomeSchema,
+  sessionConfigOptionSchema,
+  tokenUsageSchema,
+  visibilityOf,
+} from "./event";
+export type {
+  AvailableCommand,
+  InputOutcome,
+  InputQuestion,
+  ItemDeltaStream,
+  KnownSessionEventKind,
+  NativeRef,
+  PermissionDetail,
+  PermissionOption,
+  PermissionOutcome,
+  SessionConfigOption,
+  SessionEvent,
+  SessionEventFactory,
+  SessionEventFactoryOptions,
+  SessionEventIngress,
+  SessionEventInit,
+  SessionEventKind,
+  SessionEventPayload,
+  SessionEventPayloadMap,
+  TokenUsage,
+  TurnStopReason,
+} from "./event";
+
+export {
+  commandUpdateSchema,
+  parseCommandUpdate,
+  parseSessionCommand,
+  sessionCommandSchema,
+} from "./command";
+export type {
+  CommandUpdate,
+  McpExecuteResult,
+  SessionCommand,
+  SessionCommandKind,
+  SessionCommandOf,
+} from "./command";
+
+export { coalesceSessionEvents, createSessionEventBuffer, isCoalescibleKind } from "./buffer";
+export type { SessionEventBuffer, SessionEventBufferOptions } from "./buffer";

--- a/src/contract/item.ts
+++ b/src/contract/item.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+
+import { contentBlockSchema, metaSchema, openEnum } from "./content";
+import type { OpenEnum } from "./content";
+
+/**
+ * Session transcript items. One lifecycle for every kind:
+ * item.started (snapshot) → item.delta* / item.updated* → item.completed
+ * (authoritative snapshot; may not equal the concatenation of deltas).
+ *
+ * `itemId` is an opaque non-empty string so adapters can pass vendor ids
+ * (Codex UUIDv7, ACP toolCallId, …) through without a mapping table.
+ */
+export const itemIdSchema = z.string().min(1);
+
+/** Unified status vocabulary (ACP tool statuses ∪ Codex item statuses). */
+export const ITEM_STATUSES = ["pending", "in_progress", "completed", "failed", "declined"] as const;
+export type ItemStatus = OpenEnum<(typeof ITEM_STATUSES)[number]>;
+const itemStatusSchema = openEnum(ITEM_STATUSES);
+
+export const sessionErrorSchema = z.looseObject({
+  code: z.string().min(1),
+  message: z.string(),
+  retryable: z.boolean().optional(),
+  detail: metaSchema.optional(),
+});
+export type SessionError = z.infer<typeof sessionErrorSchema>;
+
+export const messageItemSchema = z.looseObject({
+  kind: z.literal("message"),
+  itemId: itemIdSchema,
+  role: z.enum(["user", "agent"]),
+  content: z.array(contentBlockSchema),
+  /** Codex MessagePhase (e.g. commentary vs final); open. */
+  phase: z.string().min(1).optional(),
+  meta: metaSchema.optional(),
+});
+
+export const reasoningItemSchema = z.looseObject({
+  kind: z.literal("reasoning"),
+  itemId: itemIdSchema,
+  /** Indexed parts: item.delta stream "reasoning_summary"/"reasoning" appends by `index`. */
+  summary: z.array(z.string()),
+  content: z.array(z.string()),
+  meta: metaSchema.optional(),
+});
+
+export const planEntrySchema = z.looseObject({
+  content: z.string(),
+  status: openEnum(["pending", "in_progress", "completed"]),
+  priority: openEnum(["high", "medium", "low"]).optional(),
+});
+
+export const planItemSchema = z.looseObject({
+  kind: z.literal("plan"),
+  itemId: itemIdSchema,
+  /** Each snapshot/patch replaces the full entry list (ACP plan semantics). */
+  entries: z.array(planEntrySchema),
+  meta: metaSchema.optional(),
+});
+
+/** Best-effort parse of what a shell command does (Codex commandActions). */
+export const commandActionSchema = z.looseObject({
+  type: openEnum(["read", "list_files", "search", "unknown"]),
+  command: z.string().optional(),
+  path: z.string().optional(),
+  query: z.string().optional(),
+  name: z.string().optional(),
+});
+
+export const commandItemSchema = z.looseObject({
+  kind: z.literal("command"),
+  itemId: itemIdSchema,
+  command: z.string(),
+  status: itemStatusSchema,
+  cwd: z.string().optional(),
+  actions: z.array(commandActionSchema).optional(),
+  /** Aggregated stdout+stderr; streamed via item.delta stream "output". */
+  output: z.string().optional(),
+  exitCode: z.number().int().nullable().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  processId: z.string().optional(),
+  source: openEnum(["agent", "user"]).optional(),
+  meta: metaSchema.optional(),
+});
+
+/** Codex FileUpdateChange ∪ ACP v2 DiffChange. */
+export const fileChangeSchema = z.looseObject({
+  path: z.string().min(1),
+  op: openEnum(["add", "modify", "delete", "move", "copy"]),
+  oldPath: z.string().optional(),
+  /** Unified diff when representable (git patch style); binary/dir changes omit it. */
+  diff: z.string().nullable().optional(),
+  fileType: openEnum(["text", "binary", "directory", "symlink"]).optional(),
+});
+
+export const fileChangeItemSchema = z.looseObject({
+  kind: z.literal("file_change"),
+  itemId: itemIdSchema,
+  changes: z.array(fileChangeSchema).min(1),
+  status: itemStatusSchema,
+  meta: metaSchema.optional(),
+});
+
+export const toolCallOutputSchema = z.looseObject({
+  content: z.array(contentBlockSchema),
+  structured: z.unknown().optional(),
+  isError: z.boolean().optional(),
+});
+
+export const toolCallLocationSchema = z.looseObject({
+  path: z.string().min(1),
+  line: z.number().int().nonnegative().optional(),
+});
+
+export const toolCallItemSchema = z.looseObject({
+  kind: z.literal("tool_call"),
+  itemId: itemIdSchema,
+  name: z.string().min(1),
+  status: itemStatusSchema,
+  title: z.string().nullable().optional(),
+  /** ACP ToolKind — generic rendering hint. */
+  category: openEnum([
+    "read",
+    "edit",
+    "delete",
+    "move",
+    "search",
+    "execute",
+    "think",
+    "fetch",
+    "other",
+  ]).optional(),
+  origin: openEnum(["mcp", "provider", "host"]).optional(),
+  /** MCP server name when origin is "mcp". */
+  server: z.string().optional(),
+  input: z.unknown().optional(),
+  output: toolCallOutputSchema.nullable().optional(),
+  error: sessionErrorSchema.nullable().optional(),
+  locations: z.array(toolCallLocationSchema).optional(),
+  /** Latest MCP progress message (LWW via item.updated). */
+  progressMessage: z.string().nullable().optional(),
+  durationMs: z.number().nonnegative().optional(),
+  meta: metaSchema.optional(),
+});
+
+/**
+ * Extension items carry vendor granularity the core does not type (Codex
+ * webSearch, imageGeneration, collab agents, review mode, context compaction…).
+ * Implementation-defined kinds should use the `x_` prefix; bare unknown kinds
+ * are reserved for future contract versions. Both parse through this shape.
+ */
+export const extensionItemSchema = z.looseObject({
+  kind: z.string().min(1),
+  itemId: itemIdSchema,
+  status: itemStatusSchema.optional(),
+  payload: metaSchema.optional(),
+  meta: metaSchema.optional(),
+});
+
+export type MessageItem = z.infer<typeof messageItemSchema>;
+export type ReasoningItem = z.infer<typeof reasoningItemSchema>;
+export type PlanEntry = z.infer<typeof planEntrySchema>;
+export type PlanItem = z.infer<typeof planItemSchema>;
+export type CommandAction = z.infer<typeof commandActionSchema>;
+export type CommandItem = z.infer<typeof commandItemSchema>;
+export type FileChange = z.infer<typeof fileChangeSchema>;
+export type FileChangeItem = z.infer<typeof fileChangeItemSchema>;
+export type ToolCallOutput = z.infer<typeof toolCallOutputSchema>;
+export type ToolCallItem = z.infer<typeof toolCallItemSchema>;
+export type ExtensionItem = z.infer<typeof extensionItemSchema>;
+
+export type SessionItem =
+  | CommandItem
+  | ExtensionItem
+  | FileChangeItem
+  | MessageItem
+  | PlanItem
+  | ReasoningItem
+  | ToolCallItem;
+
+export type SessionItemKind = SessionItem["kind"];
+
+const TYPED_ITEM_SCHEMAS = {
+  command: commandItemSchema,
+  file_change: fileChangeItemSchema,
+  message: messageItemSchema,
+  plan: planItemSchema,
+  reasoning: reasoningItemSchema,
+  tool_call: toolCallItemSchema,
+} as const;
+
+export const sessionItemSchema: z.ZodType<SessionItem> = z
+  .looseObject({ kind: z.string().min(1), itemId: itemIdSchema })
+  .transform((value, ctx) => {
+    const schema =
+      value.kind in TYPED_ITEM_SCHEMAS
+        ? TYPED_ITEM_SCHEMAS[value.kind as keyof typeof TYPED_ITEM_SCHEMAS]
+        : extensionItemSchema;
+    const result = schema.safeParse(value);
+
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: "custom",
+          message: issue.message,
+          path: [...issue.path],
+          input: value,
+        });
+      }
+
+      return z.NEVER;
+    }
+
+    return result.data;
+  });
+
+export function parseSessionItem(value: unknown): SessionItem {
+  return sessionItemSchema.parse(value);
+}
+
+/**
+ * item.updated patches: any typed item's fields minus identity (itemId/kind),
+ * replace-per-field (LWW). Unknown item kinds accept any record patch.
+ */
+const identity = { kind: true, itemId: true } as const;
+const ITEM_PATCH_SCHEMAS: Record<string, z.ZodType<Record<string, unknown>>> = {
+  command: commandItemSchema.omit(identity).partial(),
+  file_change: fileChangeItemSchema.omit(identity).partial(),
+  message: messageItemSchema.omit(identity).partial(),
+  plan: planItemSchema.omit(identity).partial(),
+  reasoning: reasoningItemSchema.omit(identity).partial(),
+  tool_call: toolCallItemSchema.omit(identity).partial(),
+};
+
+export type SessionItemPatch = Record<string, unknown>;
+
+export function parseSessionItemPatch(kind: string, value: unknown): SessionItemPatch {
+  return (ITEM_PATCH_SCHEMAS[kind] ?? metaSchema).parse(value);
+}
+
+/** Apply an item.updated patch: shallow replace-per-field, identity preserved. */
+export function applySessionItemPatch<T extends SessionItem>(item: T, patch: SessionItemPatch): T {
+  return { ...item, ...patch, itemId: item.itemId, kind: item.kind };
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -511,7 +511,7 @@ export function getActiveLogContext(): LogContext | undefined {
 }
 
 export function normalizeLogContext(context: Record<string, unknown> = {}): LogContext {
-  return normalizeLogMetadata(context) as LogContext;
+  return normalizeLogMetadata(context);
 }
 
 export function normalizeLogMetadata(metadata: Record<string, unknown> = {}): LogMetadata {

--- a/tests/contract-buffer.test.ts
+++ b/tests/contract-buffer.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  coalesceSessionEvents,
+  createSessionEventBuffer,
+  createSessionEventFactory,
+  isCoalescibleKind,
+} from "../src/contract";
+import type {
+  SessionEvent,
+  SessionEventInit,
+  SessionEventKind,
+  SessionEventPayload,
+} from "../src/contract";
+import { createDriverId } from "../src/protocol/id";
+
+const SESSION_ID = "01J0000000000000000000000K";
+const TURN_ID = "01J0000000000000000000000N";
+
+function factory() {
+  return createSessionEventFactory({ sessionId: SESSION_ID, createId: () => createDriverId() });
+}
+
+function emitter() {
+  const events = factory();
+  return <K extends SessionEventKind>(
+    kind: K,
+    payload: SessionEventPayload<K>,
+    init?: SessionEventInit,
+  ) => events.emit(kind, payload, { turnId: TURN_ID, ...init });
+}
+
+describe("coalesceSessionEvents", () => {
+  test("adjacent same-stream deltas concatenate, keeping the last identity", () => {
+    const emit = emitter();
+    const events = [
+      emit("item.delta", { itemId: "m1", stream: "text", delta: "he" }),
+      emit("item.delta", { itemId: "m1", stream: "text", delta: "llo" }),
+      emit("item.delta", { itemId: "m1", stream: "text", delta: " world" }),
+    ];
+
+    const coalesced = coalesceSessionEvents(events);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced[0]?.payload).toMatchObject({ delta: "hello world" });
+    expect(coalesced[0]?.seq).toBe(events[2]?.seq);
+    expect(coalesced[0]?.id).toBe(events[2]?.id);
+  });
+
+  test("deltas never merge across items, streams, or indices", () => {
+    const emit = emitter();
+    const events = [
+      emit("item.delta", { itemId: "m1", stream: "text", delta: "a" }),
+      emit("item.delta", { itemId: "m2", stream: "text", delta: "b" }),
+      emit("item.delta", { itemId: "m2", stream: "output", delta: "c" }),
+      emit("item.delta", { itemId: "r1", stream: "reasoning_summary", index: 0, delta: "d" }),
+      emit("item.delta", { itemId: "r1", stream: "reasoning_summary", index: 1, delta: "e" }),
+    ];
+
+    expect(coalesceSessionEvents(events)).toHaveLength(5);
+  });
+
+  test("barriers stop coalescing runs — order is never rearranged", () => {
+    const emit = emitter();
+    const events = [
+      emit("item.delta", { itemId: "m1", stream: "text", delta: "a" }),
+      emit("item.started", {
+        item: { kind: "tool_call", itemId: "t1", name: "run", status: "pending" },
+      }),
+      emit("item.delta", { itemId: "m1", stream: "text", delta: "b" }),
+    ];
+
+    const coalesced = coalesceSessionEvents(events);
+
+    expect(coalesced).toHaveLength(3);
+    expect(coalesced.map((event) => event.kind)).toEqual([
+      "item.delta",
+      "item.started",
+      "item.delta",
+    ]);
+  });
+
+  test("adjacent item.updated patches merge with later fields winning", () => {
+    const emit = emitter();
+    const events = [
+      emit("item.updated", {
+        itemId: "t1",
+        kind: "tool_call",
+        patch: { status: "in_progress", progressMessage: "10%" },
+      }),
+      emit("item.updated", {
+        itemId: "t1",
+        kind: "tool_call",
+        patch: { progressMessage: "90%", durationMs: 100 },
+      }),
+    ];
+
+    const coalesced = coalesceSessionEvents(events);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced[0]?.payload).toMatchObject({
+      patch: { status: "in_progress", progressMessage: "90%", durationMs: 100 },
+    });
+  });
+
+  test("adjacent usage.updated snapshots keep the last", () => {
+    const emit = emitter();
+    const events = [
+      emit("usage.updated", { tokens: { input: 1, output: 1, total: 2 } }),
+      emit("usage.updated", { tokens: { input: 5, output: 3, total: 8 } }),
+    ];
+
+    const coalesced = coalesceSessionEvents(events);
+
+    expect(coalesced).toHaveLength(1);
+    expect(coalesced[0]?.payload).toMatchObject({ tokens: { total: 8 } });
+  });
+
+  test("events from different turns never merge", () => {
+    const events = factory();
+    const first = events.emit(
+      "item.delta",
+      { itemId: "m1", stream: "text", delta: "a" },
+      { turnId: TURN_ID },
+    );
+    const second = events.emit(
+      "item.delta",
+      { itemId: "m1", stream: "text", delta: "b" },
+      { turnId: "01J0000000000000000000000P" },
+    );
+
+    expect(coalesceSessionEvents([first, second])).toHaveLength(2);
+  });
+
+  test("classifies coalescible kinds", () => {
+    expect(isCoalescibleKind("item.delta")).toBe(true);
+    expect(isCoalescibleKind("item.updated")).toBe(true);
+    expect(isCoalescibleKind("usage.updated")).toBe(true);
+    expect(isCoalescibleKind("item.started")).toBe(false);
+    expect(isCoalescibleKind("turn.completed")).toBe(false);
+  });
+});
+
+describe("createSessionEventBuffer", () => {
+  test("buffers coalescible events until the delay elapses", async () => {
+    const emit = emitter();
+    const batches: SessionEvent[][] = [];
+    const buffer = createSessionEventBuffer({
+      maxDelayMs: 5,
+      flush: (events) => {
+        batches.push(events);
+      },
+    });
+
+    buffer.push(emit("item.delta", { itemId: "m1", stream: "text", delta: "he" }));
+    buffer.push(emit("item.delta", { itemId: "m1", stream: "text", delta: "llo" }));
+
+    expect(batches).toHaveLength(0);
+    expect(buffer.size()).toBe(2);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0]?.[0]?.payload).toMatchObject({ delta: "hello" });
+  });
+
+  test("barrier kinds flush the whole buffer immediately, in order", async () => {
+    const emit = emitter();
+    const batches: SessionEvent[][] = [];
+    const buffer = createSessionEventBuffer({
+      maxDelayMs: 1000,
+      flush: (events) => {
+        batches.push(events);
+      },
+    });
+
+    buffer.push(emit("item.delta", { itemId: "m1", stream: "text", delta: "hi" }));
+    buffer.push(
+      emit("item.completed", {
+        item: {
+          kind: "message",
+          itemId: "m1",
+          role: "agent",
+          content: [{ type: "text", text: "hi" }],
+        },
+      }),
+    );
+
+    await buffer.flush();
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.map((event) => event.kind)).toEqual(["item.delta", "item.completed"]);
+  });
+
+  test("flushes when maxCount is reached", async () => {
+    const emit = emitter();
+    const batches: SessionEvent[][] = [];
+    const buffer = createSessionEventBuffer({
+      maxDelayMs: 1000,
+      maxCount: 3,
+      flush: (events) => {
+        batches.push(events);
+      },
+    });
+
+    for (const delta of ["a", "b", "c"]) {
+      buffer.push(emit("item.delta", { itemId: "m1", stream: "text", delta }));
+    }
+
+    await buffer.flush();
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.[0]?.payload).toMatchObject({ delta: "abc" });
+  });
+
+  test("serializes flushes and reports background errors", async () => {
+    const emit = emitter();
+    const errors: unknown[] = [];
+    const flushed: string[] = [];
+    let fail = true;
+    const buffer = createSessionEventBuffer({
+      maxDelayMs: 1,
+      flush: async (events) => {
+        if (fail) {
+          fail = false;
+          throw new Error("uplink down");
+        }
+
+        flushed.push(...events.map((event) => event.kind));
+      },
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+
+    buffer.push(emit("turn.started", {}));
+    buffer.push(emit("turn.completed", { status: "completed" }));
+    await buffer.flush();
+
+    expect(errors).toHaveLength(1);
+    expect(flushed).toEqual(["turn.completed"]);
+  });
+});

--- a/tests/contract-commands.test.ts
+++ b/tests/contract-commands.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCommandUpdate, parseSessionCommand } from "../src/contract";
+
+const ID = "01J0000000000000000000000A";
+const TURN_ID = "01J0000000000000000000000N";
+
+describe("session commands", () => {
+  test("turn.start takes multimodal content-block input", () => {
+    const command = parseSessionCommand({
+      kind: "turn.start",
+      id: ID,
+      turnId: TURN_ID,
+      input: [
+        { type: "text", text: "fix the bug in" },
+        { type: "resource_link", uri: "file:///w/a.ts", name: "a.ts" },
+        { type: "image", mimeType: "image/png", data: "aGk=" },
+      ],
+    });
+
+    expect(command.kind).toBe("turn.start");
+
+    if (command.kind === "turn.start") {
+      expect(command.input).toHaveLength(3);
+    }
+
+    expect(() =>
+      parseSessionCommand({ kind: "turn.start", id: ID, turnId: TURN_ID, input: [] }),
+    ).toThrow();
+  });
+
+  test("turn.steer and turn.cancel drive an in-flight turn", () => {
+    expect(
+      parseSessionCommand({
+        kind: "turn.steer",
+        id: ID,
+        turnId: TURN_ID,
+        input: [{ type: "text", text: "also add a test" }],
+      }).kind,
+    ).toBe("turn.steer");
+
+    expect(
+      parseSessionCommand({ kind: "turn.cancel", id: ID, reason: "user interrupt" }).kind,
+    ).toBe("turn.cancel");
+  });
+
+  test("session.config.set carries typed values", () => {
+    for (const value of [
+      { type: "select", valueId: "claude-fable-5" },
+      { type: "boolean", value: true },
+      { type: "x_slider", amount: 0.7 },
+    ]) {
+      const command = parseSessionCommand({
+        kind: "session.config.set",
+        id: ID,
+        configId: "model",
+        value,
+      });
+      expect(command.kind).toBe("session.config.set");
+    }
+  });
+
+  test("permission.resolve and input.resolve answer interaction requests", () => {
+    const permission = parseSessionCommand({
+      kind: "permission.resolve",
+      id: ID,
+      requestId: "req-1",
+      outcome: { type: "selected", optionId: "allow_always" },
+    });
+    expect(permission.kind).toBe("permission.resolve");
+
+    const input = parseSessionCommand({
+      kind: "input.resolve",
+      id: ID,
+      requestId: "req-2",
+      outcome: { type: "answered", answers: { q1: ["work"] } },
+    });
+    expect(input.kind).toBe("input.resolve");
+  });
+
+  test("mcp.execute takes structured arguments", () => {
+    const command = parseSessionCommand({
+      kind: "mcp.execute",
+      id: ID,
+      requestId: "req-3",
+      serverId: "docs",
+      toolName: "search",
+      arguments: { query: "contract", limit: 5 },
+    });
+
+    expect(command.kind).toBe("mcp.execute");
+  });
+
+  test("rejects unknown command kinds and malformed commands", () => {
+    expect(() => parseSessionCommand({ kind: "session.hibernate", id: ID })).toThrow();
+    expect(() => parseSessionCommand({ kind: "session.stop", id: ID, reason: "" })).toThrow();
+    expect(() =>
+      parseSessionCommand({ kind: "turn.start", id: "nope", turnId: TURN_ID }),
+    ).toThrow();
+  });
+});
+
+describe("command updates", () => {
+  test("reports command fate with typed results", () => {
+    const update = parseCommandUpdate({
+      commandId: ID,
+      status: "completed",
+      result: { content: [{ type: "text", text: "ok" }], isError: false },
+    });
+
+    expect(update.status).toBe("completed");
+  });
+
+  test("failed updates require an error", () => {
+    expect(() => parseCommandUpdate({ commandId: ID, status: "failed" })).toThrow();
+
+    const update = parseCommandUpdate({
+      commandId: ID,
+      status: "failed",
+      error: { code: "driver.mcp_execute_failed", message: "server unreachable", retryable: true },
+    });
+    expect(update.error?.code).toBe("driver.mcp_execute_failed");
+  });
+});

--- a/tests/contract-events.test.ts
+++ b/tests/contract-events.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONTRACT_VERSION,
+  SESSION_EVENT_KINDS,
+  admitSessionEvent,
+  createSessionEventFactory,
+  deliveryOf,
+  isKnownSessionEventKind,
+  parseSessionEvent,
+  visibilityOf,
+} from "../src/contract";
+import type { SessionEvent, SessionEventKind } from "../src/contract";
+import { createDriverId } from "../src/protocol/id";
+
+const SESSION_ID = "01J0000000000000000000000K";
+const TURN_ID = "01J0000000000000000000000N";
+const AT = "2026-07-13T00:00:00.000Z";
+
+function envelope(kind: SessionEventKind, payload: unknown, turnId?: string): unknown {
+  return {
+    id: "01J0000000000000000000000G",
+    seq: 1,
+    sessionId: SESSION_ID,
+    ...(turnId === undefined ? {} : { turnId }),
+    at: AT,
+    kind,
+    payload,
+  };
+}
+
+describe("session event envelope", () => {
+  test("contract version is a bare integer", () => {
+    expect(CONTRACT_VERSION).toBe(2);
+  });
+
+  test("parses a minimal session-plane event", () => {
+    const event = parseSessionEvent(envelope("session.started", { resumed: false }));
+
+    expect(event.kind).toBe("session.started");
+    expect(event.seq).toBe(1);
+    expect(event.payload).toEqual({ resumed: false });
+  });
+
+  test("rejects malformed envelopes", () => {
+    expect(() => parseSessionEvent(null)).toThrow();
+    expect(() => parseSessionEvent({})).toThrow();
+    expect(() =>
+      parseSessionEvent({ ...(envelope("turn.started", {}, TURN_ID) as object), seq: -1 }),
+    ).toThrow();
+    expect(() =>
+      parseSessionEvent({ ...(envelope("turn.started", {}, TURN_ID) as object), sessionId: "x" }),
+    ).toThrow();
+    expect(() =>
+      parseSessionEvent({ ...(envelope("turn.started", {}, TURN_ID) as object), at: "yesterday" }),
+    ).toThrow();
+  });
+
+  test("turn-scoped kinds require turnId", () => {
+    expect(() => parseSessionEvent(envelope("turn.started", {}))).toThrow(/turnId/);
+    expect(() =>
+      parseSessionEvent(envelope("item.delta", { itemId: "i1", stream: "text", delta: "hi" })),
+    ).toThrow(/turnId/);
+    expect(parseSessionEvent(envelope("turn.started", {}, TURN_ID)).turnId).toBe(TURN_ID);
+  });
+
+  test("strict on known kinds, open on unknown kinds", () => {
+    expect(() =>
+      parseSessionEvent(envelope("turn.completed", { status: "nope" }, TURN_ID)),
+    ).toThrow();
+
+    const extension = parseSessionEvent(
+      envelope("x_codex.turn.diff", { diff: "--- a\n+++ b" }, undefined),
+    );
+    expect(extension.payload).toEqual({ diff: "--- a\n+++ b" });
+
+    const future = parseSessionEvent(envelope("session.renamed", { title: "hi" }));
+    expect(future.kind).toBe("session.renamed");
+  });
+
+  test("unknown envelope fields are preserved", () => {
+    const raw = { ...(envelope("session.started", { resumed: true }) as object), futureField: 7 };
+    const event = parseSessionEvent(raw) as SessionEvent & { futureField?: number };
+
+    expect(event.futureField).toBe(7);
+  });
+
+  test("admitSessionEvent returns a rejection instead of throwing", () => {
+    const outcome = admitSessionEvent({ kind: "item.delta" });
+
+    expect(outcome.status).toBe("rejected");
+
+    if (outcome.status === "rejected") {
+      expect(outcome.reason.code).toBe("malformed_event");
+      expect(outcome.reason.message.length).toBeGreaterThan(0);
+    }
+
+    const accepted = admitSessionEvent(envelope("session.started", { resumed: false }));
+    expect(accepted.status).toBe("accepted");
+  });
+});
+
+describe("session event payloads", () => {
+  test("turn.completed requires an error when failed", () => {
+    expect(() =>
+      parseSessionEvent(envelope("turn.completed", { status: "failed" }, TURN_ID)),
+    ).toThrow();
+
+    const event = parseSessionEvent(
+      envelope(
+        "turn.completed",
+        {
+          status: "failed",
+          stopReason: "cancelled",
+          error: { code: "provider.crash", message: "boom", retryable: false },
+        },
+        TURN_ID,
+      ),
+    );
+    expect(event.payload).toMatchObject({ status: "failed", error: { code: "provider.crash" } });
+  });
+
+  test("usage.updated carries cumulative + last tokens, context, and cost", () => {
+    const event = parseSessionEvent(
+      envelope("usage.updated", {
+        tokens: { input: 100, cachedInput: 40, output: 20, reasoningOutput: 5, total: 125 },
+        lastTokens: { input: 10, output: 2, total: 12 },
+        context: { usedTokens: 5000, maxTokens: 200000 },
+        cost: { amount: 0.02, currency: "USD" },
+      }),
+    );
+
+    expect(event.payload).toMatchObject({
+      tokens: { total: 125 },
+      context: { maxTokens: 200000 },
+    });
+  });
+
+  test("permission.requested needs at least one option", () => {
+    const base = {
+      requestId: "req-1",
+      title: "Run this command?",
+      detail: { type: "command", command: "rm -rf build", cwd: "/workspace" },
+    };
+
+    expect(() =>
+      parseSessionEvent(envelope("permission.requested", { ...base, options: [] }, TURN_ID)),
+    ).toThrow();
+
+    const event = parseSessionEvent(
+      envelope(
+        "permission.requested",
+        {
+          ...base,
+          options: [
+            { optionId: "yes", name: "Allow once", kind: "allow_once" },
+            { optionId: "always", name: "Always", kind: "allow_always" },
+          ],
+        },
+        TURN_ID,
+      ),
+    );
+    expect(event.payload).toMatchObject({ detail: { type: "command" } });
+  });
+
+  test("permission.resolved accepts open outcomes", () => {
+    for (const outcome of [
+      { type: "selected", optionId: "yes" },
+      { type: "cancelled" },
+      { type: "timeout" },
+      { type: "x_vendor_deferred", queue: "later" },
+    ]) {
+      const event = parseSessionEvent(
+        envelope("permission.resolved", { requestId: "req-1", outcome }, TURN_ID),
+      );
+      expect(event.payload).toMatchObject({ requestId: "req-1" });
+    }
+  });
+
+  test("input.requested models codex request_user_input questions", () => {
+    const event = parseSessionEvent(
+      envelope("input.requested", {
+        requestId: "req-2",
+        questions: [
+          {
+            questionId: "q1",
+            header: "Auth",
+            question: "Which account?",
+            options: [{ label: "work" }, { label: "personal", description: "gmail" }],
+            allowFreeform: true,
+            secret: false,
+          },
+        ],
+      }),
+    );
+
+    expect(event.payload).toMatchObject({ questions: [{ questionId: "q1" }] });
+  });
+
+  test("item.updated validates typed patches and rejects garbage", () => {
+    const event = parseSessionEvent(
+      envelope(
+        "item.updated",
+        { itemId: "i1", kind: "tool_call", patch: { status: "completed", durationMs: 12 } },
+        TURN_ID,
+      ),
+    );
+    expect(event.payload).toMatchObject({ patch: { status: "completed" } });
+
+    expect(() =>
+      parseSessionEvent(
+        envelope(
+          "item.updated",
+          { itemId: "i1", kind: "tool_call", patch: { durationMs: "fast" } },
+          TURN_ID,
+        ),
+      ),
+    ).toThrow();
+
+    const unknownKind = parseSessionEvent(
+      envelope(
+        "item.updated",
+        { itemId: "i1", kind: "x_web_search", patch: { results: 3 } },
+        TURN_ID,
+      ),
+    );
+    expect(unknownKind.payload).toMatchObject({ patch: { results: 3 } });
+  });
+
+  test("item.delta carries stream + optional index for parallel parts", () => {
+    const event = parseSessionEvent(
+      envelope(
+        "item.delta",
+        { itemId: "r1", stream: "reasoning_summary", index: 2, delta: "…" },
+        TURN_ID,
+      ),
+    );
+    expect(event.payload).toMatchObject({ stream: "reasoning_summary", index: 2 });
+
+    expect(() =>
+      parseSessionEvent(envelope("item.delta", { itemId: "r1", stream: "" }, TURN_ID)),
+    ).toThrow();
+  });
+
+  test("session.config.updated speaks ACP v2 config options", () => {
+    const event = parseSessionEvent(
+      envelope("session.config.updated", {
+        options: [
+          {
+            configId: "model",
+            name: "Model",
+            category: "model",
+            type: "select",
+            currentValueId: "gpt-6",
+            options: [{ valueId: "gpt-6", name: "GPT-6" }],
+          },
+          { configId: "web", name: "Web search", type: "boolean", currentValue: true },
+        ],
+      }),
+    );
+
+    expect(event.payload).toMatchObject({ options: [{ type: "select" }, { type: "boolean" }] });
+  });
+
+  test("diagnostic and timing land in the ops plane", () => {
+    const diagnostic = parseSessionEvent(
+      envelope("diagnostic.reported", {
+        severity: "warning",
+        code: "provider.rate_limited",
+        message: "slow down",
+        retryable: true,
+      }),
+    );
+    const timing = parseSessionEvent(
+      envelope("timing.recorded", {
+        stage: "driver_backend",
+        path: "cold",
+        startedAtMs: 100,
+        totalMs: 350,
+        phases: [{ name: "spawn", durationMs: 200 }],
+      }),
+    );
+
+    expect(visibilityOf(diagnostic.kind)).toBe("owner_debug");
+    expect(visibilityOf(timing.kind)).toBe("owner_debug");
+    expect(visibilityOf("item.delta")).toBe("participant");
+  });
+});
+
+describe("classification", () => {
+  test("only item.delta is best-effort", () => {
+    for (const kind of SESSION_EVENT_KINDS) {
+      expect(deliveryOf(kind)).toBe(kind === "item.delta" ? "best_effort" : "lossless");
+    }
+  });
+
+  test("kind registry is consistent", () => {
+    expect(SESSION_EVENT_KINDS.length).toBe(17);
+
+    for (const kind of SESSION_EVENT_KINDS) {
+      expect(isKnownSessionEventKind(kind)).toBe(true);
+    }
+
+    expect(isKnownSessionEventKind("x_anything")).toBe(false);
+  });
+});
+
+describe("session event factory", () => {
+  test("assigns ids, monotonic seq, timestamps, and validates payloads", () => {
+    const factory = createSessionEventFactory({
+      sessionId: SESSION_ID,
+      createId: () => createDriverId(),
+      traceId: "trace-1",
+    });
+
+    const first = factory.emit("session.started", { resumed: false });
+    const second = factory.emit(
+      "item.delta",
+      { itemId: "m1", stream: "text", delta: "hello" },
+      { turnId: TURN_ID },
+    );
+
+    expect(first.seq).toBe(0);
+    expect(second.seq).toBe(1);
+    expect(second.turnId).toBe(TURN_ID);
+    expect(second.traceId).toBe("trace-1");
+    expect(() => factory.emit("turn.started", {})).toThrow(/turnId/);
+  });
+});

--- a/tests/contract-granularity.test.ts
+++ b/tests/contract-granularity.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, test } from "bun:test";
+
+import { createSessionEventFactory, parseSessionEvent } from "../src/contract";
+import type { SessionEventFactory } from "../src/contract";
+import { createDriverId } from "../src/protocol/id";
+
+/**
+ * Conformance evidence for docs/contract.md: representative native payloads
+ * from Codex app-server v2 and ACP v2 map onto the contract WITHOUT losing a
+ * field. These are the mappings the future protocol adapters implement.
+ */
+
+const SESSION_ID = "01J0000000000000000000000K";
+const TURN_ID = "01J0000000000000000000000N";
+
+function factory(): SessionEventFactory {
+  return createSessionEventFactory({ sessionId: SESSION_ID, createId: () => createDriverId() });
+}
+
+describe("codex app-server v2 granularity", () => {
+  test("item/started commandExecution keeps every codex field", () => {
+    // Native: item/started { item: { type: "commandExecution", ... } }
+    const native = {
+      id: "item_3",
+      command: "rg --files -g '*.rs' | head",
+      cwd: "/workspace/codex",
+      processId: "pty-11",
+      source: "agent",
+      status: "inProgress",
+      commandActions: [{ type: "search", command: "rg --files -g '*.rs'" }],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+
+    const event = factory().emit(
+      "item.started",
+      {
+        item: {
+          kind: "command",
+          itemId: native.id,
+          command: native.command,
+          cwd: native.cwd,
+          processId: native.processId,
+          source: "agent",
+          status: "in_progress",
+          actions: [{ type: "search", command: "rg --files -g '*.rs'" }],
+        },
+      },
+      {
+        turnId: TURN_ID,
+        native: { provider: "openai-app-server", eventName: "item/started", itemId: native.id },
+      },
+    );
+
+    expect(event.payload.item).toMatchObject({
+      command: native.command,
+      cwd: native.cwd,
+      processId: native.processId,
+    });
+    expect(event.native?.eventName).toBe("item/started");
+  });
+
+  test("reasoning summary/content deltas keep their part indices", () => {
+    const events = factory();
+    // Native: item/reasoning/summaryTextDelta { itemId, delta, summaryIndex: 1 }
+    const summary = events.emit(
+      "item.delta",
+      { itemId: "item_5", stream: "reasoning_summary", index: 1, delta: "Weighing options…" },
+      { turnId: TURN_ID },
+    );
+    // Native: item/reasoning/textDelta { itemId, delta, contentIndex: 0 } —
+    // the old contract DROPPED this stream entirely.
+    const raw = events.emit(
+      "item.delta",
+      { itemId: "item_5", stream: "reasoning", index: 0, delta: "The allocator must…" },
+      { turnId: TURN_ID },
+    );
+
+    expect(summary.payload.index).toBe(1);
+    expect(raw.payload.stream).toBe("reasoning");
+  });
+
+  test("command approval request keeps codex decision granularity via options", () => {
+    // Native: item/commandExecution/requestApproval with proposed amendments
+    // and availableDecisions [accept, acceptForSession,
+    // acceptWithExecpolicyAmendment, decline, cancel].
+    const event = factory().emit(
+      "permission.requested",
+      {
+        requestId: "req_9",
+        itemId: "item_3",
+        title: "Run `cargo test`?",
+        description: "Requires network access",
+        detail: {
+          type: "command",
+          command: "cargo test",
+          cwd: "/workspace/codex",
+          reason: "network access",
+        },
+        options: [
+          { optionId: "accept", name: "Allow once", kind: "allow_once" },
+          { optionId: "acceptForSession", name: "Allow for session", kind: "allow_always" },
+          {
+            optionId: "acceptWithExecpolicyAmendment",
+            name: "Always allow cargo test",
+            kind: "allow_always",
+            meta: { execpolicyAmendment: ["cargo", "test"] },
+          },
+          { optionId: "decline", name: "Decline", kind: "reject_once" },
+          {
+            optionId: "cancel",
+            name: "Cancel turn",
+            kind: "reject_once",
+            meta: { interrupts: true },
+          },
+        ],
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.options).toHaveLength(5);
+    expect(event.payload.options[2]?.meta).toEqual({ execpolicyAmendment: ["cargo", "test"] });
+  });
+
+  test("request_user_input maps onto input.requested without loss", () => {
+    // Native: item/tool/requestUserInput { questions: [{ id, header, question,
+    // isSecret, options }] }
+    const event = factory().emit(
+      "input.requested",
+      {
+        requestId: "req_12",
+        itemId: "item_8",
+        questions: [
+          {
+            questionId: "q_env",
+            header: "Environment",
+            question: "Which environment should I deploy to?",
+            options: [
+              { label: "staging", description: "safe" },
+              { label: "production", description: "careful" },
+            ],
+            allowFreeform: false,
+            secret: false,
+          },
+        ],
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.questions[0]).toMatchObject({ header: "Environment" });
+  });
+
+  test("codex items outside the typed core survive as extension items", () => {
+    // Native: item/completed { item: { type: "webSearch", id, query, action } }
+    const event = factory().emit(
+      "item.completed",
+      {
+        item: {
+          kind: "x_codex_web_search",
+          itemId: "item_9",
+          status: "completed",
+          payload: { query: "bun ffi", action: { type: "openPage", url: "https://bun.sh" } },
+        },
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.item).toMatchObject({
+      payload: { action: { type: "openPage", url: "https://bun.sh" } },
+    });
+  });
+
+  test("thread/tokenUsage/updated keeps total + last breakdowns and context window", () => {
+    const event = factory().emit("usage.updated", {
+      tokens: { input: 5000, cachedInput: 4000, output: 800, reasoningOutput: 300, total: 5800 },
+      lastTokens: { input: 900, cachedInput: 700, output: 120, reasoningOutput: 40, total: 1020 },
+      context: { usedTokens: 5800, maxTokens: 272000 },
+    });
+
+    expect(event.payload.lastTokens?.reasoningOutput).toBe(40);
+    expect(event.payload.context?.maxTokens).toBe(272000);
+  });
+
+  test("turn failure carries codexErrorInfo-grade detail", () => {
+    const event = factory().emit(
+      "turn.completed",
+      {
+        status: "failed",
+        error: {
+          code: "codex.response_stream_connection_failed",
+          message: "stream disconnected",
+          retryable: true,
+          detail: { httpStatusCode: 502 },
+        },
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.error?.detail).toEqual({ httpStatusCode: 502 });
+  });
+});
+
+describe("ACP v2 granularity", () => {
+  test("tool_call_update upsert maps to item.updated with full field fidelity", () => {
+    // Native: session/update { sessionUpdate: "tool_call_update", toolCallId,
+    // title, kind, status, locations, rawInput }
+    const event = factory().emit(
+      "item.updated",
+      {
+        itemId: "call_001",
+        kind: "tool_call",
+        patch: {
+          title: "Reading configuration",
+          category: "read",
+          status: "in_progress",
+          locations: [{ path: "/workspace/config.toml", line: 12 }],
+          input: { path: "/workspace/config.toml" },
+        },
+      },
+      { turnId: TURN_ID, native: { provider: "acp", eventName: "tool_call_update" } },
+    );
+
+    expect(event.payload.patch).toMatchObject({
+      category: "read",
+      locations: [{ path: "/workspace/config.toml", line: 12 }],
+    });
+  });
+
+  test("structured content blocks survive end to end (no string flattening)", () => {
+    // Native: agent_message_chunk { content: { type: "image", data, mimeType } }
+    const event = factory().emit(
+      "item.completed",
+      {
+        item: {
+          kind: "message",
+          itemId: "msg_2",
+          role: "agent",
+          content: [
+            { type: "text", text: "rendered chart:" },
+            { type: "image", mimeType: "image/png", data: "aGk=" },
+            {
+              type: "resource",
+              resource: { uri: "file:///w/report.md", mimeType: "text/markdown", text: "# Report" },
+            },
+          ],
+        },
+      },
+      { turnId: TURN_ID },
+    );
+
+    const item = event.payload.item;
+    expect(item.kind).toBe("message");
+
+    if (item.kind === "message") {
+      expect(item.content[1]).toMatchObject({ type: "image", mimeType: "image/png" });
+      expect(item.content[2]).toMatchObject({ resource: { text: "# Report" } });
+    }
+  });
+
+  test("ACP v2 structured diffs map to file_change items", () => {
+    // Native: tool_call content { type: "diff", changes: [...], patch: { format:
+    // "git_patch", diff } }
+    const event = factory().emit(
+      "item.completed",
+      {
+        item: {
+          kind: "file_change",
+          itemId: "call_7",
+          status: "completed",
+          changes: [
+            { path: "/w/old_file.txt", op: "delete", fileType: "text" },
+            { path: "/w/renamed.ts", op: "move", oldPath: "/w/original.ts", fileType: "text" },
+            { path: "/w/logo.png", op: "add", fileType: "binary", diff: null },
+          ],
+          meta: { patchFormat: "git_patch" },
+        },
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.item).toMatchObject({
+      changes: [{ op: "delete" }, { oldPath: "/w/original.ts" }, { fileType: "binary" }],
+    });
+  });
+
+  test("plan_update replaces entries per plan id", () => {
+    const event = factory().emit(
+      "item.updated",
+      {
+        itemId: "plan_main",
+        kind: "plan",
+        patch: {
+          entries: [
+            { content: "Check for syntax errors", status: "completed", priority: "high" },
+            { content: "Identify the root cause", status: "in_progress", priority: "high" },
+          ],
+        },
+      },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.patch["entries"]).toHaveLength(2);
+  });
+
+  test("session config options and available commands round-trip", () => {
+    const events = factory();
+    const config = events.emit("session.config.updated", {
+      options: [
+        {
+          configId: "mode",
+          name: "Mode",
+          category: "mode",
+          type: "select",
+          currentValueId: "code",
+          options: [
+            { valueId: "ask", name: "Ask" },
+            { valueId: "code", name: "Code" },
+          ],
+        },
+      ],
+    });
+    const commands = events.emit("session.commands.updated", {
+      commands: [{ name: "web", description: "Search the web", inputHint: "query" }],
+    });
+
+    expect(config.payload.options[0]).toMatchObject({ currentValueId: "code" });
+    expect(commands.payload.commands[0]).toMatchObject({ name: "web" });
+  });
+
+  test("state_update stop reasons survive on turn.completed", () => {
+    const event = factory().emit(
+      "turn.completed",
+      { status: "completed", stopReason: "max_turns" },
+      { turnId: TURN_ID },
+    );
+
+    expect(event.payload.stopReason).toBe("max_turns");
+  });
+
+  test("unknown ACP session updates flow through as extension events", () => {
+    // Native: a future or _vendor sessionUpdate discriminant the driver does
+    // not know. Adapters forward it without interpretation.
+    const raw = {
+      id: createDriverId(),
+      seq: 40,
+      sessionId: SESSION_ID,
+      at: "2026-07-13T00:00:00.000Z",
+      kind: "x_acp_session_update",
+      payload: { sessionUpdate: "_zed_prediction", confidence: 0.9 },
+      native: { provider: "acp", eventName: "_zed_prediction" },
+    };
+
+    const event = parseSessionEvent(raw);
+
+    expect(event.payload).toMatchObject({ confidence: 0.9 });
+  });
+});

--- a/tests/contract-items.test.ts
+++ b/tests/contract-items.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applySessionItemPatch,
+  contentBlockText,
+  parseSessionItem,
+  parseSessionItemPatch,
+} from "../src/contract";
+import type { MessageItem, ToolCallItem } from "../src/contract";
+
+describe("session items", () => {
+  test("message item carries structured content blocks", () => {
+    const item = parseSessionItem({
+      kind: "message",
+      itemId: "m1",
+      role: "agent",
+      phase: "final",
+      content: [
+        { type: "text", text: "see the diagram" },
+        { type: "image", mimeType: "image/png", data: "aGk=" },
+        { type: "resource_link", uri: "file:///workspace/a.ts", name: "a.ts" },
+      ],
+    }) as MessageItem;
+
+    expect(item.role).toBe("agent");
+    expect(item.content).toHaveLength(3);
+    expect(contentBlockText(item.content[0])).toBe("see the diagram");
+    expect(contentBlockText(item.content[1])).toBe("[image]");
+    expect(contentBlockText(item.content[2])).toBe("[resource_link: a.ts]");
+  });
+
+  test("image content requires data or uri", () => {
+    expect(() =>
+      parseSessionItem({
+        kind: "message",
+        itemId: "m1",
+        role: "user",
+        content: [{ type: "image", mimeType: "image/png" }],
+      }),
+    ).toThrow();
+  });
+
+  test("reasoning item keeps indexed summary and content parts", () => {
+    const item = parseSessionItem({
+      kind: "reasoning",
+      itemId: "r1",
+      summary: ["first section", "second section"],
+      content: ["raw chain of thought"],
+    });
+
+    expect(item).toMatchObject({ summary: ["first section", "second section"] });
+  });
+
+  test("plan item entries carry status and priority", () => {
+    const item = parseSessionItem({
+      kind: "plan",
+      itemId: "p1",
+      entries: [
+        { content: "read the code", status: "completed", priority: "high" },
+        { content: "write the fix", status: "in_progress" },
+      ],
+    });
+
+    expect(item).toMatchObject({ entries: [{ status: "completed" }, { status: "in_progress" }] });
+  });
+
+  test("command item covers codex commandExecution granularity", () => {
+    const item = parseSessionItem({
+      kind: "command",
+      itemId: "c1",
+      command: "rg --files | head",
+      cwd: "/workspace",
+      status: "completed",
+      actions: [
+        { type: "search", command: "rg --files" },
+        { type: "unknown", command: "head" },
+      ],
+      output: "a.ts\nb.ts\n",
+      exitCode: 0,
+      durationMs: 42,
+      processId: "pty-7",
+      source: "agent",
+    });
+
+    expect(item).toMatchObject({ exitCode: 0, actions: [{ type: "search" }, { type: "unknown" }] });
+  });
+
+  test("file_change item merges codex changes and ACP v2 diff ops", () => {
+    const item = parseSessionItem({
+      kind: "file_change",
+      itemId: "f1",
+      status: "completed",
+      changes: [
+        { path: "/w/a.ts", op: "modify", diff: "--- a\n+++ b\n" },
+        { path: "/w/b.png", op: "add", fileType: "binary", diff: null },
+        { path: "/w/new.ts", op: "move", oldPath: "/w/old.ts" },
+      ],
+    });
+
+    expect(item).toMatchObject({
+      changes: [{ op: "modify" }, { fileType: "binary" }, { op: "move" }],
+    });
+    expect(() =>
+      parseSessionItem({ kind: "file_change", itemId: "f1", status: "completed", changes: [] }),
+    ).toThrow();
+  });
+
+  test("tool_call item keeps ACP classification and MCP-shaped output", () => {
+    const item = parseSessionItem({
+      kind: "tool_call",
+      itemId: "t1",
+      name: "search_docs",
+      title: "Searching docs",
+      category: "search",
+      origin: "mcp",
+      server: "docs",
+      status: "completed",
+      input: { query: "contract" },
+      output: {
+        content: [{ type: "text", text: "3 results" }],
+        structured: { hits: 3 },
+        isError: false,
+      },
+      locations: [{ path: "/w/docs/contract.md", line: 12 }],
+      progressMessage: "done",
+      durationMs: 88,
+    }) as ToolCallItem;
+
+    expect(item.output?.structured).toEqual({ hits: 3 });
+    expect(item.locations).toEqual([{ path: "/w/docs/contract.md", line: 12 }]);
+  });
+
+  test("extension items carry vendor granularity", () => {
+    const item = parseSessionItem({
+      kind: "x_codex_web_search",
+      itemId: "w1",
+      status: "completed",
+      payload: { query: "zig allocator", action: { type: "search" } },
+    });
+
+    expect(item).toMatchObject({ kind: "x_codex_web_search" });
+
+    const future = parseSessionItem({ kind: "hologram", itemId: "h1" });
+    expect(future.kind).toBe("hologram");
+  });
+
+  test("rejects malformed typed items loudly", () => {
+    expect(() =>
+      parseSessionItem({ kind: "message", itemId: "m1", role: "bot", content: [] }),
+    ).toThrow();
+    expect(() => parseSessionItem({ kind: "tool_call", itemId: "t1" })).toThrow();
+    expect(() => parseSessionItem({ itemId: "t1" })).toThrow();
+  });
+});
+
+describe("item patches", () => {
+  test("typed patches validate against the item schema minus identity", () => {
+    expect(parseSessionItemPatch("command", { status: "completed", exitCode: 1 })).toEqual({
+      status: "completed",
+      exitCode: 1,
+    });
+    expect(() => parseSessionItemPatch("command", { exitCode: "one" })).toThrow();
+    expect(parseSessionItemPatch("x_custom", { anything: true })).toEqual({ anything: true });
+  });
+
+  test("applySessionItemPatch replaces per-field and preserves identity", () => {
+    const item = parseSessionItem({
+      kind: "tool_call",
+      itemId: "t1",
+      name: "run",
+      status: "in_progress",
+      input: { a: 1 },
+    }) as ToolCallItem;
+
+    const patched = applySessionItemPatch(item, {
+      status: "completed",
+      itemId: "hijack",
+      kind: "message",
+    });
+
+    expect(patched.itemId).toBe("t1");
+    expect(patched.kind).toBe("tool_call");
+    expect(patched.status).toBe("completed");
+    expect(patched.input).toEqual({ a: 1 });
+  });
+});

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -30,6 +30,7 @@ const PUBLIC_EXPORTS = [
   "./boot",
   "./cma-http",
   "./cma-sdk",
+  "./contract",
   "./events",
   "./orpc",
   "./paths",

--- a/tests/driver-logger.test.ts
+++ b/tests/driver-logger.test.ts
@@ -77,10 +77,10 @@ describe("createDriverLogger", () => {
 
     const stderrWrites: string[] = [];
     const originalWrite = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: string | Uint8Array) => {
+    process.stderr.write = (chunk: string | Uint8Array) => {
       stderrWrites.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
       return true;
-    }) as typeof process.stderr.write;
+    };
 
     try {
       fake.failNextPush = new Error("Internal server error");

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { DRIVER_PROTOCOL_VERSION as DRIVER_PROTOCOL_VERSION_FROM_BOOT_SUBPATH } from "../src/boot";
 import { createCmaHttpHandler as createCmaHttpHandlerFromSubpath } from "../src/cma-http";
 import { createCmaSdkClient as createCmaSdkClientFromSubpath } from "../src/cma-sdk";
+import {
+  CONTRACT_VERSION as CONTRACT_VERSION_FROM_SUBPATH,
+  parseSessionCommand as parseSessionCommandFromSubpath,
+  parseSessionEvent as parseSessionEventFromSubpath,
+} from "../src/contract";
 import { parseDriverEventEnvelope as parseDriverEventEnvelopeFromSubpath } from "../src/events";
 import {
   AGENT_DRIVER_PROVIDER_REGISTRY,
@@ -59,6 +64,9 @@ describe("public API", () => {
     const heartbeatReason = "ping" satisfies DriverHeartbeatInputFromOrpcSubpath["reason"];
 
     expect(DRIVER_PROTOCOL_VERSION_FROM_BOOT_SUBPATH).toBe(1);
+    expect(CONTRACT_VERSION_FROM_SUBPATH).toBe(2);
+    expect(parseSessionEventFromSubpath).toBeFunction();
+    expect(parseSessionCommandFromSubpath).toBeFunction();
     expect(createCmaHttpHandlerFromSubpath).toBe(createCmaHttpHandler);
     expect(createCmaSdkClientFromSubpath).toBe(createCmaSdkClient);
     expect(parseDriverEventEnvelopeFromSubpath).toBeFunction();


### PR DESCRIPTION
## Summary

Two-part change, delivered as a draft while the kernel/backends/host migration is planned:

### 1. Dependency refresh (all deps to latest)

| package | from | to |
|---|---|---|
| typescript | 6.0.3 | **7.0.2** |
| @types/node | 25.8 | 26.1.1 |
| vite-plus | 0.1.24 | 0.2.4 |
| @anthropic-ai/sdk | 0.100.1 | 0.111.0 |
| @anthropic-ai/claude-agent-sdk | 0.3.205 | 0.3.207 |
| @modelcontextprotocol/client | 2.0.0-beta.2 | 2.0.0-beta.3 |
| @orpc/client | 1.14.6 | 1.14.7 |

Migration fallout was minimal: two type assertions dropped for the stricter `no-unnecessary-type-assertion` lint. `bun@1.3.14` remains the latest stable. Full CI flow (frozen-lockfile install → lint → tc → test → build → artifact) verified on a clean standalone checkout.

### 2. Driver Contract v2 (`agent-driver/contract`, spec in `docs/contract.md`)

A clean, deliberately incompatible redesign of the agent-session event/data contract, synthesized from the **latest Codex app-server protocol** (thread/turn/item model) and **ACP v2** (`protocolVersion: 2`), cross-checked against Claude Agent SDK, AG-UI, Vercel AI SDK streams, and A2A. The old `2026-05-26` runtime-event generation stays wired until the kernel, the three backends, and the host migrate onto v2 via protocol adapters (follow-ups).

Highlights over the old contract:

- **17 typed event kinds + open `x_*` extension rule** replace 107 declared / ~20 emitted untyped kinds; zod v4 schemas are the single source of truth (previously hand-rolled validators duplicated driver/host).
- **One item lifecycle for everything** — `item.started/delta/updated/completed` with authoritative completed snapshots (Codex semantics), covering `message`, `reasoning` (indexed summary/raw parts), `plan`, `command`, `file_change`, `tool_call`, and extension items. Ends the parallel `message.*`-family vs `item.*` split and the `tool.call.updated` field-sniffing mega-event.
- **MCP/ACP-aligned content blocks** end to end (text/image/audio/resource_link/resource) — no more `"[image: …]"` string flattening; multimodal `turn.start`/`turn.steer` input.
- **Interaction plane**: option-based permission requests with typed command/file-change/tool subjects (unknown outcome ≠ approval), plus `input.requested/resolved` for Codex `request_user_input` / MCP elicitation.
- **Transport performance is contract-level**: emitter-assigned per-session `seq`, delta-only `best_effort` classification, normative adjacent-coalescing rules (`coalesceSessionEvents`) and a reference buffer (`createSessionEventBuffer`) so any boundary can batch/merge high-frequency deltas safely.
- Granularity conformance suite maps representative native Codex v2 / ACP v2 payloads onto the contract with zero field loss (`tests/contract-granularity.test.ts`).

## Testing

- `bun run lint` / `bun run tc` / `bun test tests` (256 pass) / `bun run build` — all green, including on a clean `git archive` checkout with `bun install --frozen-lockfile` (the CI flow).
- New contract suite: 63 tests across events/items/commands/buffer/granularity.

## Follow-ups (out of scope here)

- Migrate kernel + ACP/Claude/OpenAI backends to emit Contract v2; adapt the oRPC wire and hello capability negotiation.
- Host-side (`mosoo` repo `pkgs/runtime-events`) migration off the parallel schema copy.
- Retire `src/runtime-events` / `src/runtime-command` once both edges are on v2.