### PR TITLE
fix(runtime): enforce package manager capabilities

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,4 +1,7 @@
 *
 !Containerfile
+!environment-package-managers.json
+!scripts/
+!scripts/environment-package-manager-check.mjs
 !dist/
 !dist/driver.mjs

--- a/Containerfile
+++ b/Containerfile
@@ -6,12 +6,21 @@ ARG ANTHROPIC_SDK_VERSION=0.111.0
 ARG OPENAI_RUNTIME_VERSION=0.144.5
 ARG OPENCODE_VERSION=1.18.4
 
-# Environment package setup invokes `pip`, so the runtime image must provide it.
+# Install the Python runtime behind writable pip package declarations.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3-pip python-is-python3 \
-    && rm -rf /var/lib/apt/lists/* \
-    && python --version \
-    && pip --version
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3 \
+      python3-pip \
+      python-is-python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY environment-package-managers.json /etc/mosoo/environment-package-managers.json
+COPY scripts/environment-package-manager-check.mjs /usr/local/libexec/mosoo/environment-package-manager-check.mjs
+
+# Environment writes expose only package managers verified by this image.
+# Check executables, parseable versions, and runtime aliases here so capability
+# failures surface while building the image rather than during a user Run.
+RUN node /usr/local/libexec/mosoo/environment-package-manager-check.mjs verify
 
 # Native agent CLIs pre-installed so the driver can spawn them via PATH.
 # Installed in a single npm invocation to keep the agent packages in one layer.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ vp run clean
 
 `vp run build:image` uses Buildah to produce a local `agent-driver:local` OCI image and installs `dist/driver.mjs` on the image `PATH` as `agent-driver`.
 
+The image contract in `environment-package-managers.json` exposes `npm` and `pip` to Mosoo Environment writes. The image build verifies that each tool is executable, reports a valid version, and resolves through coherent Python/pip aliases. `vp run docker:smoke:environment` installs and executes one pinned package through each manager using the same isolated-prefix mode as Mosoo Environment artifacts.
+
 ## Boundaries
 
 - The Driver Kernel owns command dispatch, runtime event emission, provider lifecycle, permission flow, diagnostics, and host port contracts.
@@ -174,6 +176,7 @@ vp run clean
 
 - `vp run check`
 - `vp run build:image`
+- `vp run docker:smoke:environment`
 - no `@mosoo/*` runtime dependencies in `package.json`
 - public entries include typed exports
 - live artifact tests are gated by environment credentials

--- a/environment-package-managers.json
+++ b/environment-package-managers.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "managers": ["npm", "pip"]
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "build": "vp run build:types && bun build src/bin/driver.ts --target bun --outfile dist/driver.mjs",
     "build:types": "rm -rf dist/types && vp exec tsc -p tsconfig.types.json",
     "build:image": "vp run build && buildah build -t agent-driver:local .",
+    "docker:smoke:environment": "docker run --rm --entrypoint node agent-driver:local /usr/local/libexec/mosoo/environment-package-manager-check.mjs smoke",
     "check": "vp check && vp run tc && vp run test && vp run build",
     "prepack": "vp run build"
   },

--- a/scripts/environment-package-manager-check.mjs
+++ b/scripts/environment-package-manager-check.mjs
@@ -1,0 +1,194 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mode = process.argv[2] ?? "smoke";
+const manifestPath =
+  process.env.MOSOO_ENVIRONMENT_PACKAGE_MANAGER_MANIFEST ??
+  "/etc/mosoo/environment-package-managers.json";
+const SEMANTIC_VERSION = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function readManifest() {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    fail(
+      `Invalid Environment package-manager manifest: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (manifest?.schemaVersion !== 1) {
+    fail("Invalid Environment package-manager manifest: schemaVersion must be 1");
+  }
+  if (!Array.isArray(manifest.managers) || manifest.managers.length === 0) {
+    fail("Invalid Environment package-manager manifest: managers must be a non-empty array");
+  }
+
+  const seen = new Set();
+  for (const manager of manifest.managers) {
+    if (typeof manager !== "string" || !/^[a-z][a-z0-9-]*$/.test(manager)) {
+      fail(`Invalid Environment package-manager manifest: invalid manager ${String(manager)}`);
+    }
+    if (seen.has(manager)) {
+      fail(`Invalid Environment package-manager manifest: duplicate manager ${manager}`);
+    }
+    seen.add(manager);
+  }
+
+  return manifest.managers;
+}
+
+function readCommandOutput(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, { encoding: "utf8", ...options }).trim();
+  } catch (error) {
+    fail(`${command} failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  try {
+    execFileSync(command, args, { stdio: "inherit", ...options });
+  } catch (error) {
+    fail(`${command} failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function withTemporaryRoot(manager, callback) {
+  const root = mkdtempSync(join(tmpdir(), `mosoo-environment-${manager}-`));
+
+  try {
+    callback(root);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+function assertExactVersion(tool, expected, actual) {
+  if (actual !== expected) {
+    fail(`${tool} version mismatch: expected ${expected}, got ${actual}`);
+  }
+}
+
+function assertSemanticVersion(tool, version) {
+  if (!SEMANTIC_VERSION.test(version)) {
+    fail(`${tool} returned an invalid version: ${version || "<empty>"}`);
+  }
+  return version;
+}
+
+function readSemanticVersion(tool, command, args, prefix = "") {
+  const output = readCommandOutput(command, args);
+  if (!output.startsWith(prefix)) {
+    fail(`${tool} returned an invalid version: ${output || "<empty>"}`);
+  }
+  return assertSemanticVersion(tool, output.slice(prefix.length));
+}
+
+function readPipVersion(tool, command, args) {
+  const output = readCommandOutput(command, args);
+  const match = /^pip (\S+) /u.exec(output);
+  return assertSemanticVersion(tool, match?.[1] ?? "");
+}
+
+function assertMatchingVersions(leftTool, leftVersion, rightTool, rightVersion) {
+  if (leftVersion !== rightVersion) {
+    fail(`${leftTool} and ${rightTool} versions do not match: ${leftVersion} != ${rightVersion}`);
+  }
+}
+
+const managerChecks = new Map([
+  [
+    "npm",
+    {
+      verify() {
+        const nodeVersion = readSemanticVersion("node", "node", ["--version"], "v");
+        const npmVersion = readSemanticVersion("npm", "npm", ["--version"]);
+        console.log(`Verified node ${nodeVersion} and npm ${npmVersion}.`);
+      },
+      smoke() {
+        withTemporaryRoot("npm", (root) => {
+          const npmRoot = join(root, "npm");
+          runCommand("npm", [
+            "install",
+            "--prefix",
+            npmRoot,
+            "--no-audit",
+            "--no-fund",
+            "--save-exact",
+            "prettier@3.3.3",
+          ]);
+          assertExactVersion(
+            "prettier",
+            "3.3.3",
+            readCommandOutput(join(npmRoot, "node_modules", ".bin", "prettier"), ["--version"]),
+          );
+        });
+      },
+    },
+  ],
+  [
+    "pip",
+    {
+      verify() {
+        const pythonVersion = readSemanticVersion("python", "python", ["--version"], "Python ");
+        const python3Version = readSemanticVersion("python3", "python3", ["--version"], "Python ");
+        assertMatchingVersions("python", pythonVersion, "python3", python3Version);
+
+        const pipVersion = readPipVersion("pip", "pip", ["--version"]);
+        const modulePipVersion = readPipVersion("python -m pip", "python", [
+          "-m",
+          "pip",
+          "--version",
+        ]);
+        assertMatchingVersions("pip", pipVersion, "python -m pip", modulePipVersion);
+        console.log(`Verified python ${pythonVersion} and pip ${pipVersion}.`);
+      },
+      smoke() {
+        withTemporaryRoot("pip", (root) => {
+          const pipRoot = join(root, "python");
+          runCommand("python", [
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            "--ignore-installed",
+            "--prefix",
+            pipRoot,
+            "six==1.16.0",
+          ]);
+          const pythonSite = readCommandOutput("python", [
+            "-c",
+            'import sys,sysconfig; p=sys.argv[1]; print(sysconfig.get_path("purelib",vars={"base":p,"platbase":p}))',
+            pipRoot,
+          ]);
+          runCommand("python", ["-c", 'import six; assert six.__version__ == "1.16.0"'], {
+            env: { ...process.env, PYTHONPATH: pythonSite },
+          });
+        });
+      },
+    },
+  ],
+]);
+
+if (mode !== "verify" && mode !== "smoke") {
+  fail(`Unsupported Environment package-manager check mode: ${mode}`);
+}
+
+for (const manager of readManifest()) {
+  const check = managerChecks.get(manager);
+  if (!check) {
+    fail(`Environment package manager has no ${mode} check: ${manager}`);
+  }
+  check[mode]();
+}

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -33,6 +33,11 @@ interface DriverPackageJson {
   readonly version?: string;
 }
 
+interface EnvironmentPackageManagerManifest {
+  readonly managers?: readonly string[];
+  readonly schemaVersion?: number;
+}
+
 const PUBLIC_EXPORTS = [
   ".",
   "./boot",
@@ -52,6 +57,12 @@ function readText(path: string): string {
 
 function readDriverPackageJson(): DriverPackageJson {
   return JSON.parse(readText("../package.json")) as DriverPackageJson;
+}
+
+function readEnvironmentPackageManagerManifest(): EnvironmentPackageManagerManifest {
+  return JSON.parse(
+    readText("../environment-package-managers.json"),
+  ) as EnvironmentPackageManagerManifest;
 }
 
 describe("driver artifact contract", () => {
@@ -241,7 +252,16 @@ describe("driver artifact contract", () => {
     expect(imageIndex).toBeGreaterThan(liveIndex);
   });
 
-  test("keeps the standalone package out of mosoo workspace dependencies", () => {
+  test("declares writable Environment package managers", () => {
+    const manifest = readEnvironmentPackageManagerManifest();
+
+    expect(manifest).toEqual({
+      managers: ["npm", "pip"],
+      schemaVersion: 1,
+    });
+  });
+
+  test("keeps the standalone package out of Mosoo workspace dependencies", () => {
     const packageJson = readDriverPackageJson();
     const deps = Object.keys(packageJson.dependencies ?? {});
     const tsconfig = readText("../tsconfig.json");


### PR DESCRIPTION
## Summary

- Add a versioned Driver image capability manifest declaring `npm` and `pip` as the package managers guaranteed by the maintained runtime image.
- Use the Cloudflare Sandbox 0.12.3 base image and verify during image construction that Node.js, npm, Python, and pip are executable and report valid versions.
- Verify that `python`/`python3` and `pip`/`python -m pip` resolve coherently without duplicating base-image or Ubuntu package versions in Docker arguments.
- Use one image-owned checker for build verification and CI smoke coverage. Malformed, duplicate, missing-binary, or unimplemented manager declarations fail closed.
- Exercise npm and pip with the same isolated-prefix layout used by Mosoo's reusable package artifacts from #345.
- Keep the change based on current Driver `main`, including #49 runtime path projection and #50 ACP behavior.

## Why

- langgenius/mosoo#337 requires the product's writable manager set to match capabilities guaranteed by the selected Driver image. Without an image-owned contract, a base-image change can turn a valid Environment into a user-Run failure.
- Exact `EXPECTED_*` values would duplicate versions produced by the pinned base image and mutable Ubuntu repositories. The maintained boundary is executable availability, valid version reporting, coherent aliases, and a real pinned-package smoke test.
- Mosoo #345 prepares npm/pip dependencies as reusable Sandbox Backups, and Driver #49 projects restored artifact paths into child processes. This PR supplies the missing image capability and fail-fast verification layer.
- The dependent product-side PR is [langgenius/mosoo#340](https://github.com/langgenius/mosoo/pull/340). This PR does not close the Mosoo issue by itself. **Merge this PR first; #340 must then point its Driver submodule at the resulting upstream commit.**

## Verification

- Commands:
  - `bun run lint`, `bun run tc`, and `bun run build`: passed.
  - `bun run test`: `205` passed and `4` credential-backed live tests skipped.
  - Driver artifact contract suite: `6` passed.
  - Driver #49 child-process environment regression suites: `17` passed across the path projection and provider launch paths.
  - Parent Mosoo `just check`: passed formatting, docs links, lint, typecheck, all workspace tests, and GraphQL freshness; API reported `1022` tests across `172` files.
  - Mosoo #345 artifact/build/restore regression suites: `44` passed.
  - Current amd64 Docker image build: passed; build output verified Node/npm and Python/pip availability and coherent aliases.
  - `bun run docker:smoke:environment`: installed and executed `prettier@3.3.3` and `six==1.16.0` from temporary isolated prefixes.
  - Missing-npm injection failed closed with `npm failed: spawnSync npm ENOENT`.
  - Malformed npm version injection failed closed with `npm returned an invalid version: not-a-version`.
  - Unknown-manager manifest injection failed closed with `Environment package manager has no verify check: cargo`.
- Manual steps:
  - Built the Driver Dockerfile through local Wrangler using the real `@cloudflare/sandbox` Durable Object path.
  - Built pinned npm/pip artifacts in one Sandbox, persisted them through a local R2-backed Sandbox Backup, destroyed it, restored into a second Sandbox, and applied Driver #49's child-process environment projection.
  - Executed the restored Prettier CLI, Node package lookup, and Python import; output was `3.3.3`, `3.3.3`, and `1.16.0`.
- Not run:
  - Remote Cloudflare production deployment or account-backed platform integration tests.

**Source logic, the #337 reproduction path, and the local Worker/Sandbox/R2/Driver injection chain demonstrate that the runtime capability fix is effective. The unverified boundary is remote Cloudflare platform integration behavior, not the issue's package-manager consistency contract.**

## Impact

- User/API/contract changes:
  - Adds `environment-package-managers.json` as the Driver-owned declaration for writable Environment managers.
  - Does not change the Driver protocol, command grammar, provider behavior, Run lifecycle, or #49 child-process path projection.
- Generated files / GraphQL / DB / lockfile:
  - No generated files, GraphQL changes, DB migrations, lockfile changes, caches, or build outputs are committed.
- Env or config changes:
  - Keeps `cloudflare/sandbox:0.12.3` as the versioned base image tag; image behavior is verified during the build.
  - Adds no `EXPECTED_*` version arguments and no global `PIP_*` runtime environment variables.
  - Does not rewrite apt sources or add local network retry workarounds. Python/pip are installed through the image's normal Ubuntu repositories and verified afterward.
- Risk and rollback:
  - Missing binaries, malformed version output, mismatched aliases, or an unimplemented manifest entry fail image construction instead of a user Run.
  - Compatible Ubuntu security updates are not rejected solely because a duplicated version constant became stale.
  - A base-image upgrade remains explicit through the tag update and is covered by build verification and pinned-package smoke tests.
  - Rollback is a revert of these commits; no persistent data migration is involved.

## Review

- Closest review areas:
  - Docker image ownership and base digest maintenance.
  - Capability manifest semantics and cross-repository consumption.
  - Build-time verifier and isolated-prefix smoke behavior.
- Known trade-offs:
  - `apt`, `cargo`, `gem`, and `go` are deliberately absent; Mosoo #340 owns legacy read compatibility and migration errors.
  - The small JSON manifest is intentional: it is the machine-readable Driver-owned boundary consumed by the image checker and Mosoo's drift test.
  - Local Wrangler validates the production code paths and container image, but cannot certify remote Cloudflare account behavior.

