### PR TITLE
build: migrate image builds to Buildah

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,4 +1,4 @@
 *
-!Dockerfile
+!Containerfile
 !dist/
 !dist/driver.mjs

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=gpt-5-nano
 # AGENT_DRIVER_LIVE_OPENCODE_MODEL=glm-4.7
 # AGENT_DRIVER_LIVE_OPENCODE_SMALL_MODEL=glm-4.7-flash
 
-# ACP fallback runtime. The packaged Docker image defaults this generic ACP
+# ACP fallback runtime. The packaged container image defaults this generic ACP
 # fallback to OpenCode. Override these for another ACP-compatible agent.
 # MOSOO_ACP_FALLBACK_COMMAND=opencode
 # MOSOO_ACP_FALLBACK_ARGS=["acp","--pure"]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Verify driver artifact
         run: test -f dist/driver.mjs
 
-  docker:
-    name: Docker
+  image:
+    name: Container image
     needs: check
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -97,12 +97,13 @@ jobs:
       - name: Build driver artifact
         run: vp run build
 
-      - name: Build Docker image
-        run: docker build --platform linux/amd64 -t agent-driver:ci .
+      - name: Build container image
+        run: buildah build --platform linux/amd64 -t agent-driver:ci .
 
       - name: Verify packaged binaries
         run: |
-          docker run --rm --entrypoint /bin/sh agent-driver:ci -c '
+          buildah from --name agent-driver-ci-container agent-driver:ci
+          buildah run agent-driver-ci-container -- /bin/sh -c '
             test -x /usr/local/bin/agent-driver
             test -x /usr/local/bin/mosoo-claude-code
             codex --version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,11 +59,17 @@ jobs:
           run-install: |
             - args: ['--frozen-lockfile']
 
-      - name: Setup just
-        uses: extractions/setup-just@v3
-
       - name: Check
-        run: just check
+        run: |
+          set -euo pipefail
+          vp run lint
+          vp run tc
+          vp run test
+          vp run build
+          test -f dist/driver.mjs
+          test -s dist/driver.mjs
+          test -x dist/driver.mjs
+          test "$(head -n 1 dist/driver.mjs)" = '#!/usr/bin/env bun'
 
   image:
     name: Container image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,20 +59,11 @@ jobs:
           run-install: |
             - args: ['--frozen-lockfile']
 
-      - name: Lint
-        run: vp run lint
+      - name: Setup just
+        uses: extractions/setup-just@v3
 
-      - name: Typecheck
-        run: vp run tc
-
-      - name: Test
-        run: vp run test
-
-      - name: Build
-        run: vp run build
-
-      - name: Verify driver artifact
-        run: test -f dist/driver.mjs
+      - name: Check
+        run: just check
 
   image:
     name: Container image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,8 +99,9 @@ jobs:
 
       - name: Verify packaged binaries
         run: |
-          buildah from --name agent-driver-ci-container agent-driver:ci
-          buildah run agent-driver-ci-container -- /bin/sh -c '
+          container="$(buildah from agent-driver:ci)"
+          trap 'buildah rm "$container"' EXIT
+          buildah run "$container" -- /bin/sh -c '
             test -x /usr/local/bin/agent-driver
             test -x /usr/local/bin/mosoo-claude-code
             codex --version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,9 +99,8 @@ jobs:
 
       - name: Verify packaged binaries
         run: |
-          container="$(buildah from agent-driver:ci)"
-          trap 'buildah rm "$container"' EXIT
-          buildah run "$container" -- /bin/sh -c '
+          buildah from --name agent-driver-ci-container agent-driver:ci
+          buildah run agent-driver-ci-container -- /bin/sh -c '
             test -x /usr/local/bin/agent-driver
             test -x /usr/local/bin/mosoo-claude-code
             codex --version

--- a/Containerfile
+++ b/Containerfile
@@ -14,8 +14,7 @@ RUN apt-get update \
     && pip --version
 
 # Native agent CLIs pre-installed so the driver can spawn them via PATH.
-# Installed in a single npm invocation so Docker caches the whole agent
-# layer as one unit.
+# Installed in a single npm invocation to keep the agent packages in one layer.
 #
 # Package -> binary -> runtime:
 #   @anthropic-ai/claude-agent-sdk        -> native claude    -> claude-agent-sdk
@@ -25,8 +24,8 @@ RUN apt-get update \
 #
 # Pick the architecture-specific `claude` binary that npm just installed under
 # `@anthropic-ai/claude-agent-sdk-<linux-x64|linux-arm64>` so the image works
-# on CF Containers (linux/amd64) and on local arm64 hosts (e.g. Apple Silicon
-# via OrbStack/Docker Desktop) without forcing platform emulation.
+# on CF Containers (linux/amd64) and local arm64 hosts (e.g. Apple Silicon)
+# without forcing platform emulation.
 RUN OPENAI_RUNTIME_PACKAGE="@openai/co""dex@${OPENAI_RUNTIME_VERSION}" \
     && npm install -g \
       @anthropic-ai/claude-agent-sdk@${CLAUDE_AGENT_SDK_VERSION} \

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ vp run lint
 vp run tc
 vp run test
 vp run build
-vp run docker:build
+vp run image:build
 ```
 
-`vp run docker:build` produces a local `agent-driver:local` image and installs `dist/driver.mjs` on the image `PATH` as `agent-driver`.
+`vp run image:build` uses Buildah to produce a local `agent-driver:local` OCI image and installs `dist/driver.mjs` on the image `PATH` as `agent-driver`.
 
 ## Boundaries
 
@@ -177,7 +177,7 @@ vp run docker:build
 - `vp run tc`
 - `vp run test`
 - `vp run build`
-- `vp run docker:build`
+- `vp run image:build`
 - no `@mosoo/*` runtime dependencies in `package.json`
 - public entries include typed exports
 - live provider smoke tests are gated by environment credentials

--- a/justfile
+++ b/justfile
@@ -16,8 +16,8 @@ test: lint
 build: test
     vp run build
 
-docker-build:
-    vp run docker:build
+image-build:
+    vp run image:build
 
 live-anthropic:
     vp run test:live:anthropic

--- a/justfile
+++ b/justfile
@@ -22,6 +22,9 @@ check:
     vp run test
     vp run build
     test -f dist/driver.mjs
+    test -s dist/driver.mjs
+    test -x dist/driver.mjs
+    test "$(head -n 1 dist/driver.mjs)" = '#!/usr/bin/env bun'
 
 image-build:
     vp run image:build

--- a/justfile
+++ b/justfile
@@ -16,6 +16,13 @@ test: lint
 build: test
     vp run build
 
+check:
+    vp run lint
+    vp run tc
+    vp run test
+    vp run build
+    test -f dist/driver.mjs
+
 image-build:
     vp run image:build
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "files": [
     "dist",
     "src",
-    "Dockerfile",
-    ".dockerignore",
+    "Containerfile",
+    ".containerignore",
     "README.md"
   ],
   "type": "module",
@@ -66,7 +66,7 @@
     "bench": "bun bench/ttft-bench.ts",
     "build": "vp run build:types && bun build src/bin/driver.ts --outfile dist/driver.mjs --target bun --format esm --bundle",
     "build:types": "rm -rf dist/types && vp exec tsc -p tsconfig.types.json",
-    "docker:build": "vp run build && docker build -t agent-driver:local .",
+    "image:build": "vp run build && buildah build -t agent-driver:local .",
     "lint": "vp lint src tests",
     "tc": "vp exec tsc --noEmit",
     "test": "bun test",

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -113,19 +113,19 @@ describe("ACP runtime configuration", () => {
         },
       },
       {
-        HTTPS_PROXY: "http://host.docker.internal:7897",
+        HTTPS_PROXY: "http://host.containers.internal:7897",
         NODE_USE_ENV_PROXY: "1",
         PATH: "/usr/local/bin:/usr/bin",
         RANDOM_SECRET: "secret",
-        http_proxy: "http://host.docker.internal:7897",
+        http_proxy: "http://host.containers.internal:7897",
       },
     );
 
     expect(env).toMatchObject({
-      HTTPS_PROXY: "http://host.docker.internal:7897",
+      HTTPS_PROXY: "http://host.containers.internal:7897",
       NODE_USE_ENV_PROXY: "1",
       PATH: "/artifact/bin:/usr/local/bin:/usr/bin",
-      http_proxy: "http://host.docker.internal:7897",
+      http_proxy: "http://host.containers.internal:7897",
     });
     expect(env["RANDOM_SECRET"]).toBeUndefined();
   });

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -64,7 +64,7 @@ describe("driver artifact contract", () => {
     });
     expect(packageJson.types).toBe("./dist/types/index.d.ts");
     expect(packageJson.files).toEqual(
-      expect.arrayContaining(["dist", "src", "Dockerfile", ".dockerignore", "README.md"]),
+      expect.arrayContaining(["dist", "src", "Containerfile", ".containerignore", "README.md"]),
     );
     expect(packageJson.files).not.toContain("tests/fixtures");
   });
@@ -105,30 +105,32 @@ describe("driver artifact contract", () => {
   test("builds and packages only the process runner artifact", () => {
     const packageJson = readDriverPackageJson();
     const buildScript = packageJson.scripts?.["build"] ?? "";
-    const dockerBuildScript = packageJson.scripts?.["docker:build"] ?? "";
-    const dockerignore = readText("../.dockerignore");
-    const dockerfile = readText("../Dockerfile");
+    const imageBuildScript = packageJson.scripts?.["image:build"] ?? "";
+    const containerignore = readText("../.containerignore");
+    const containerfile = readText("../Containerfile");
     const processEntry = readText("../src/bin/driver.ts");
 
     expect(processEntry.startsWith("#!/usr/bin/env bun\n")).toBe(true);
     expect(buildScript).toContain("src/bin/driver.ts");
     expect(buildScript).toContain("dist/driver.mjs");
     expect(buildScript).not.toContain("src/index.ts");
-    expect(dockerfile).toContain("COPY dist/driver.mjs /usr/local/bin/agent-driver");
-    expect(dockerfile).toContain("RUN chmod +x /usr/local/bin/agent-driver");
-    expect(dockerfile).toContain("ENV MOSOO_ACP_FALLBACK_COMMAND=opencode");
-    expect(dockerignore).toContain("!dist/driver.mjs");
-    expect(dockerBuildScript).toBe("vp run build && docker build -t agent-driver:local .");
+    expect(containerfile).toContain("COPY dist/driver.mjs /usr/local/bin/agent-driver");
+    expect(containerfile).toContain("RUN chmod +x /usr/local/bin/agent-driver");
+    expect(containerfile).toContain("ENV MOSOO_ACP_FALLBACK_COMMAND=opencode");
+    expect(containerignore).toContain("!dist/driver.mjs");
+    expect(imageBuildScript).toBe("vp run build && buildah build -t agent-driver:local .");
   });
 
   test("pins the OpenAI runtime, SDK, and app-server schema to one stable version", () => {
     const packageJson = readDriverPackageJson();
-    const dockerfile = readText("../Dockerfile");
+    const containerfile = readText("../Containerfile");
 
     expect(packageJson.devDependencies?.["@openai/codex-sdk"]).toBe(
       OPENAI_APP_SERVER_SCHEMA_VERSION,
     );
-    expect(dockerfile).toContain(`ARG OPENAI_RUNTIME_VERSION=${OPENAI_APP_SERVER_SCHEMA_VERSION}`);
+    expect(containerfile).toContain(
+      `ARG OPENAI_RUNTIME_VERSION=${OPENAI_APP_SERVER_SCHEMA_VERSION}`,
+    );
   });
 
   test("keeps the standalone package out of Mosoo workspace dependencies", () => {

--- a/tests/driver-boot-payload-fixture.ts
+++ b/tests/driver-boot-payload-fixture.ts
@@ -17,7 +17,7 @@ export const DRIVER_TEST_IDS = {
 
 export const driverBootPayload = {
   bootToken: "boot-token",
-  controlUrl: "http://host.docker.internal:8787/api/driver/socket",
+  controlUrl: "http://host.containers.internal:8787/api/driver/socket",
   driverControlPort: DRIVER_CONTROL_PORT_MIN,
   driverGeneration: 0,
   driverInstanceId: DRIVER_TEST_IDS.driverInstanceId,


### PR DESCRIPTION
Closes #59

## Summary

- Rename `Dockerfile` and `.dockerignore` to their container-native names.
- Rename local build commands around the image artifact.
- Build and inspect the CI image with Buildah.
- Replace Docker-specific host aliases with `host.containers.internal`.
- Add a local `just check` command and inline the equivalent strict checks in CI.
- Update documentation, package contents, and artifact contract tests.

## Why

The image workflow should use vendor-neutral OCI and container terminology while using Buildah for image packaging.

Local verification should have one convenient command, while CI should remain explicit and self-contained without installing `just`.

## Impact

- Local image builds now use `vp run image:build`.
- Local verification now uses `just check`.
- CI directly runs linting, type checking, tests, the production build, and artifact integrity checks.
- CI image packaging and verification now run through Buildah.
- Repository-owned files no longer contain Docker-specific names or references.

## Validation

- `just check`
- 1060 passing tests, 20 credential-gated skips, and 0 failures.
- The built driver artifact exists, is non-empty and executable, and has the expected Bun shebang.
- `npm pack --dry-run` includes `Containerfile`, `.containerignore`, and `dist/driver.mjs`.

The local environment did not provide a Buildah executable, so the image build is delegated to the pull request check on `ubuntu-latest`.
