### PR TITLE
fix(acp): fail empty completed turns

### DIFF
--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -231,7 +231,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
       const completionEvents = this.#turnEvents.completePrompt(stopReason, promptResult.usage);
       const promptCancelled =
         this.#activeTurn.cancelRequested || promptResult.stopReason === "cancelled";
-      const promptFailed = stopReason === "max_turn_requests";
+      const promptFailed = completionEvents.some((event) => event.kind === "run.failed");
 
       await this.#push(
         context,

--- a/src/runtimes/acp/acp-event-translator.ts
+++ b/src/runtimes/acp/acp-event-translator.ts
@@ -151,6 +151,12 @@ export class AcpTurnEventState {
       });
     }
 
+    const finalMessage = this.#lastCompletedAssistantMessage;
+    const emptyTurn =
+      stopReason === "end_turn" &&
+      (finalMessage === null || finalMessage.text.trim().length === 0) &&
+      !this.#tools.hasActivity();
+
     if (stopReason === "cancelled") {
       events.push({
         kind: "run.cancelled",
@@ -173,9 +179,20 @@ export class AcpTurnEventState {
         },
         runId,
       });
+    } else if (emptyTurn) {
+      events.push({
+        kind: "run.failed",
+        payload: {
+          error: {
+            code: "acp.empty_turn",
+            message: "ACP prompt ended without assistant output or tool activity.",
+          },
+          recoverable: true,
+          stopReason,
+        },
+        runId,
+      });
     } else {
-      const finalMessage = this.#lastCompletedAssistantMessage;
-
       events.push({
         kind: "run.completed",
         payload: {

--- a/src/runtimes/acp/acp-tool-events.ts
+++ b/src/runtimes/acp/acp-tool-events.ts
@@ -35,6 +35,10 @@ export class AcpToolEventState {
   readonly #completed = new Set<string>();
   readonly #started = new Set<string>();
 
+  hasActivity(): boolean {
+    return this.#started.size > 0;
+  }
+
   clear(): void {
     this.#completed.clear();
     this.#started.clear();

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -219,7 +219,7 @@ describe("ACP runtime event translation", () => {
       }),
       ...anonymousFinalState.completePrompt("end_turn", null),
     ];
-    const anonymousCompleted = requireEvent(anonymousFinalEvents, "run.completed");
+    const anonymousFailed = requireEvent(anonymousFinalEvents, "run.failed");
     const firstAnonymousDelta = requireEvent(
       anonymousFinalEvents.filter(
         (event) =>
@@ -240,8 +240,13 @@ describe("ACP runtime event translation", () => {
     expect(eventPayloadString(firstAnonymousDelta, "messageId")).not.toBe(
       eventPayloadString(finalAnonymousDelta, "messageId"),
     );
-    expect(eventPayload(anonymousCompleted)).not.toHaveProperty("finalMessageId");
-    expect(eventPayload(anonymousCompleted)).not.toHaveProperty("finalMessageText");
+    expect(eventPayload(anonymousFailed)).toMatchObject({
+      error: {
+        code: "acp.empty_turn",
+      },
+      recoverable: true,
+      stopReason: "end_turn",
+    });
   });
 
   test("maps ACP turn updates onto canonical runtime events with one tool lifecycle", () => {
@@ -516,6 +521,32 @@ describe("ACP runtime event translation", () => {
     });
   });
 
+  test("fails an empty end turn instead of reporting a blank completed run", () => {
+    const state = new AcpTurnEventState();
+
+    state.begin({
+      messageId: "message-1",
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    const events = state.completePrompt("end_turn", {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+
+    expect(eventKinds(events)).toEqual(["usage.updated", "run.failed"]);
+    expect(eventPayload(events[1])).toMatchObject({
+      error: {
+        code: "acp.empty_turn",
+        message: "ACP prompt ended without assistant output or tool activity.",
+      },
+      recoverable: true,
+      stopReason: "end_turn",
+    });
+  });
+
   test("ignores ACP user message echo chunks because driver input is the source of truth", () => {
     const state = new AcpTurnEventState();
 
@@ -672,7 +703,7 @@ describe("ACP runtime event translation", () => {
       }),
       ...state.completePrompt("end_turn", null),
     ];
-    const completed = requireEvent(events, "run.completed");
+    const failed = requireEvent(events, "run.failed");
 
     expect(eventKinds(events)).toEqual([
       "message.started",
@@ -681,10 +712,15 @@ describe("ACP runtime event translation", () => {
       "thought.started",
       "thought.delta",
       "thought.completed",
-      "run.completed",
+      "run.failed",
     ]);
-    expect(eventPayload(completed)).not.toHaveProperty("finalMessageId");
-    expect(eventPayload(completed)).not.toHaveProperty("finalMessageText");
+    expect(eventPayload(failed)).toMatchObject({
+      error: {
+        code: "acp.empty_turn",
+      },
+      recoverable: true,
+      stopReason: "end_turn",
+    });
   });
 
   test("closes open stream items before a failed turn event", () => {

--- a/tests/fixtures/providers/acp/cases/thought-and-unknown-update.json
+++ b/tests/fixtures/providers/acp/cases/thought-and-unknown-update.json
@@ -70,8 +70,13 @@
       "runId": "run-1"
     },
     {
-      "kind": "run.completed",
+      "kind": "run.failed",
       "payload": {
+        "error": {
+          "code": "acp.empty_turn",
+          "message": "ACP prompt ended without assistant output or tool activity."
+        },
+        "recoverable": true,
         "stopReason": "end_turn"
       },
       "runId": "run-1"


### PR DESCRIPTION
## Summary

- fail ACP `end_turn` prompts that produced neither assistant output nor tool activity
- derive backend failure state from emitted terminal events
- update translator coverage and the ACP provider fixture

## Root cause

ACP could return `end_turn` without a completed assistant message or any tool activity. The translator still emitted `run.completed`, so Mosoo showed a successful but completely empty Agent run.

## Validation

- `bun run tc`
- `bun run lint`
- `bun test tests/acp-event-translator.test.ts tests/acp-provider-fixtures.test.ts` (23 passed)

The full suite also passes the changed ACP coverage. Its existing OpenCode process contract test fails locally because the installed `opencode` command writes non-JSON text to stdout before the ACP response; this is unrelated to the changed files and reproduces when run alone.