### PR TITLE
fix(runtime): provide python and pip in sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ ARG ANTHROPIC_SDK_VERSION=0.100.1
 ARG OPENAI_RUNTIME_VERSION=0.144.0
 ARG OPENCODE_VERSION=1.17.7
 
+# Environment package setup invokes `pip`, so the runtime image must provide it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-pip python-is-python3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && python --version \
+    && pip --version
+
 # Native agent CLIs pre-installed so the driver can spawn them via PATH.
 # Installed in a single npm invocation so Docker caches the whole agent
 # layer as one unit.


### PR DESCRIPTION
## What changed

- install Ubuntu's `python3-pip` and `python-is-python3` packages in the runtime image
- verify `python` and `pip` versions while the image builds

## Root cause

Mosoo environment package setup emits `pip install ...`, but the lean `cloudflare/sandbox:0.12.3` base image does not include Python or pip. Environment setup therefore exited with status 127 before the Driver could start.

## Impact

Runtime environments can install declared pip packages through the existing setup contract.

## Validation

- `bun run lint`
- `bun run tc`
- `bun run test` — 198 passed, 4 live/provider-gated tests skipped, 0 failed
- `bun run build`
- `docker build --platform linux/amd64 -t agent-driver:pip-fix .`
- container smoke: verified `agent-driver`, `python`, and `pip`; ran `pip install 'openai' 'pillow'`; imported `openai` and `PIL`
