### PR TITLE
fix(openai): honor authoritative terminal events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
           docker run --rm --entrypoint /bin/sh agent-driver:ci -c '
             test -x /usr/local/bin/agent-driver
             test -x /usr/local/bin/mosoo-claude-code
+            codex --version
+            codex app-server --help >/dev/null
             opencode --version
             opencode acp --help >/dev/null
             test "$MOSOO_ACP_FALLBACK_COMMAND" = opencode

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN OPENAI_RUNTIME_PACKAGE="@openai/co""dex@${OPENAI_RUNTIME_VERSION}" \
       @anthropic-ai/sdk@${ANTHROPIC_SDK_VERSION} \
       opencode-ai@${OPENCODE_VERSION} \
       "$OPENAI_RUNTIME_PACKAGE" \
+    && codex --version \
+    && codex app-server --help >/dev/null \
     && opencode --version \
     && opencode acp --help >/dev/null \
     && CLAUDE_ARCH_PACKAGE="$(node -p "'@anthropic-ai/claude-agent-sdk-' + (process.arch === 'arm64' ? 'linux-arm64' : 'linux-x64')")" \

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -222,8 +222,14 @@ export class OpenAiAppServerClient {
         });
       });
       child.once("exit", (code, signal) => {
-        const message = `OpenAi app-server exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}.`;
-        this.#rejectPending(new Error(message));
+        const error = new Error(
+          `OpenAi app-server exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}.`,
+        );
+        this.#rejectPending(error);
+        this.#serverMessageQueue = this.#notifyProtocolErrorAfterQueuedMessages(
+          this.#serverMessageQueue,
+          error,
+        );
       });
     });
 
@@ -373,6 +379,14 @@ export class OpenAiAppServerClient {
         this.respondError(id, error instanceof Error ? error.message : "Server request failed.");
       }
     }
+  }
+
+  async #notifyProtocolErrorAfterQueuedMessages(
+    previousMessage: Promise<void>,
+    error: Error,
+  ): Promise<void> {
+    await previousMessage;
+    await this.#context.handleProtocolError(error);
   }
 
   #handleClientResponse(id: RequestId, message: JsonObject): void {

--- a/src/runtimes/openai/app-server-driver-backend.ts
+++ b/src/runtimes/openai/app-server-driver-backend.ts
@@ -262,7 +262,6 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
   ): Promise<void> {
     const client = this.#requireClient();
     const threadId = this.#requireThreadId();
-    this.#events.resetRuntimeError();
     await this.#events.publishNativeResumeRef(context);
 
     context.logger.info("driver.openai.prompt.sending", {

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -55,7 +55,6 @@ export class OpenAiAppServerEventBridge {
   readonly #plans = new OpenAiPlanState();
   readonly #tools = new OpenAiToolState();
   readonly #turns = new OpenAiTurnTracker();
-  #runtimeErrorEmitted = false;
 
   constructor(options: OpenAiAppServerEventBridgeOptions) {
     this.#options = options;
@@ -88,10 +87,6 @@ export class OpenAiAppServerEventBridge {
     this.#turns.markCancelled(turnId, reason);
   }
 
-  resetRuntimeError(): void {
-    this.#runtimeErrorEmitted = false;
-  }
-
   async trackTurn(turnId: string, runId: RunId): Promise<void> {
     return this.#turns.track(turnId, runId);
   }
@@ -121,7 +116,7 @@ export class OpenAiAppServerEventBridge {
         return;
       }
       case "thread/status/changed": {
-        await this.#handleThreadStatusChanged(context, payload);
+        this.#handleThreadStatusChanged(context, payload);
         return;
       }
       case "thread/settings/updated": {
@@ -182,7 +177,7 @@ export class OpenAiAppServerEventBridge {
         return;
       }
       case "error": {
-        await this.#handleRuntimeError(context, payload);
+        this.#handleRuntimeError(context, payload);
         return;
       }
       default: {
@@ -263,7 +258,7 @@ export class OpenAiAppServerEventBridge {
     });
   }
 
-  async #handleThreadStatusChanged(context: AgentDriverContext, params: JsonObject): Promise<void> {
+  #handleThreadStatusChanged(context: AgentDriverContext, params: JsonObject): void {
     const status = readRecord(params, "status");
     const statusType = readString(status, "type");
 
@@ -273,8 +268,8 @@ export class OpenAiAppServerEventBridge {
     });
 
     if (statusType === "systemError") {
-      await this.#handleRuntimeError(context, {
-        message: "OpenAi app-server thread entered systemError.",
+      context.logger.warn("driver.openai.thread.system_error.awaiting_turn_completion", {
+        threadIdPresent: readString(params, "threadId") !== null,
       });
     }
   }
@@ -286,61 +281,21 @@ export class OpenAiAppServerEventBridge {
     });
   }
 
-  async #handleRuntimeError(context: AgentDriverContext, params: JsonObject): Promise<void> {
+  #handleRuntimeError(context: AgentDriverContext, params: JsonObject): void {
     const error = readRecord(params, "error");
     const message =
       readString(error, "message") ?? readString(params, "message") ?? "OpenAi app-server error.";
     const additionalDetails = readString(error, "additionalDetails");
-    const displayMessage = toOpenAiErrorMessage(message, additionalDetails);
     const turnId = readString(params, "turnId");
     const willRetry = params["willRetry"] === true;
 
-    if (willRetry) {
-      context.logger.warn("driver.openai.error.retrying", {
-        additionalDetails,
-        message,
-        threadIdPresent: readString(params, "threadId") !== null,
-        turnIdPresent: turnId !== null,
-      });
-      return;
-    }
-
-    const errorResult = new Error(displayMessage);
-    const runId = turnId === null ? undefined : (this.#turns.activeRunId(turnId) ?? undefined);
-
-    if (turnId !== null) {
-      this.#turns.settle(turnId, { error: errorResult, kind: "failed" });
-    } else {
-      for (const activeTurnId of this.activeTurnIds()) {
-        this.#turns.settle(activeTurnId, { error: errorResult, kind: "failed" });
-      }
-    }
-
-    if (this.#runtimeErrorEmitted) {
-      return;
-    }
-
-    this.#runtimeErrorEmitted = true;
-
-    await this.#push(context, "driver.openai.error", [
-      {
-        ...(turnId === null
-          ? {}
-          : createOpenAiTurnEventFields({
-              eventName: "turn.failed",
-              runId,
-              turnId,
-            })),
-        kind: "run.failed",
-        payload: {
-          error: {
-            code: "openai.app_server.error",
-            message: displayMessage,
-          },
-          recoverable: false,
-        },
-      },
-    ]);
+    context.logger.warn("driver.openai.error.awaiting_turn_completion", {
+      additionalDetails,
+      message,
+      threadIdPresent: readString(params, "threadId") !== null,
+      turnIdPresent: turnId !== null,
+      willRetry,
+    });
   }
 
   async #handleTurnCompleted(context: AgentDriverContext, params: JsonObject): Promise<void> {
@@ -373,7 +328,10 @@ export class OpenAiAppServerEventBridge {
     }
 
     if (status === "failed") {
-      const message = readString(error, "message") ?? "OpenAi turn failed.";
+      const message = toOpenAiErrorMessage(
+        readString(error, "message") ?? "OpenAi turn failed.",
+        readString(error, "additionalDetails"),
+      );
       await this.#push(context, "driver.openai.turn.failed", [
         {
           ...createOpenAiTurnEventFields({

--- a/src/runtimes/openai/generated/app-server-protocol-common.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-common.ts
@@ -11,6 +11,7 @@ import type {
   ThreadTokenUsage,
   TokenUsageBreakdown,
   Turn,
+  TurnError,
   TurnItemsView,
   TurnPlanStep,
   TurnPlanStepStatus,
@@ -380,10 +381,10 @@ export function parseTurn(value: unknown, label: string): Turn {
     throw new Error(`${label}.id must be a non-empty string.`);
   }
 
-  const error = record["error"];
-  const parsedError =
-    error === undefined || error === null ? null : expectRecord(error, `${label}.error`);
-  const errorMessage = parsedError === null ? null : readString(parsedError, "message");
+  const error =
+    record["error"] === undefined || record["error"] === null
+      ? null
+      : parseTurnError(record["error"], `${label}.error`);
   const items = parseOptionalThreadItems(record["items"], `${label}.items`);
   const itemsView = parseTurnItemsView(record["itemsView"], `${label}.itemsView`);
   const startedAt = readOptionalNullableNumber(record, "startedAt", label);
@@ -395,11 +396,20 @@ export function parseTurn(value: unknown, label: string): Turn {
     id,
     ...(completedAt === undefined ? {} : { completedAt }),
     ...(durationMs === undefined ? {} : { durationMs }),
-    ...(errorMessage === null ? {} : { error: { message: errorMessage } }),
+    ...(error === null ? {} : { error }),
     ...(items === undefined ? {} : { items }),
     ...(itemsView === undefined ? {} : { itemsView }),
     ...(startedAt === undefined ? {} : { startedAt }),
     ...(status === undefined ? {} : { status }),
+  };
+}
+
+export function parseTurnError(value: unknown, label: string): TurnError {
+  const record = expectRecord(value, label);
+
+  return {
+    additionalDetails: readOptionalNullableString(record, "additionalDetails", label) ?? null,
+    message: readRequiredString(record, "message", label),
   };
 }
 

--- a/src/runtimes/openai/generated/app-server-protocol-server.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-server.ts
@@ -10,6 +10,7 @@ import {
   parseThreadTokenUsage,
   parseThreadTurnIds,
   parseTurn,
+  parseTurnError,
   parseTurnPlan,
   readOptionalNullableString,
   readRequiredBoolean,
@@ -32,7 +33,6 @@ import type {
   ServerNotificationParams,
   ThreadSettingsUpdatedNotification,
   TurnDiffUpdatedNotification,
-  TurnError,
   TurnPlanUpdatedNotification,
   WarningNotification,
 } from "./app-server-protocol-types";
@@ -66,21 +66,12 @@ function parseWarningNotification(value: unknown): WarningNotification {
   };
 }
 
-function parseTurnErrorPayload(value: unknown, label: string): TurnError {
-  const record = expectRecord(value, label);
-
-  return {
-    additionalDetails: readOptionalNullableString(record, "additionalDetails", label) ?? null,
-    message: readRequiredString(record, "message", label),
-  };
-}
-
 function parseErrorNotification(value: unknown): ErrorNotification {
   const label = "error params";
   const record = readParams(value, "error");
 
   return {
-    error: parseTurnErrorPayload(record["error"], `${label}.error`),
+    error: parseTurnError(record["error"], `${label}.error`),
     threadId: readRequiredString(record, "threadId", label),
     turnId: readRequiredString(record, "turnId", label),
     willRetry: readRequiredBoolean(record, "willRetry", label),

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -119,7 +119,7 @@ export type ThreadItem = JsonObject & {
 export interface Turn {
   completedAt?: number | null;
   durationMs?: number | null;
-  error?: { message?: string } | null;
+  error?: TurnError | null;
   id: string;
   items?: ThreadItem[];
   itemsView?: TurnItemsView;

--- a/tests/fixtures/providers/openai-app-server/cases/error-before-tracked-turn.json
+++ b/tests/fixtures/providers/openai-app-server/cases/error-before-tracked-turn.json
@@ -11,6 +11,20 @@
         "turnId": "turn-1",
         "willRetry": false
       }
+    },
+    {
+      "method": "turn/completed",
+      "params": {
+        "threadId": "thread-1",
+        "turn": {
+          "error": {
+            "additionalDetails": "HTTP 502 from upstream.",
+            "message": "Response stream disconnected."
+          },
+          "id": "turn-1",
+          "status": "failed"
+        }
+      }
     }
   ],
   "trackTurnAfterNotifications": {
@@ -18,6 +32,18 @@
     "turnId": "turn-1"
   },
   "expectedEvents": [
+    {
+      "kind": "run.started",
+      "native": {
+        "eventName": "turn.started",
+        "provider": "openai",
+        "turnId": "turn-1"
+      },
+      "payload": {
+        "startedAt": "<iso-timestamp>"
+      },
+      "sourceEventId": "openai.turn.started:turn-1"
+    },
     {
       "kind": "run.failed",
       "native": {
@@ -27,7 +53,7 @@
       },
       "payload": {
         "error": {
-          "code": "openai.app_server.error",
+          "code": "openai.turn_failed",
           "message": "Response stream disconnected.\nHTTP 502 from upstream."
         },
         "recoverable": false

--- a/tests/openai-app-server-client.test.ts
+++ b/tests/openai-app-server-client.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createBufferedSinkLogger } from "../src/observability";
+import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
+import { createAgentDriverContext } from "../src/runtimes/agent-driver-backend";
+import { OpenAiAppServerClient } from "../src/runtimes/openai/app-server-client";
+import { driverBootPayload } from "./driver-boot-payload-fixture";
+
+const originalExecutable = process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  if (originalExecutable === undefined) {
+    delete process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"];
+  } else {
+    process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] = originalExecutable;
+  }
+
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("OpenAi app-server client", () => {
+  test("reports process exit after queued server messages", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mosoo-openai-client-"));
+    temporaryDirectories.push(directory);
+    const executable = join(directory, "fake-app-server");
+    await Bun.write(
+      executable,
+      `#!/usr/bin/env bun
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const newline = buffer.indexOf("\\n");
+  if (newline < 0) return;
+  const request = JSON.parse(buffer.slice(0, newline));
+  process.stdout.write(JSON.stringify({ id: request.id, result: {} }) + "\\n");
+  setTimeout(() => process.exit(17), 25);
+});
+`,
+    );
+    await chmod(executable, 0o755);
+    process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] = executable;
+
+    const payload = createDriverStartInputFromBootPayload({
+      ...driverBootPayload,
+      execution: {
+        ...driverBootPayload.execution,
+        session: {
+          ...driverBootPayload.execution.session,
+          context: {
+            ...driverBootPayload.execution.session.context,
+            homePath: join(directory, "home"),
+            sessionOrganizationPath: directory,
+          },
+          cwd: directory,
+        },
+      },
+    });
+    const logger = createBufferedSinkLogger({
+      level: "debug",
+      service: "openai-app-server-client-test",
+      sink: async () => {},
+    });
+    const context = createAgentDriverContext({
+      eventSink: { pushEvents: async () => {} },
+      logger,
+      payload,
+      permission: { request: async () => "allow_once" },
+    });
+    const protocolErrors: Error[] = [];
+    const client = new OpenAiAppServerClient(payload, {
+      ...context,
+      handleNotification: async () => {},
+      handleProtocolError: async (error) => {
+        protocolErrors.push(error);
+      },
+    });
+
+    await client.start();
+
+    for (let attempt = 0; attempt < 50 && protocolErrors.length === 0; attempt += 1) {
+      await Bun.sleep(10);
+    }
+
+    expect(protocolErrors).toHaveLength(1);
+    expect(protocolErrors[0]?.message).toBe("OpenAi app-server exited with code 17.");
+    client.stop();
+    await logger.destroy();
+  });
+});

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -107,7 +107,7 @@ describe("OpenAi app-server event bridge", () => {
     ]);
   });
 
-  test("turn errors can arrive before the turn response is tracked", async () => {
+  test("turn errors wait for the authoritative failed turn", async () => {
     const { bridge, context, events, logger } = createHarness();
 
     await bridge.handleNotification(context, "error", {
@@ -120,20 +120,73 @@ describe("OpenAi app-server event bridge", () => {
       willRetry: false,
     });
 
-    await expect(bridge.trackTurn("turn-1", DRIVER_TEST_IDS.runId)).rejects.toThrow();
+    expect(events()).toEqual([]);
+    const trackedTurn = bridge.trackTurn("turn-1", DRIVER_TEST_IDS.runId);
+
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        error: {
+          additionalDetails: "HTTP 502 from upstream.",
+          message: "Response stream disconnected.",
+        },
+        id: "turn-1",
+        status: "failed",
+      },
+    });
+
+    await expect(trackedTurn).rejects.toThrow(
+      "Response stream disconnected.\nHTTP 502 from upstream.",
+    );
     await logger.destroy();
 
-    const [failedEvent] = events();
-    expect(failedEvent?.runId).toBeUndefined();
+    const failedEvent = events().find((event) => event.kind === "run.failed");
+    expect(failedEvent?.runId).toBe(DRIVER_TEST_IDS.runId);
     expect(events()).toMatchObject([
+      {
+        kind: "run.started",
+      },
       {
         kind: "run.failed",
         payload: {
           error: {
-            code: "openai.app_server.error",
-            message: expect.any(String),
+            code: "openai.turn_failed",
+            message: "Response stream disconnected.\nHTTP 502 from upstream.",
           },
           recoverable: false,
+        },
+      },
+    ]);
+  });
+
+  test("thread systemError waits for the authoritative failed turn", async () => {
+    const { bridge, context, events, logger } = createHarness();
+    const trackedTurn = bridge.trackTurn("turn-1", DRIVER_TEST_IDS.runId);
+
+    await bridge.handleNotification(context, "thread/status/changed", {
+      status: { type: "systemError" },
+      threadId: "thread-1",
+    });
+    await bridge.handleNotification(context, "turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        error: {
+          message: "The model returned an empty response.",
+        },
+        id: "turn-1",
+        status: "failed",
+      },
+    });
+
+    await expect(trackedTurn).rejects.toThrow("The model returned an empty response.");
+    await logger.destroy();
+    expect(events().filter((event) => event.kind === "run.failed")).toMatchObject([
+      {
+        payload: {
+          error: {
+            code: "openai.turn_failed",
+            message: "The model returned an empty response.",
+          },
         },
       },
     ]);


### PR DESCRIPTION
## Summary

- verify the image contains a runnable Codex app-server artifact
- wait for authoritative turn/completed instead of settling on advisory error or thread systemError notifications
- reject active turns when the app-server process exits and preserve structured failure details

## Root cause

The bridge treated non-terminal notifications as terminal and the client only rejected pending JSON-RPC calls when the child exited. That could both duplicate failures and leave an already-dispatched Turn unresolved. The fix follows the app-server protocol terminal boundary and has no timing fallback.

## Verification

- bun run lint
- bun run tc
- bun run test (195 pass, 4 skip, 0 fail)
- bun run build
- live credentialed Mosoo Run completed end to end

## Related

This is a correctness-focused alternative to #44. It avoids the arbitrary 100 ms fallback and also covers app-server process exit.