### PR TITLE
fix(openai): preserve app-server error details

### DIFF
--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -23,6 +23,8 @@ interface OpenAiAppServerEventBridgeOptions {
   requireThreadId(): string;
 }
 
+const OPENAI_SYSTEM_ERROR_FALLBACK_DELAY_MS = 100;
+
 function createOpenAiTurnSourceEventId(eventName: string, turnId: string): string {
   return `openai.${eventName}:${turnId}`;
 }
@@ -56,6 +58,7 @@ export class OpenAiAppServerEventBridge {
   readonly #tools = new OpenAiToolState();
   readonly #turns = new OpenAiTurnTracker();
   #runtimeErrorEmitted = false;
+  #systemErrorFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: OpenAiAppServerEventBridgeOptions) {
     this.#options = options;
@@ -73,6 +76,7 @@ export class OpenAiAppServerEventBridge {
   }
 
   clearActiveTurns(): void {
+    this.#clearSystemErrorFallback();
     this.#turns.clearActiveTurns();
   }
 
@@ -89,6 +93,7 @@ export class OpenAiAppServerEventBridge {
   }
 
   resetRuntimeError(): void {
+    this.#clearSystemErrorFallback();
     this.#runtimeErrorEmitted = false;
   }
 
@@ -272,11 +277,12 @@ export class OpenAiAppServerEventBridge {
       threadIdPresent: readString(params, "threadId") !== null,
     });
 
-    if (statusType === "systemError") {
-      await this.#handleRuntimeError(context, {
-        message: "OpenAi app-server thread entered systemError.",
-      });
+    if (statusType !== "systemError") {
+      this.#clearSystemErrorFallback();
+      return;
     }
+
+    this.#scheduleSystemErrorFallback(context);
   }
 
   #handleWarning(context: AgentDriverContext, params: JsonObject): void {
@@ -287,6 +293,7 @@ export class OpenAiAppServerEventBridge {
   }
 
   async #handleRuntimeError(context: AgentDriverContext, params: JsonObject): Promise<void> {
+    this.#clearSystemErrorFallback();
     const error = readRecord(params, "error");
     const message =
       readString(error, "message") ?? readString(params, "message") ?? "OpenAi app-server error.";
@@ -364,6 +371,10 @@ export class OpenAiAppServerEventBridge {
     const error = turn ? readRecord(turn, "error") : null;
     const cancellationReason = this.#turns.takeCancellationReason(turnId);
 
+    if (status !== "inProgress") {
+      this.#clearSystemErrorFallback();
+    }
+
     if (cancellationReason !== null || status === "interrupted") {
       this.#turns.settle(turnId, {
         error: new DriverTurnCancelledError(cancellationReason ?? "OpenAI turn was interrupted."),
@@ -373,7 +384,10 @@ export class OpenAiAppServerEventBridge {
     }
 
     if (status === "failed") {
-      const message = readString(error, "message") ?? "OpenAi turn failed.";
+      const message = toOpenAiErrorMessage(
+        readString(error, "message") ?? "OpenAi turn failed.",
+        readString(error, "additionalDetails"),
+      );
       await this.#push(context, "driver.openai.turn.failed", [
         {
           ...createOpenAiTurnEventFields({
@@ -462,6 +476,27 @@ export class OpenAiAppServerEventBridge {
         payload: toOpenAiSessionUsageSummary(params),
       },
     ]);
+  }
+
+  #clearSystemErrorFallback(): void {
+    if (this.#systemErrorFallbackTimer === null) {
+      return;
+    }
+
+    clearTimeout(this.#systemErrorFallbackTimer);
+    this.#systemErrorFallbackTimer = null;
+  }
+
+  #scheduleSystemErrorFallback(context: AgentDriverContext): void {
+    this.#clearSystemErrorFallback();
+    this.#systemErrorFallbackTimer = setTimeout(() => {
+      this.#systemErrorFallbackTimer = null;
+      void this.#handleRuntimeError(context, {
+        message: "OpenAi app-server thread entered systemError.",
+      }).catch((error: unknown) => {
+        context.logger.error("driver.openai.system_error_fallback.failed", error);
+      });
+    }, OPENAI_SYSTEM_ERROR_FALLBACK_DELAY_MS);
   }
 
   async #push(

--- a/src/runtimes/openai/generated/app-server-protocol-common.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-common.ts
@@ -11,6 +11,7 @@ import type {
   ThreadTokenUsage,
   TokenUsageBreakdown,
   Turn,
+  TurnError,
   TurnItemsView,
   TurnPlanStep,
   TurnPlanStepStatus,
@@ -380,10 +381,10 @@ export function parseTurn(value: unknown, label: string): Turn {
     throw new Error(`${label}.id must be a non-empty string.`);
   }
 
-  const error = record["error"];
-  const parsedError =
-    error === undefined || error === null ? null : expectRecord(error, `${label}.error`);
-  const errorMessage = parsedError === null ? null : readString(parsedError, "message");
+  const error =
+    record["error"] === undefined || record["error"] === null
+      ? null
+      : parseTurnError(record["error"], `${label}.error`);
   const items = parseOptionalThreadItems(record["items"], `${label}.items`);
   const itemsView = parseTurnItemsView(record["itemsView"], `${label}.itemsView`);
   const startedAt = readOptionalNullableNumber(record, "startedAt", label);
@@ -395,11 +396,20 @@ export function parseTurn(value: unknown, label: string): Turn {
     id,
     ...(completedAt === undefined ? {} : { completedAt }),
     ...(durationMs === undefined ? {} : { durationMs }),
-    ...(errorMessage === null ? {} : { error: { message: errorMessage } }),
+    ...(error === null ? {} : { error }),
     ...(items === undefined ? {} : { items }),
     ...(itemsView === undefined ? {} : { itemsView }),
     ...(startedAt === undefined ? {} : { startedAt }),
     ...(status === undefined ? {} : { status }),
+  };
+}
+
+export function parseTurnError(value: unknown, label: string): TurnError {
+  const record = expectRecord(value, label);
+
+  return {
+    additionalDetails: readOptionalNullableString(record, "additionalDetails", label) ?? null,
+    message: readRequiredString(record, "message", label),
   };
 }
 

--- a/src/runtimes/openai/generated/app-server-protocol-server.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-server.ts
@@ -10,6 +10,7 @@ import {
   parseThreadTokenUsage,
   parseThreadTurnIds,
   parseTurn,
+  parseTurnError,
   parseTurnPlan,
   readOptionalNullableString,
   readRequiredBoolean,
@@ -32,7 +33,6 @@ import type {
   ServerNotificationParams,
   ThreadSettingsUpdatedNotification,
   TurnDiffUpdatedNotification,
-  TurnError,
   TurnPlanUpdatedNotification,
   WarningNotification,
 } from "./app-server-protocol-types";
@@ -66,21 +66,12 @@ function parseWarningNotification(value: unknown): WarningNotification {
   };
 }
 
-function parseTurnErrorPayload(value: unknown, label: string): TurnError {
-  const record = expectRecord(value, label);
-
-  return {
-    additionalDetails: readOptionalNullableString(record, "additionalDetails", label) ?? null,
-    message: readRequiredString(record, "message", label),
-  };
-}
-
 function parseErrorNotification(value: unknown): ErrorNotification {
   const label = "error params";
   const record = readParams(value, "error");
 
   return {
-    error: parseTurnErrorPayload(record["error"], `${label}.error`),
+    error: parseTurnError(record["error"], `${label}.error`),
     threadId: readRequiredString(record, "threadId", label),
     turnId: readRequiredString(record, "turnId", label),
     willRetry: readRequiredBoolean(record, "willRetry", label),

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -119,7 +119,7 @@ export type ThreadItem = JsonObject & {
 export interface Turn {
   completedAt?: number | null;
   durationMs?: number | null;
-  error?: { message?: string } | null;
+  error?: TurnError | null;
   id: string;
   items?: ThreadItem[];
   itemsView?: TurnItemsView;

--- a/tests/fixtures/providers/openai-app-server/cases/system-error-followed-by-error.json
+++ b/tests/fixtures/providers/openai-app-server/cases/system-error-followed-by-error.json
@@ -1,0 +1,48 @@
+{
+  "notifications": [
+    {
+      "method": "thread/status/changed",
+      "params": {
+        "threadId": "thread-1",
+        "status": {
+          "type": "systemError"
+        }
+      }
+    },
+    {
+      "method": "error",
+      "params": {
+        "error": {
+          "additionalDetails": null,
+          "codexErrorInfo": "usageLimitExceeded",
+          "message": "Quota exceeded. Check your plan and billing details."
+        },
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "willRetry": false
+      }
+    }
+  ],
+  "trackTurnAfterNotifications": {
+    "expectation": "reject",
+    "turnId": "turn-1"
+  },
+  "expectedEvents": [
+    {
+      "kind": "run.failed",
+      "native": {
+        "eventName": "turn.failed",
+        "provider": "openai",
+        "turnId": "turn-1"
+      },
+      "payload": {
+        "error": {
+          "code": "openai.app_server.error",
+          "message": "Quota exceeded. Check your plan and billing details."
+        },
+        "recoverable": false
+      },
+      "sourceEventId": "openai.turn.failed:turn-1"
+    }
+  ]
+}

--- a/tests/fixtures/providers/openai-app-server/cases/turn-completed-failed-with-details.json
+++ b/tests/fixtures/providers/openai-app-server/cases/turn-completed-failed-with-details.json
@@ -1,0 +1,55 @@
+{
+  "notifications": [
+    {
+      "method": "turn/completed",
+      "params": {
+        "threadId": "thread-1",
+        "turn": {
+          "id": "turn-1",
+          "items": [],
+          "itemsView": "notLoaded",
+          "status": "failed",
+          "error": {
+            "additionalDetails": "HTTP 429 from upstream.",
+            "codexErrorInfo": "usageLimitExceeded",
+            "message": "Quota exceeded."
+          }
+        }
+      }
+    }
+  ],
+  "trackTurnAfterNotifications": {
+    "expectation": "reject",
+    "turnId": "turn-1"
+  },
+  "expectedEvents": [
+    {
+      "kind": "run.started",
+      "native": {
+        "eventName": "turn.started",
+        "provider": "openai",
+        "turnId": "turn-1"
+      },
+      "payload": {
+        "startedAt": "<iso-timestamp>"
+      },
+      "sourceEventId": "openai.turn.started:turn-1"
+    },
+    {
+      "kind": "run.failed",
+      "native": {
+        "eventName": "turn.failed",
+        "provider": "openai",
+        "turnId": "turn-1"
+      },
+      "payload": {
+        "error": {
+          "code": "openai.turn_failed",
+          "message": "Quota exceeded.\nHTTP 429 from upstream."
+        },
+        "recoverable": false
+      },
+      "sourceEventId": "openai.turn.failed:turn-1"
+    }
+  ]
+}

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -139,6 +139,32 @@ describe("OpenAi app-server event bridge", () => {
     ]);
   });
 
+  test("system errors fall back to a generic failure when no detailed error arrives", async () => {
+    const { bridge, context, events, logger } = createHarness();
+
+    await bridge.handleNotification(context, "thread/status/changed", {
+      status: {
+        type: "systemError",
+      },
+      threadId: "thread-1",
+    });
+    await Bun.sleep(150);
+    await logger.destroy();
+
+    expect(events()).toMatchObject([
+      {
+        kind: "run.failed",
+        payload: {
+          error: {
+            code: "openai.app_server.error",
+            message: "OpenAi app-server thread entered systemError.",
+          },
+          recoverable: false,
+        },
+      },
+    ]);
+  });
+
   test("completed agent messages backfill text when no deltas streamed", async () => {
     const { bridge, context, events, logger } = createHarness();
 

--- a/tests/openai-app-server-provider-fixtures.test.ts
+++ b/tests/openai-app-server-provider-fixtures.test.ts
@@ -40,6 +40,8 @@ const providerFixtureNames = [
   "agent-message-completed",
   "command-output-stream",
   "error-before-tracked-turn",
+  "system-error-followed-by-error",
+  "turn-completed-failed-with-details",
   "turn-completed-with-final-agent-message",
   "turn-plan-updated",
   "unknown-notification-ignored",


### PR DESCRIPTION
## Summary

- defer generic systemError handling briefly so the following app-server error notification can provide the actual failure
- preserve additionalDetails on failed turns and share one TurnError parser
- add fixtures for quota errors and failed turn details, plus a generic fallback test

## Root cause

The app-server emits thread/status/changed with status systemError before emitting the detailed error notification. The driver immediately converted the status event into a generic openai.app_server.error and marked the runtime error as emitted, suppressing the later quota message.

With this change, the observed live failure is reported as: Quota exceeded. Check your plan and billing details.

## Verification

- bun run lint
- bun run tc
- focused OpenAI bridge and provider fixture tests: 28 passed
- full non-live suite: 196 passed, 4 skipped, 0 failed
- bun run build
- live OpenAI smoke: reaches the expected upstream quota failure and now preserves the detailed message

The unfiltered full suite also attempted configured live providers: OpenAI failed because the configured project quota is exhausted; Anthropic failed because its configured live credential/provider call did not complete successfully. These external failures are unrelated to this patch.

## Generated and schema artifacts

- Generated files: yes; OpenAI app-server protocol adapter files under src/runtimes/openai/generated were updated to preserve the existing TurnError shape
- GraphQL codegen: no
- DB baseline or migrations: no
- Lockfile changes: no