### PR TITLE
fix(openai): recover missing thread rollouts

### DIFF
--- a/src/infrastructure/logging/driver-debug-paths.ts
+++ b/src/infrastructure/logging/driver-debug-paths.ts
@@ -114,6 +114,7 @@ export function summarizeDriverBootPayload(payload: DriverBootPayload): Record<s
       mcpServerCount: session.mcpServers.length,
       profilePrompt: summarizeTextDigest(payload.execution.profilePrompt),
       readySkillCount: payload.execution.skills.filter((skill) => skill.snapshotId).length,
+      recoveryMessageCount: session.recoveryMessages.length,
       sessionContext: {
         homePath: summarizePath(context.homePath),
         origin: {

--- a/src/protocol/boot/index.ts
+++ b/src/protocol/boot/index.ts
@@ -144,12 +144,18 @@ export interface UnavailableDriverBootMcpServer {
 
 export type DriverBootMcpServer = AuthorizedDriverBootMcpServer | UnavailableDriverBootMcpServer;
 
+export interface DriverRecoveryMessage {
+  readonly content: string;
+  readonly role: "assistant" | "user";
+}
+
 export interface DriverExecutionSessionSpec {
   readonly additionalDirectories: string[];
   readonly context: DriverExecutionSessionContext;
   readonly cwd: string;
   readonly mcpServers: DriverBootMcpServer[];
   readonly nativeResumeRef: DriverNativeRuntimeRef | null;
+  readonly recoveryMessages: DriverRecoveryMessage[];
 }
 
 /**
@@ -382,6 +388,25 @@ function readBootMcpServer(value: unknown, index: number): DriverBootMcpServer {
 
 function readExecutionSession(value: unknown): DriverExecutionSessionSpec {
   const record = readRecord(value, "execution.session");
+  const recoveryMessages =
+    record["recoveryMessages"] === undefined
+      ? []
+      : readArray(record["recoveryMessages"], "execution.session.recoveryMessages").map(
+          (entry, index): DriverRecoveryMessage => {
+            const label = `execution.session.recoveryMessages[${index}]`;
+            const message = readRecord(entry, label);
+            const role = readNonEmptyString(message, "role", label);
+
+            if (role !== "assistant" && role !== "user") {
+              throw new TypeError(`${label}.role is unsupported.`);
+            }
+
+            return {
+              content: readNonEmptyString(message, "content", label),
+              role,
+            };
+          },
+        );
 
   return {
     additionalDirectories: readStringArray(record, "additionalDirectories", "execution.session"),
@@ -391,6 +416,7 @@ function readExecutionSession(value: unknown): DriverExecutionSessionSpec {
       readBootMcpServer,
     ),
     nativeResumeRef: readNativeRuntimeRef(record["nativeResumeRef"]),
+    recoveryMessages,
   };
 }
 

--- a/src/protocol/execution.ts
+++ b/src/protocol/execution.ts
@@ -4,6 +4,7 @@ import type {
   DriverExecutionSpec,
   DriverNativeRuntimeRef,
   DriverPermissionPolicy,
+  DriverRecoveryMessage,
   DriverResolvedSkill,
   DriverSkillCatalogEntry,
 } from "./boot";
@@ -20,6 +21,7 @@ export interface DriverExecutionSessionInput {
   readonly homePath: string;
   readonly mcpServers: DriverBootMcpServer[];
   readonly nativeResumeRef: DriverNativeRuntimeRef | null;
+  readonly recoveryMessages: DriverRecoveryMessage[];
   readonly sharedRootPath: string;
 }
 
@@ -57,6 +59,7 @@ export function createDriverExecutionInputFromBootExecution(
       homePath: execution.session.context.homePath,
       mcpServers: execution.session.mcpServers,
       nativeResumeRef: execution.session.nativeResumeRef,
+      recoveryMessages: execution.session.recoveryMessages,
       sharedRootPath: execution.session.context.sessionOrganizationPath,
     },
     skillCatalog: execution.skillCatalog,

--- a/src/runtimes/openai/app-server-driver-backend.ts
+++ b/src/runtimes/openai/app-server-driver-backend.ts
@@ -26,6 +26,7 @@ import { MOSOO_OPENAI_RUNTIME_SANDBOX_MODE } from "./app-server-env";
 import { OpenAiAppServerEventBridge } from "./app-server-event-bridge";
 import type {
   ApprovalPolicy,
+  JsonObject,
   ThreadResumeParams,
   ThreadStartParams,
   ThreadStartResponse,
@@ -82,6 +83,21 @@ function isTerminalOpenAiTurnStatus(status: TurnStatus | undefined): boolean {
 
 function isMissingOpenAiRollout(error: unknown, threadId: string): boolean {
   return error instanceof Error && error.message === `no rollout found for thread id ${threadId}`;
+}
+
+function toOpenAiRecoveryItems(
+  messages: DriverStartInput["execution"]["session"]["recoveryMessages"],
+): JsonObject[] {
+  return messages.map((message) => ({
+    content: [
+      {
+        text: message.content,
+        type: message.role === "user" ? "input_text" : "output_text",
+      },
+    ],
+    role: message.role,
+    type: "message",
+  }));
 }
 
 export function createOpenAiTurnStartParams(input: OpenAiTurnStartInput): TurnStartParams {
@@ -230,12 +246,25 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
         threadResult = await measureStartupPhase("thread.start_after_missing_rollout", () =>
           client.request("thread/start", threadStartParams),
         );
+        const recoveryItems = toOpenAiRecoveryItems(
+          this.#payload.execution.session.recoveryMessages,
+        );
+
+        if (recoveryItems.length > 0) {
+          await measureStartupPhase("thread.inject_recovery_items", () =>
+            client.request("thread/inject_items", {
+              items: recoveryItems,
+              threadId: threadResult.thread.id,
+            }),
+          );
+        }
+
+        context.logger.warn("driver.openai.native_resume_ref.semantic_recovery", {
+          recoveryMessageCount: recoveryItems.length,
+        });
       }
     }
     this.#threadId = threadResult.thread.id;
-    await measureStartupPhase("native_resume.publish", () =>
-      this.#events.publishNativeResumeRef(context),
-    );
     void this.#emitStartupTimingEvent(context, startupStartedAtMs, startupPhases);
 
     context.logger.info("driver.openai.runtime.started", {
@@ -284,7 +313,6 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
   ): Promise<void> {
     const client = this.#requireClient();
     const threadId = this.#requireThreadId();
-    await this.#events.publishNativeResumeRef(context);
 
     context.logger.info("driver.openai.prompt.sending", {
       textLength: input.text.length,

--- a/src/runtimes/openai/app-server-driver-backend.ts
+++ b/src/runtimes/openai/app-server-driver-backend.ts
@@ -28,6 +28,7 @@ import type {
   ApprovalPolicy,
   ThreadResumeParams,
   ThreadStartParams,
+  ThreadStartResponse,
   TurnStatus,
   TurnStartParams,
   TurnStartResponse,
@@ -77,6 +78,10 @@ function readOpenAiNativeResumeThreadId(payload: DriverStartInput): string | nul
 
 function isTerminalOpenAiTurnStatus(status: TurnStatus | undefined): boolean {
   return status === "completed" || status === "failed" || status === "interrupted";
+}
+
+function isMissingOpenAiRollout(error: unknown, threadId: string): boolean {
+  return error instanceof Error && error.message === `no rollout found for thread id ${threadId}`;
 }
 
 export function createOpenAiTurnStartParams(input: OpenAiTurnStartInput): TurnStartParams {
@@ -194,22 +199,39 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
       modelProvider: this.#payload.execution.provider,
       sandbox: MOSOO_OPENAI_RUNTIME_SANDBOX_MODE,
     } satisfies ThreadStartParams;
+    const threadStartParams = {
+      ...baseThreadParams,
+      ...(developerInstructions === null ? {} : { developerInstructions }),
+      sessionStartSource: "startup",
+    } satisfies ThreadStartParams;
+    let threadResult: ThreadStartResponse;
 
-    const threadResult = await measureStartupPhase(
-      nativeResumeThreadId === null ? "thread.start" : "thread.resume",
-      () =>
-        nativeResumeThreadId === null
-          ? client.request("thread/start", {
-              ...baseThreadParams,
-              ...(developerInstructions === null ? {} : { developerInstructions }),
-              sessionStartSource: "startup",
-            })
-          : client.request("thread/resume", {
-              ...baseThreadParams,
-              ...(developerInstructions === null ? {} : { developerInstructions }),
-              threadId: nativeResumeThreadId,
-            } satisfies ThreadResumeParams),
-    );
+    if (nativeResumeThreadId === null) {
+      threadResult = await measureStartupPhase("thread.start", () =>
+        client.request("thread/start", threadStartParams),
+      );
+    } else {
+      try {
+        threadResult = await measureStartupPhase("thread.resume", () =>
+          client.request("thread/resume", {
+            ...baseThreadParams,
+            ...(developerInstructions === null ? {} : { developerInstructions }),
+            threadId: nativeResumeThreadId,
+          } satisfies ThreadResumeParams),
+        );
+      } catch (error) {
+        if (!isMissingOpenAiRollout(error, nativeResumeThreadId)) {
+          throw error;
+        }
+
+        context.logger.warn("driver.openai.native_resume_ref.missing_rollout", {
+          nativeResumeRefPresent: true,
+        });
+        threadResult = await measureStartupPhase("thread.start_after_missing_rollout", () =>
+          client.request("thread/start", threadStartParams),
+        );
+      }
+    }
     this.#threadId = threadResult.thread.id;
     await measureStartupPhase("native_resume.publish", () =>
       this.#events.publishNativeResumeRef(context),

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -375,6 +375,20 @@ export class OpenAiAppServerEventBridge {
         },
       },
     ]);
+
+    // A fresh app-server thread may not have a rollout until its first successful
+    // turn is materialized. Resume metadata must never turn that successful turn
+    // into a failure, so publish it only after the canonical completion settles.
+    try {
+      await this.publishNativeResumeRef(context);
+    } catch (publishError) {
+      context.logger.warn("driver.openai.native_resume_ref.publish_failed", {
+        message:
+          publishError instanceof Error
+            ? publishError.message
+            : "Native resume ref publish failed.",
+      });
+    }
     this.#turns.settle(turnId, { kind: "completed" });
   }
 

--- a/src/runtimes/openai/generated/app-server-protocol-client.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-client.ts
@@ -3,6 +3,7 @@ import type {
   ClientRequestMethod,
   ClientRequestResult,
   InitializeResponse,
+  ThreadInjectItemsResponse,
   ThreadResumeResponse,
   ThreadStartResponse,
   TurnInterruptResponse,
@@ -43,10 +44,17 @@ function parseTurnInterruptResponse(value: unknown): TurnInterruptResponse {
   return turn === undefined ? {} : { turn: parseTurn(turn, "turn/interrupt result.turn") };
 }
 
+function parseEmptyResponse(value: unknown, method: string): Record<string, never> {
+  expectRecord(value ?? {}, `${method} result`);
+  return {};
+}
+
 export const CLIENT_REQUEST_RESULT_PARSERS: {
   [Method in ClientRequestMethod]: (value: unknown) => ClientRequestResult[Method];
 } = {
   initialize: parseInitializeResponse,
+  "thread/inject_items": (value: unknown): ThreadInjectItemsResponse =>
+    parseEmptyResponse(value, "thread/inject_items"),
   "thread/resume": (value: unknown): ThreadResumeResponse =>
     parseThreadResponse(value, "thread/resume"),
   "thread/start": (value: unknown): ThreadStartResponse =>
@@ -56,6 +64,10 @@ export const CLIENT_REQUEST_RESULT_PARSERS: {
 };
 
 export function parseClientRequestResult(method: "initialize", value: unknown): InitializeResponse;
+export function parseClientRequestResult(
+  method: "thread/inject_items",
+  value: unknown,
+): ThreadInjectItemsResponse;
 export function parseClientRequestResult(
   method: "thread/resume",
   value: unknown,

--- a/src/runtimes/openai/generated/app-server-protocol-types.ts
+++ b/src/runtimes/openai/generated/app-server-protocol-types.ts
@@ -76,6 +76,13 @@ export interface ThreadResumeResponse {
   thread: Thread;
 }
 
+export interface ThreadInjectItemsParams {
+  items: JsonObject[];
+  threadId: string;
+}
+
+export type ThreadInjectItemsResponse = Record<string, never>;
+
 export interface TurnStartParams {
   approvalPolicy?: ApprovalPolicy | null;
   approvalsReviewer?: string | JsonObject | null;
@@ -305,6 +312,7 @@ export type ServerNotificationMethod = keyof ServerNotificationParams;
 
 export interface ClientRequestParams {
   initialize: InitializeParams;
+  "thread/inject_items": ThreadInjectItemsParams;
   "thread/resume": ThreadResumeParams;
   "thread/start": ThreadStartParams;
   "turn/interrupt": TurnInterruptParams;
@@ -313,6 +321,7 @@ export interface ClientRequestParams {
 
 export interface ClientRequestResult {
   initialize: InitializeResponse;
+  "thread/inject_items": ThreadInjectItemsResponse;
   "thread/resume": ThreadResumeResponse;
   "thread/start": ThreadStartResponse;
   "turn/interrupt": TurnInterruptResponse;

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -69,6 +69,7 @@ export const driverBootPayload = {
       cwd: "/tmp/organization",
       mcpServers: [],
       nativeResumeRef: null,
+      recoveryMessages: [],
     },
     skillCatalog: [],
     skills: [],

--- a/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
+++ b/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
@@ -71,6 +71,14 @@
         "stopReason": "end_turn"
       },
       "sourceEventId": "openai.turn.completed:turn-1"
+    },
+    {
+      "kind": "runtime.resume.updated",
+      "payload": {
+        "resumePointer": "thread-1",
+        "threadId": "thread-1"
+      },
+      "visibility": "owner_debug"
     }
   ]
 }

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -40,7 +40,7 @@ function readAssistantMessageId(events: readonly DriverEvent[]): string {
   throw new Error("Expected a platform assistant message ID.");
 }
 
-function createHarness() {
+function createHarness(options: { failNativeResumePublish?: boolean } = {}) {
   const batches: EventBatch[] = [];
   const logger = createBufferedSinkLogger({
     level: "debug",
@@ -60,6 +60,12 @@ function createHarness() {
   const bridge = new OpenAiAppServerEventBridge({
     push: async (_context, reason, events) => {
       batches.push({ events, reason });
+      if (
+        options.failNativeResumePublish === true &&
+        reason === "driver.openai.native_resume_ref.updated"
+      ) {
+        throw new Error("event sink unavailable");
+      }
     },
     requireThreadId: () => "thread-1",
   });
@@ -104,7 +110,35 @@ describe("OpenAi app-server event bridge", () => {
           stopReason: "end_turn",
         },
       },
+      {
+        kind: "runtime.resume.updated",
+        payload: {
+          resumePointer: "thread-1",
+          threadId: "thread-1",
+        },
+      },
     ]);
+  });
+
+  test("resume metadata failure does not reject a completed turn", async () => {
+    const { bridge, context, events, logger } = createHarness({
+      failNativeResumePublish: true,
+    });
+    const trackedTurn = bridge.trackTurn("turn-1", DRIVER_TEST_IDS.runId);
+
+    await expect(
+      bridge.handleNotification(context, "turn/completed", {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+        },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(trackedTurn).resolves.toBeUndefined();
+    await logger.destroy();
+
+    expect(events().some((event) => event.kind === "run.completed")).toBe(true);
   });
 
   test("turn errors wait for the authoritative failed turn", async () => {
@@ -610,6 +644,13 @@ describe("OpenAi app-server event bridge", () => {
           stopReason: "end_turn",
         },
       },
+      {
+        kind: "runtime.resume.updated",
+        payload: {
+          resumePointer: "thread-1",
+          threadId: "thread-1",
+        },
+      },
     ]);
   });
 
@@ -676,6 +717,13 @@ describe("OpenAi app-server event bridge", () => {
         kind: "run.completed",
         payload: {
           stopReason: "end_turn",
+        },
+      },
+      {
+        kind: "runtime.resume.updated",
+        payload: {
+          resumePointer: "thread-1",
+          threadId: "thread-1",
         },
       },
     ]);

--- a/tests/openai-app-server-startup.test.ts
+++ b/tests/openai-app-server-startup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,13 +27,21 @@ afterEach(async () => {
   );
 });
 
-async function createHarness(resumeErrorMessage: string) {
+async function createHarness(
+  resumeErrorMessage: string,
+  recoveryMessages = [
+    { content: "Earlier question", role: "user" as const },
+    { content: "Earlier answer", role: "assistant" as const },
+  ],
+) {
   const directory = await mkdtemp(join(tmpdir(), "mosoo-openai-startup-"));
   temporaryDirectories.push(directory);
   const executable = join(directory, "fake-app-server");
+  const requestLog = join(directory, "requests.jsonl");
   await Bun.write(
     executable,
     `#!/usr/bin/env bun
+import { appendFileSync } from "node:fs";
 let buffer = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => {
@@ -42,6 +50,7 @@ process.stdin.on("data", (chunk) => {
   while (newline >= 0) {
     const request = JSON.parse(buffer.slice(0, newline));
     buffer = buffer.slice(newline + 1);
+    appendFileSync(${JSON.stringify(requestLog)}, JSON.stringify(request) + "\\n");
     const response = request.method === "thread/resume"
       ? { id: request.id, error: { code: -32600, message: ${JSON.stringify(resumeErrorMessage)} } }
       : request.method === "thread/start"
@@ -73,6 +82,7 @@ process.stdin.on("data", (chunk) => {
           runtimeId: "openai-runtime",
           value: "stale-thread",
         },
+        recoveryMessages,
       },
     },
   });
@@ -106,24 +116,37 @@ process.stdin.on("data", (chunk) => {
     context,
     events,
     logger,
+    requestLog,
   };
 }
 
 describe("OpenAI app-server startup", () => {
-  test("starts a fresh thread when the persisted rollout is missing", async () => {
-    const { backend, context, events, logger } = await createHarness(
+  test("injects platform transcript without publishing an unmaterialized thread", async () => {
+    const { backend, context, events, logger, requestLog } = await createHarness(
       "no rollout found for thread id stale-thread",
     );
 
     await backend.start(context);
 
-    expect(events).toContainEqual({
-      kind: "runtime.resume.updated",
-      payload: {
-        resumePointer: "fresh-thread",
-        threadId: "fresh-thread",
-      },
-      visibility: "owner_debug",
+    expect(events.some((event) => event.kind === "runtime.resume.updated")).toBe(false);
+    const requests = (await readFile(requestLog, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { method: string; params?: unknown });
+    expect(requests.find((request) => request.method === "thread/inject_items")?.params).toEqual({
+      items: [
+        {
+          content: [{ text: "Earlier question", type: "input_text" }],
+          role: "user",
+          type: "message",
+        },
+        {
+          content: [{ text: "Earlier answer", type: "output_text" }],
+          role: "assistant",
+          type: "message",
+        },
+      ],
+      threadId: "fresh-thread",
     });
     await backend.stop(context, "test complete");
     await logger.destroy();

--- a/tests/openai-app-server-startup.test.ts
+++ b/tests/openai-app-server-startup.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createBufferedSinkLogger } from "../src/observability";
+import type { DriverEventInput } from "../src/protocol/events";
+import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
+import { createAgentDriverContext } from "../src/runtimes/agent-driver-backend";
+import { OpenAiAppServerDriverBackend } from "../src/runtimes/openai/app-server-driver-backend";
+import { driverBootPayload } from "./driver-boot-payload-fixture";
+
+const originalExecutable = process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  if (originalExecutable === undefined) {
+    delete process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"];
+  } else {
+    process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] = originalExecutable;
+  }
+
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+async function createHarness(resumeErrorMessage: string) {
+  const directory = await mkdtemp(join(tmpdir(), "mosoo-openai-startup-"));
+  temporaryDirectories.push(directory);
+  const executable = join(directory, "fake-app-server");
+  await Bun.write(
+    executable,
+    `#!/usr/bin/env bun
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newline = buffer.indexOf("\\n");
+  while (newline >= 0) {
+    const request = JSON.parse(buffer.slice(0, newline));
+    buffer = buffer.slice(newline + 1);
+    const response = request.method === "thread/resume"
+      ? { id: request.id, error: { code: -32600, message: ${JSON.stringify(resumeErrorMessage)} } }
+      : request.method === "thread/start"
+        ? { id: request.id, result: { thread: { id: "fresh-thread" } } }
+        : { id: request.id, result: {} };
+    process.stdout.write(JSON.stringify(response) + "\\n");
+    newline = buffer.indexOf("\\n");
+  }
+});
+`,
+  );
+  await chmod(executable, 0o755);
+  process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] = executable;
+
+  const payload = createDriverStartInputFromBootPayload({
+    ...driverBootPayload,
+    execution: {
+      ...driverBootPayload.execution,
+      session: {
+        ...driverBootPayload.execution.session,
+        context: {
+          ...driverBootPayload.execution.session.context,
+          homePath: join(directory, "home"),
+          sessionOrganizationPath: directory,
+        },
+        cwd: directory,
+        nativeResumeRef: {
+          kind: "openai_thread_id",
+          runtimeId: "openai-runtime",
+          value: "stale-thread",
+        },
+      },
+    },
+  });
+  const events: DriverEventInput[] = [];
+  const logger = createBufferedSinkLogger({
+    level: "debug",
+    service: "openai-app-server-startup-test",
+    sink: async () => {},
+  });
+  const context = createAgentDriverContext({
+    eventSink: {
+      commandUpdate: async () => {},
+      pushEvents: async (input) => {
+        events.push(...input.events);
+        return {
+          accepted: input.events.map((event, index) => ({
+            seq: index + 1,
+            type: event.kind,
+          })),
+        };
+      },
+    },
+    logger,
+    payload,
+    permission: { request: async () => "allow_once" },
+    ports: { skill: { materialize: async () => [] } },
+  });
+
+  return {
+    backend: new OpenAiAppServerDriverBackend(payload),
+    context,
+    events,
+    logger,
+  };
+}
+
+describe("OpenAI app-server startup", () => {
+  test("starts a fresh thread when the persisted rollout is missing", async () => {
+    const { backend, context, events, logger } = await createHarness(
+      "no rollout found for thread id stale-thread",
+    );
+
+    await backend.start(context);
+
+    expect(events).toContainEqual({
+      kind: "runtime.resume.updated",
+      payload: {
+        resumePointer: "fresh-thread",
+        threadId: "fresh-thread",
+      },
+      visibility: "owner_debug",
+    });
+    await backend.stop(context, "test complete");
+    await logger.destroy();
+  });
+
+  test("does not replace the thread for other resume failures", async () => {
+    const { backend, context, events, logger } = await createHarness("Unauthorized");
+
+    try {
+      await expect(backend.start(context)).rejects.toThrow("Unauthorized");
+      expect(events).toEqual([]);
+    } finally {
+      await backend.stop(context, "test complete");
+      await logger.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- recover only the exact `no rollout found` resume failure by starting a fresh OpenAI thread and injecting Mosoo persisted transcript items
- publish a native resume ref only after a successful turn materializes the rollout; ref delivery is best-effort and cannot turn a completed run into `systemError`
- keep all other resume failures fail-closed and never replay tool turns

## Root cause
Mosoo previously published a fresh OpenAI thread id before its first rollout existed. D1 could therefore durably outlive—or even point ahead of—the Sandbox-local rollout. The fix restores the lifecycle invariant and adds a bounded semantic fallback for already-stale refs.

## Recovery boundary
Deleted provider-native reasoning, tool state, and attachments cannot be reconstructed bit-for-bit. Recovery injects Mosoo persisted user/final-assistant text, preserving visible conversation semantics without replaying tool side effects.

## Verification
- `bun test` (198 pass, 4 skip)
- `bun run lint`
- `bun run tc`
- `bun run build`
- sink-failure test proves resume metadata cannot reject a completed turn
- credentialed local E2E: removed the Sandbox/rollout, resumed the stale ref, injected 9 messages, returned the prior answer, then persisted the new ref after `run.completed`