### PR TITLE
fix(claude): key assistant messages by API message id during streaming

### DIFF
--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -45,6 +45,7 @@ export class ClaudeAgentSdkMessageTranslator {
   readonly #options: ClaudeMessageTranslatorOptions;
   readonly #streamedTextMessages = new Set<string>();
   readonly #streamedTextByMessageId = new Map<string, string>();
+  readonly #streamingNativeMessageIds = new Map<string, string>();
   readonly #textByAssistantMessageId = new Map<MessageId, string>();
 
   constructor(options: ClaudeMessageTranslatorOptions) {
@@ -65,6 +66,7 @@ export class ClaudeAgentSdkMessageTranslator {
     this.#lastCompletedAssistantMessages.clear();
     this.#streamedTextByMessageId.clear();
     this.#streamedTextMessages.clear();
+    this.#streamingNativeMessageIds.clear();
     this.#textByAssistantMessageId.clear();
   }
 
@@ -152,7 +154,8 @@ export class ClaudeAgentSdkMessageTranslator {
         const isDuplicateStreamedText =
           text === null ||
           this.#streamedTextMessages.has(messageId) ||
-          isDuplicateClaudeFinalText(this.#streamedTextByMessageId, messageId, text);
+          isDuplicateClaudeFinalText(this.#streamedTextByMessageId, messageId, text) ||
+          this.#textByAssistantMessageId.get(messageId) === text;
 
         if (isTruthy(text) && !isDuplicateStreamedText) {
           this.#appendAssistantText(messageId, text);
@@ -207,16 +210,29 @@ export class ClaudeAgentSdkMessageTranslator {
   ): Promise<void> {
     const event = isRecord(message.event) ? message.event : null;
     const eventType = readString(event, "type");
+    // Each stream_event envelope carries its own uuid, so per-event envelope ids
+    // cannot identify the message. The API message id from message_start is the
+    // stable identity for every chunk until the matching message_stop.
+    const streamScopeKey = this.#streamScopeKey(runId, message);
 
     if (eventType === "message_start") {
+      const nativeMessageId = readString(readRecord(event, "message"), "id");
+
+      if (nativeMessageId !== null) {
+        this.#streamingNativeMessageIds.set(streamScopeKey, nativeMessageId);
+      }
+
       await this.#events.ensureMessageStarted(
         context,
-        this.#assistantMessageId(runId, this.#readNativeMessageId(message)),
+        this.#assistantMessageId(runId, nativeMessageId),
       );
       return;
     }
 
-    const messageId = this.#assistantMessageId(runId, this.#readNativeMessageId(message));
+    const messageId = this.#assistantMessageId(
+      runId,
+      this.#streamingNativeMessageIds.get(streamScopeKey) ?? null,
+    );
 
     if (eventType === "content_block_start") {
       await this.#handleContentBlockStart(context, messageId, event);
@@ -240,6 +256,7 @@ export class ClaudeAgentSdkMessageTranslator {
     if (eventType === "message_stop") {
       await this.endActiveThought(context);
       await this.#endAssistantMessage(context, runId, messageId);
+      this.#streamingNativeMessageIds.delete(streamScopeKey);
       this.#blockIndexToToolCallId.clear();
       return;
     }
@@ -249,6 +266,15 @@ export class ClaudeAgentSdkMessageTranslator {
       const usage = readRecord(event, "usage");
       await this.#events.pushUsage(context, usage ?? delta, null);
     }
+  }
+
+  #streamScopeKey(runId: RunId, message: SDKMessage): string {
+    // Subagent stream events (parent_tool_use_id set) interleave with the main
+    // thread; scope the in-flight message pointer so they never cross-merge.
+    const parentToolUseId = isRecord(message)
+      ? readString(message, "parent_tool_use_id")
+      : null;
+    return `${runId}:${parentToolUseId ?? "main"}`;
   }
 
   #appendStreamedText(messageId: string, text: string): void {
@@ -519,7 +545,14 @@ export class ClaudeAgentSdkMessageTranslator {
   }
 
   #readNativeMessageId(message: SDKMessage): string | null {
-    return isRecord(message) ? readString(message, "uuid") : null;
+    if (!isRecord(message)) {
+      return null;
+    }
+
+    // The envelope uuid is unique per emitted SDK message, including the
+    // complete-assistant replays of an already-streamed message. Prefer the API
+    // message id so stream chunks and completion snapshots share one identity.
+    return readString(readRecord(message, "message"), "id") ?? readString(message, "uuid");
   }
 
   async #handleSystemMessage(

--- a/tests/claude-agent-sdk-provider-fixtures.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures.test.ts
@@ -361,6 +361,179 @@ describe("Claude Agent SDK provider fixtures", () => {
     expect(payload?.["finalMessageText"]).toBe("相同文本");
   });
 
+  test("keeps chunked stream deltas and the complete assistant snapshot on one message", async () => {
+    // Real SDK wire shape: every envelope (each stream chunk and the complete
+    // assistant replay) carries a distinct uuid; only the API message id inside
+    // message_start / assistant.message is stable across the whole message.
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          message: { id: "msg-api-1" },
+          type: "message_start",
+        },
+        type: "stream_event",
+        uuid: "envelope-1",
+      },
+      {
+        event: {
+          content_block: { text: "", type: "text" },
+          index: 0,
+          type: "content_block_start",
+        },
+        type: "stream_event",
+        uuid: "envelope-2",
+      },
+      {
+        event: {
+          delta: { text: "Got it —", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "envelope-3",
+      },
+      {
+        event: {
+          delta: { text: " I'm here.", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "envelope-4",
+      },
+      {
+        message: {
+          content: [{ text: "Got it — I'm here.", type: "text" }],
+          id: "msg-api-1",
+        },
+        type: "assistant",
+        uuid: "envelope-5",
+      },
+      {
+        event: {
+          index: 0,
+          type: "content_block_stop",
+        },
+        type: "stream_event",
+        uuid: "envelope-6",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "envelope-7",
+      },
+      {
+        result: "Got it — I'm here.",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "envelope-8",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const startedEvents = events().filter((event) => event.kind === "message.started");
+    const completedEvents = events().filter((event) => event.kind === "message.completed");
+    const textMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+      return typeof contentDelta === "string" && typeof messageId === "string"
+        ? [{ contentDelta, messageId }]
+        : [];
+    });
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(startedEvents).toHaveLength(1);
+    expect(completedEvents).toHaveLength(1);
+    expect(textMessages.map((entry) => entry.contentDelta)).toEqual(["Got it —", " I'm here."]);
+    expect(new Set(textMessages.map((entry) => entry.messageId)).size).toBe(1);
+    expect(payload?.["finalMessageId"]).toBe(textMessages[0]?.messageId);
+    expect(payload?.["finalMessageText"]).toBe("Got it — I'm here.");
+  });
+
+  test("scopes interleaved subagent stream chunks away from the main message", async () => {
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          message: { id: "msg-main" },
+          type: "message_start",
+        },
+        parent_tool_use_id: null,
+        type: "stream_event",
+        uuid: "envelope-1",
+      },
+      {
+        event: {
+          message: { id: "msg-subagent" },
+          type: "message_start",
+        },
+        parent_tool_use_id: "tool-task-1",
+        type: "stream_event",
+        uuid: "envelope-2",
+      },
+      {
+        event: {
+          delta: { text: "主线程回答", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        parent_tool_use_id: null,
+        type: "stream_event",
+        uuid: "envelope-3",
+      },
+      {
+        event: {
+          delta: { text: "子代理输出", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        parent_tool_use_id: "tool-task-1",
+        type: "stream_event",
+        uuid: "envelope-4",
+      },
+      {
+        event: {
+          delta: { text: "，继续。", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        parent_tool_use_id: null,
+        type: "stream_event",
+        uuid: "envelope-5",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const textByMessageId = new Map<string, string>();
+
+    for (const event of events()) {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        continue;
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+
+      if (typeof contentDelta === "string" && typeof messageId === "string") {
+        textByMessageId.set(messageId, (textByMessageId.get(messageId) ?? "") + contentDelta);
+      }
+    }
+
+    expect([...textByMessageId.values()].toSorted()).toEqual(["主线程回答，继续。", "子代理输出"]);
+  });
+
   test("does not promote a replayed stream-only message stop to canonical final", async () => {
     const { context, events, logger, translator } = createHarness();
     const messages = [


### PR DESCRIPTION
## Summary

- Key Claude assistant message identity on the stable API message id (`message_start.message.id` / `assistant.message.id`) instead of the per-event SDK envelope `uuid`.
- Track the in-flight streaming message per run, scoped by `parent_tool_use_id`, so stream chunks resolve to one message until `message_stop` and subagent streams cannot cross-merge into the main thread.
- Treat an authoritative text that already matches the projected message content as a duplicate, keeping replayed complete-assistant frames idempotent.
- Add regression tests modeling the real wire shape (distinct envelope uuid per event, stable `message.id`), including an interleaved main/subagent stream case.

## Why

Fixes YEF-852 (mosoo): streamed responses duplicated the final snapshot on screen and stream fragments never cleared.

Claude Code assigns a distinct envelope `uuid` to every emitted SDK message — each `stream_event` chunk and the complete-assistant replay all carry different uuids (verified against live `--output-format stream-json --include-partial-messages` output). Because the translator keyed assistant identity on that uuid:

1. every text chunk minted a fresh `messageId`, so each chunk rendered as its own message bubble;
2. the complete `assistant` envelope minted yet another `messageId`, so its full text bypassed the streamed-text dedupe and was re-emitted as a duplicate message;
3. `run.completed` bound `finalMessageId` to the duplicate, so the persisted snapshot never replaced the streamed fragments left in the live state.

## Verification

- Commands: `bun run lint`, `bun run tc`, `bun run test` (206 pass / 0 fail).
- Manual steps: replayed a captured live Claude Code stream-json session shape through the translator; confirmed one `message.started`, chunk deltas sharing one `messageId`, no full-text re-emit, and `finalMessageId` matching the streamed message. Confirmed the new regression tests fail against the previous implementation.
- Not run: `test:live:*` provider suites (need provider credentials).

## Impact

- User/API/contract changes: none — emitted driver event kinds/payloads unchanged; only message identity becomes stable across chunks and completion frames.
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: low; fixture-only shapes without API message ids keep the previous uuid/sequence fallback behavior. Revert the commit to roll back.

## Review

- Closest review areas: `#handleStreamEvent` streaming-pointer lifecycle (`message_start` → chunks → `message_stop`), `#readNativeMessageId` fallback order, and the duplicate-text guard in `#handleAssistantMessage`.
- Known trade-offs: multi-text-block final binding (`#resolveFinalAssistantSnapshot` exact-match) is unchanged; assistant envelopes without any API message id still fall back to envelope-uuid identity.
