### PR TITLE
feat(runtime): inject artifact paths into child process env

### DIFF
--- a/src/protocol/boot/index.ts
+++ b/src/protocol/boot/index.ts
@@ -65,6 +65,11 @@ export type {
 } from "../runtime";
 
 export interface DriverExecutionEnvironment {
+  readonly paths?: {
+    readonly executable: string[];
+    readonly node: string[];
+    readonly python: string[];
+  };
   readonly variables: Record<string, string>;
 }
 
@@ -215,6 +220,28 @@ function readVariables(value: unknown): Record<string, string> {
   }
 
   return variables;
+}
+
+function readAbsolutePathArray(record: Record<string, unknown>, field: string): string[] {
+  const label = "execution.environment.paths";
+  return readStringArray(record, field, label).map((path, index) => {
+    if (!path.startsWith("/") || path.includes("\0")) {
+      throw new TypeError(
+        `${label}.${field}[${index}] must be an absolute path without null bytes.`,
+      );
+    }
+
+    return path;
+  });
+}
+
+function readEnvironmentPaths(value: unknown): NonNullable<DriverExecutionEnvironment["paths"]> {
+  const paths = readRecord(value, "execution.environment.paths");
+  return {
+    executable: readAbsolutePathArray(paths, "executable"),
+    node: readAbsolutePathArray(paths, "node"),
+    python: readAbsolutePathArray(paths, "python"),
+  };
 }
 
 function readNativeRuntimeRef(value: unknown): DriverNativeRuntimeRef | null {
@@ -440,6 +467,9 @@ function readExecution(value: unknown): DriverExecutionSpec {
     builtInTools: readArray(record["builtInTools"], "execution.builtInTools").map(readBuiltInTool),
     configRevision: readConfigRevision(record["configRevision"]),
     environment: {
+      ...(environment["paths"] === undefined
+        ? {}
+        : { paths: readEnvironmentPaths(environment["paths"]) }),
       variables: readVariables(environment["variables"]),
     },
     model: readNonEmptyString(record, "model", "execution"),

--- a/src/runtimes/acp/acp-client-request-handler.ts
+++ b/src/runtimes/acp/acp-client-request-handler.ts
@@ -1,3 +1,4 @@
+import type { DriverExecutionEnvironment } from "../../protocol/boot";
 import type { DriverEventInput } from "../../protocol/events";
 import type { AgentDriverContext } from "../agent-driver-backend";
 import { shouldIgnoreAcpReplayUpdate, toAcpPermissionResolvedEvent } from "./acp-event-translator";
@@ -11,6 +12,7 @@ import { isRecord, readNonEmptyString, stringifyForDisplay } from "./acp-types";
 interface AcpClientRequestHandlerOptions {
   readonly allowedRoots: readonly string[];
   readonly cwd: string;
+  readonly paths?: DriverExecutionEnvironment["paths"];
   isTurnCancelRequested(): boolean;
   nativeSessionId(): string | null;
   push(context: AgentDriverContext, reason: string, events: DriverEventInput[]): Promise<void>;
@@ -39,6 +41,7 @@ export class AcpClientRequestHandler {
     this.#terminalManager = new AcpTerminalManager({
       allowedRoots: options.allowedRoots,
       cwd: options.cwd,
+      paths: options.paths,
       push: options.push,
     });
   }

--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -1,5 +1,6 @@
 import type { DriverExecutionSessionContext } from "../../protocol/boot";
 import type { DriverStartInput } from "../../protocol/start";
+import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import type { AcpAuthMethod, AcpInitializeResult, AcpMcpServer, JsonObject } from "./acp-types";
 import { isRecord, readRecord } from "./acp-types";
 
@@ -61,7 +62,7 @@ export function buildAcpChildProcessEnv(
 ): Record<string, string> {
   const { homePath } = payload.execution.session;
 
-  return {
+  return buildRuntimeChildProcessEnv(payload.execution.environment.paths, {
     ...buildAcpInheritedProcessEnv(processEnv),
     ...payload.execution.environment.variables,
     DISABLE_AUTOUPDATER: "1",
@@ -72,7 +73,7 @@ export function buildAcpChildProcessEnv(
     IS_SANDBOX: "1",
     PATH: processEnv["PATH"] ?? "",
     PWD: payload.execution.session.cwd,
-  };
+  });
 }
 
 export function buildAcpClientCapabilities(): JsonObject {

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -96,6 +96,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
       cwd: payload.execution.session.cwd,
       isTurnCancelRequested: () => this.#activeTurn?.cancelRequested ?? false,
       nativeSessionId: () => this.#nativeSessionId,
+      paths: payload.execution.environment.paths,
       push: async (context, reason, events) => this.#push(context, reason, events),
       turnEvents: this.#turnEvents,
     });

--- a/src/runtimes/acp/acp-terminal-manager.ts
+++ b/src/runtimes/acp/acp-terminal-manager.ts
@@ -3,8 +3,10 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { isAbsolute, resolve } from "node:path";
 
+import type { DriverExecutionEnvironment } from "../../protocol/boot";
 import type { DriverEventInput } from "../../protocol/events";
 import type { AgentDriverContext } from "../agent-driver-backend";
+import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import { isRecord, readArray, readNonEmptyString, readNumber, readString } from "./acp-types";
 import type { JsonObject } from "./acp-types";
 
@@ -27,6 +29,7 @@ interface AcpTerminalExitStatus {
 interface AcpTerminalManagerOptions {
   readonly allowedRoots: readonly string[];
   readonly cwd: string;
+  readonly paths?: DriverExecutionEnvironment["paths"];
   push(context: AgentDriverContext, reason: string, events: DriverEventInput[]): Promise<void>;
 }
 
@@ -64,10 +67,10 @@ export class AcpTerminalManager {
     const terminalId = randomUUID();
     const child = spawn(command, args, {
       cwd,
-      env: {
+      env: buildRuntimeChildProcessEnv(this.#options.paths, {
         ...process.env,
         ...env,
-      },
+      }),
       stdio: ["pipe", "pipe", "pipe"],
     });
     const exited = new Promise<AcpTerminalExitStatus>((resolveExit) => {

--- a/src/runtimes/child-process-env.ts
+++ b/src/runtimes/child-process-env.ts
@@ -1,15 +1,28 @@
 import { DRIVER_BOOT_PAYLOAD_ENV_NAME, DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME } from "../protocol/boot";
+import type { DriverExecutionEnvironment } from "../protocol/boot";
 
 export { DRIVER_BOOT_PAYLOAD_ENV_NAME, DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME };
 
-export function buildRuntimeChildProcessEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  const env = {
-    ...process.env,
-    ...overrides,
-  };
+export function buildRuntimeChildProcessEnv(
+  paths: DriverExecutionEnvironment["paths"],
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const childEnv = Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
 
-  delete env[DRIVER_BOOT_PAYLOAD_ENV_NAME];
-  delete env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME];
+  for (const [name, artifactPaths] of [
+    ["PATH", paths?.executable ?? []],
+    ["NODE_PATH", paths?.node ?? []],
+    ["PYTHONPATH", paths?.python ?? []],
+  ] as const) {
+    if (artifactPaths.length > 0) {
+      childEnv[name] = [...artifactPaths, ...(childEnv[name] ? [childEnv[name]] : [])].join(":");
+    }
+  }
 
-  return env;
+  delete childEnv[DRIVER_BOOT_PAYLOAD_ENV_NAME];
+  delete childEnv[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME];
+
+  return childEnv;
 }

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -91,11 +91,12 @@ function toClaudeMcpServers(
 }
 
 function toClaudeEnv(payload: DriverStartInput, claudeConfigDir: string): NodeJS.ProcessEnv {
-  return buildRuntimeChildProcessEnv({
+  return {
+    ...process.env,
     ...payload.execution.environment.variables,
     CLAUDE_AGENT_SDK_CLIENT_APP: "mosoo-driver/0.1.0",
     CLAUDE_CONFIG_DIR: claudeConfigDir,
-  });
+  };
 }
 
 export function toClaudeBuiltInTools(payload: DriverStartInput): string[] {
@@ -168,6 +169,10 @@ export async function createClaudeQueryOptions(input: {
   }
 
   const mergedOptions = mergeClaudeQueryOptions(options, input.payload.execution.providerOptions);
+  mergedOptions.env = buildRuntimeChildProcessEnv(
+    input.payload.execution.environment.paths,
+    mergedOptions.env ?? {},
+  );
   mergedOptions.tools = builtInTools;
   return mergedOptions;
 }

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -166,7 +166,8 @@ export class OpenAiAppServerClient {
     await measure("app_server.home.mkdir", () => mkdir(runtimeHome, { recursive: true }));
 
     const mcpConfig = buildOpenAiMcpServerConfig(this.#payload.execution.session.mcpServers);
-    const env = buildRuntimeChildProcessEnv({
+    const env = buildRuntimeChildProcessEnv(this.#payload.execution.environment.paths, {
+      ...process.env,
       ...this.#payload.execution.environment.variables,
       ...mcpConfig.env,
       [OPENAI_RUNTIME_HOME_ENV_NAME]: runtimeHome,

--- a/tests/acp-client-request-handler.test.ts
+++ b/tests/acp-client-request-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { AcpClientRequestHandler } from "../src/runtimes/acp/acp-client-request-handler";
 import { AcpTurnEventState } from "../src/runtimes/acp/acp-event-translator";
+import { AcpTerminalManager } from "../src/runtimes/acp/acp-terminal-manager";
 
 describe("ACP client request handler", () => {
   test("suppresses turn-scoped session updates before a turn is active", async () => {
@@ -42,5 +43,23 @@ describe("ACP client request handler", () => {
     }
 
     expect(pushedReasons).toEqual([]);
+  });
+
+  test("prepends artifact paths to terminal child processes", async () => {
+    const manager = new AcpTerminalManager({
+      allowedRoots: [],
+      cwd: process.cwd(),
+      paths: { executable: ["/artifact/bin"], node: [], python: [] },
+      push: async () => {},
+    });
+    const { terminalId } = await manager.create({} as never, {
+      args: ["-e", "process.stdout.write(process.env.PATH ?? '')"],
+      command: process.execPath,
+      env: [],
+    });
+
+    await manager.waitForExit({ terminalId });
+
+    expect(manager.output({ terminalId }).output).toStartWith("/artifact/bin:");
   });
 });

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -50,19 +50,35 @@ describe("ACP runtime configuration", () => {
     ).toThrow();
   });
 
-  test("inherits runtime proxy env for ACP child processes only", () => {
-    const env = buildAcpChildProcessEnv(bootPayload, {
-      HTTPS_PROXY: "http://host.docker.internal:7897",
-      NODE_USE_ENV_PROXY: "1",
-      PATH: "/usr/local/bin:/usr/bin",
-      RANDOM_SECRET: "secret",
-      http_proxy: "http://host.docker.internal:7897",
-    });
+  test("inherits only runtime proxy env and prepends artifact paths", () => {
+    const env = buildAcpChildProcessEnv(
+      {
+        ...bootPayload,
+        execution: {
+          ...bootPayload.execution,
+          environment: {
+            paths: {
+              executable: ["/artifact/bin"],
+              node: [],
+              python: [],
+            },
+            variables: {},
+          },
+        },
+      },
+      {
+        HTTPS_PROXY: "http://host.docker.internal:7897",
+        NODE_USE_ENV_PROXY: "1",
+        PATH: "/usr/local/bin:/usr/bin",
+        RANDOM_SECRET: "secret",
+        http_proxy: "http://host.docker.internal:7897",
+      },
+    );
 
     expect(env).toMatchObject({
       HTTPS_PROXY: "http://host.docker.internal:7897",
       NODE_USE_ENV_PROXY: "1",
-      PATH: "/usr/local/bin:/usr/bin",
+      PATH: "/artifact/bin:/usr/local/bin:/usr/bin",
       http_proxy: "http://host.docker.internal:7897",
     });
     expect(env["RANDOM_SECRET"]).toBeUndefined();

--- a/tests/child-process-env.test.ts
+++ b/tests/child-process-env.test.ts
@@ -1,59 +1,80 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
+import { parseDriverBootPayload } from "../src/protocol/boot";
 import {
   DRIVER_BOOT_PAYLOAD_ENV_NAME,
   DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME,
   buildRuntimeChildProcessEnv,
 } from "../src/runtimes/child-process-env";
+import { driverBootPayload } from "./driver-boot-payload-fixture";
 
-const inheritedEnvName = "MOSOO_DRIVER_ENV_TEST_KEEP";
-const inheritedEnvValue = process.env[inheritedEnvName];
-const bootPayloadEnvValue = process.env[DRIVER_BOOT_PAYLOAD_ENV_NAME];
-const bootPayloadFileEnvValue = process.env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME];
-
-afterEach(() => {
-  if (inheritedEnvValue === undefined) {
-    delete process.env[inheritedEnvName];
-  } else {
-    process.env[inheritedEnvName] = inheritedEnvValue;
-  }
-
-  if (bootPayloadEnvValue === undefined) {
-    delete process.env[DRIVER_BOOT_PAYLOAD_ENV_NAME];
-  } else {
-    process.env[DRIVER_BOOT_PAYLOAD_ENV_NAME] = bootPayloadEnvValue;
-  }
-
-  if (bootPayloadFileEnvValue === undefined) {
-    delete process.env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME];
-  } else {
-    process.env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME] = bootPayloadFileEnvValue;
-  }
-});
+function withEnvironmentPaths(paths: unknown) {
+  return {
+    ...driverBootPayload,
+    execution: {
+      ...driverBootPayload.execution,
+      environment: { ...driverBootPayload.execution.environment, paths },
+    },
+  };
+}
 
 describe("buildRuntimeChildProcessEnv", () => {
-  test("keeps inherited environment and removes driver-only boot payload", () => {
-    process.env[inheritedEnvName] = "keep";
-    process.env[DRIVER_BOOT_PAYLOAD_ENV_NAME] = "large-private-payload";
-    process.env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME] = "large-private-payload-file";
-
-    const env = buildRuntimeChildProcessEnv({
+  test("keeps the final environment and removes driver-only boot payload", () => {
+    const env = buildRuntimeChildProcessEnv(driverBootPayload.execution.environment.paths, {
+      [DRIVER_BOOT_PAYLOAD_ENV_NAME]: "large-private-payload",
+      [DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME]: "large-private-payload-file",
+      INHERITED_VAR: "keep",
+      PATH: "",
       RUNTIME_VISIBLE_VAR: "visible",
     });
 
-    expect(env[inheritedEnvName]).toBe("keep");
+    expect(env["INHERITED_VAR"]).toBe("keep");
+    expect(env["PATH"]).toBe("");
     expect(env["RUNTIME_VISIBLE_VAR"]).toBe("visible");
     expect(env[DRIVER_BOOT_PAYLOAD_ENV_NAME]).toBeUndefined();
     expect(env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME]).toBeUndefined();
   });
 
-  test("does not allow overrides to reintroduce driver-only boot payload references", () => {
-    const env = buildRuntimeChildProcessEnv({
-      [DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME]: "override-payload-file",
-      [DRIVER_BOOT_PAYLOAD_ENV_NAME]: "override",
-    });
+  test("prepends artifact paths to the final child environment", () => {
+    const env = buildRuntimeChildProcessEnv(
+      {
+        executable: ["/artifact/bin"],
+        node: ["/artifact/node"],
+        python: ["/artifact/python"],
+      },
+      {
+        NODE_PATH: "/runtime/node",
+        PATH: "/runtime/bin",
+        PYTHONPATH: "/runtime/python",
+      },
+    );
 
-    expect(env[DRIVER_BOOT_PAYLOAD_ENV_NAME]).toBeUndefined();
-    expect(env[DRIVER_BOOT_PAYLOAD_FILE_ENV_NAME]).toBeUndefined();
+    expect(env["PATH"]).toBe("/artifact/bin:/runtime/bin");
+    expect(env["NODE_PATH"]).toBe("/artifact/node:/runtime/node");
+    expect(env["PYTHONPATH"]).toBe("/artifact/python:/runtime/python");
+  });
+});
+
+describe("Driver execution environment paths", () => {
+  test("parses absolute path arrays as an additive protocol version 1 field", () => {
+    const paths = {
+      executable: ["/artifact/bin"],
+      node: ["/artifact/node"],
+      python: ["/artifact/python"],
+    };
+
+    expect(parseDriverBootPayload(withEnvironmentPaths(paths)).execution.environment.paths).toEqual(
+      paths,
+    );
+  });
+
+  test("keeps legacy version 1 payloads valid when paths are absent", () => {
+    expect(parseDriverBootPayload(driverBootPayload).execution.environment.paths).toBeUndefined();
+  });
+
+  test.each(["relative/path", "/artifact/\0bin"])("rejects invalid path %j", (path) => {
+    expect(() =>
+      parseDriverBootPayload(withEnvironmentPaths({ executable: [path], node: [], python: [] })),
+    ).toThrow("execution.environment.paths.executable[0]");
   });
 });

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -115,7 +115,7 @@ describe("Claude Agent SDK query options", () => {
     ]);
   });
 
-  test("passes reasoning effort, turn budget, and tools into Claude SDK query options", async () => {
+  test("passes runtime options and artifact paths into Claude SDK query options", async () => {
     const runtimeHome = await createRuntimeHome();
     const payload = createDriverStartInputFromBootPayload({
       ...driverBootPayload,
@@ -126,9 +126,21 @@ describe("Claude Agent SDK query options", () => {
             ? { enabled: false, name: tool.name }
             : tool,
         ),
+        environment: {
+          paths: {
+            executable: ["/artifact/bin"],
+            node: [],
+            python: [],
+          },
+          variables: {},
+        },
         model: "claude-sonnet-4-5",
         provider: "anthropic",
         providerOptions: {
+          env: {
+            MOSOO_DRIVER_BOOT_PAYLOAD: "must-not-leak",
+            PATH: "/provider/bin",
+          },
           effort: "max",
           maxTurns: 7,
           tools: ["Bash", "Read", "WebFetch"],
@@ -173,5 +185,8 @@ describe("Claude Agent SDK query options", () => {
       permissionMode: "default",
       tools: ["Read", "Write", "Edit", "Glob", "Grep", "WebFetch"],
     });
+
+    expect(options.env?.["PATH"]).toBe("/artifact/bin:/provider/bin");
+    expect(options.env?.["MOSOO_DRIVER_BOOT_PAYLOAD"]).toBeUndefined();
   });
 });

--- a/tests/openai-app-server-client.test.ts
+++ b/tests/openai-app-server-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -27,13 +27,16 @@ afterEach(async () => {
 });
 
 describe("OpenAi app-server client", () => {
-  test("reports process exit after queued server messages", async () => {
+  test("injects artifact paths and reports process exit after queued server messages", async () => {
     const directory = await mkdtemp(join(tmpdir(), "mosoo-openai-client-"));
     temporaryDirectories.push(directory);
     const executable = join(directory, "fake-app-server");
+    const environmentLog = join(directory, "environment.json");
     await Bun.write(
       executable,
-      `#!/usr/bin/env bun
+      `#!${process.execPath}
+import { writeFileSync } from "node:fs";
+writeFileSync(${JSON.stringify(environmentLog)}, process.env.PATH ?? "");
 let buffer = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => {
@@ -53,6 +56,14 @@ process.stdin.on("data", (chunk) => {
       ...driverBootPayload,
       execution: {
         ...driverBootPayload.execution,
+        environment: {
+          paths: {
+            executable: ["/artifact/bin"],
+            node: [],
+            python: [],
+          },
+          variables: { PATH: "/environment/bin" },
+        },
         session: {
           ...driverBootPayload.execution.session,
           context: {
@@ -85,6 +96,8 @@ process.stdin.on("data", (chunk) => {
     });
 
     await client.start();
+
+    expect(await readFile(environmentLog, "utf8")).toBe("/artifact/bin:/environment/bin");
 
     for (let attempt = 0; attempt < 50 && protocolErrors.length === 0; attempt += 1) {
       await Bun.sleep(10);


### PR DESCRIPTION
## Summary

- Add optional `execution.environment.paths` (`executable` / `node` / `python`) to the driver boot protocol, validating absolute paths without null bytes while keeping legacy payloads valid when the field is absent.
- Rewrite `buildRuntimeChildProcessEnv` to prepend those artifact directories onto `PATH` / `NODE_PATH` / `PYTHONPATH` and strip driver boot-payload env keys from the final child environment.
- Wire the same injection through ACP child/terminal processes, Claude Agent SDK query options, and the OpenAI app-server spawn path, with focused regression coverage.

## Why

- Sandbox artifact installs need to surface their bins and module roots to runtime child processes without callers hand-editing PATH-like env vars per provider.

## Verification

- Commands: `bun test tests/child-process-env.test.ts tests/acp-configuration.test.ts tests/acp-client-request-handler.test.ts tests/claude-agent-sdk-query-options.test.ts tests/openai-app-server-client.test.ts` (17 pass)
- Manual steps: N/A
- Not run: full package test suite / e2e

## Impact

- User/API/contract changes: additive optional `execution.environment.paths` on boot protocol version 1; `buildRuntimeChildProcessEnv(paths, env)` signature change for in-package callers
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: when `paths` is present, child processes receive prepended `PATH` / `NODE_PATH` / `PYTHONPATH`
- Risk and rollback: low; omit `paths` to restore prior env construction. Rollback by reverting this commit.

## Review

- Closest review areas: `src/protocol/boot/index.ts`, `src/runtimes/child-process-env.ts`, ACP/Claude/OpenAI call sites
- Known trade-offs: path entries are joined with `:`; validation is absolute-path + null-byte only (sandbox file-path helpers are intentionally not reused for PATH directories)