### PR TITLE
ci: enforce repository formatting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Check
         run: |
           set -euo pipefail
+          vp fmt --check
           vp run lint
           vp run tc
           vp run test

--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ build: test
     vp run build
 
 check:
+    vp fmt --check
     vp run lint
     vp run tc
     vp run test

--- a/src/core/agent-driver-kernel.ts
+++ b/src/core/agent-driver-kernel.ts
@@ -309,12 +309,15 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
     });
   }
 
-  async commandUpdate(input: {
-    commandId: string;
-    error?: RunError;
-    result?: RuntimeCommandResult;
-    status: "accepted" | "cancelled" | "completed" | "failed";
-  }, _signal: AbortSignal): Promise<void> {
+  async commandUpdate(
+    input: {
+      commandId: string;
+      error?: RunError;
+      result?: RuntimeCommandResult;
+      status: "accepted" | "cancelled" | "completed" | "failed";
+    },
+    _signal: AbortSignal,
+  ): Promise<void> {
     const update = structuredClone(input);
     if (update.status === "accepted") {
       return;
@@ -646,16 +649,14 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
     this.#rejectPendingCommands(error);
 
     if (this.#activeRunId !== null) {
-      void this
-        .failRun({
-          code: "driver.runtime_failed",
-          details: {},
-          message: error.message,
-          retryable: false,
-        })
-        .catch((eventError: unknown) => {
-          this.#logger.error("driver.kernel.run_failure_event.failed", eventError, {});
-        });
+      void this.failRun({
+        code: "driver.runtime_failed",
+        details: {},
+        message: error.message,
+        retryable: false,
+      }).catch((eventError: unknown) => {
+        this.#logger.error("driver.kernel.run_failure_event.failed", eventError, {});
+      });
     }
 
     void this.#shutdown("driver.backend_failed").catch((shutdownError: unknown) => {
@@ -680,7 +681,11 @@ export class AgentDriverKernelCore implements AgentDriverKernel, DriverRuntimeIo
     this.#events.pushReserved(structuredClone(event));
   }
 
-  #stopBackend(backend: AgentDriverBackend, payload: DriverStartInput, reason: string): Promise<void> {
+  #stopBackend(
+    backend: AgentDriverBackend,
+    payload: DriverStartInput,
+    reason: string,
+  ): Promise<void> {
     const controller = new AbortController();
     const task = Promise.resolve().then(() =>
       backend.stop(this.#createContext(payload), reason, controller.signal),

--- a/src/core/driver-command-dispatcher.ts
+++ b/src/core/driver-command-dispatcher.ts
@@ -126,10 +126,7 @@ async function sendCommandUpdate(
     ...(update.result === undefined ? {} : { result: update.result }),
     status: update.status,
   });
-  await raceWithAbort(
-    runtimeContext.ports.eventSink.commandUpdate(delivery, signal),
-    signal,
-  );
+  await raceWithAbort(runtimeContext.ports.eventSink.commandUpdate(delivery, signal), signal);
 
   runtimeContext.logger.debug("driver.runtime.command.status.sent", {
     command: summarizeRuntimeCommand(command),
@@ -276,10 +273,7 @@ export class DriverCommandDispatcher {
 
         if (settleFailure !== null) {
           logger.warn("driver.runtime.active-work.settle-failed", {
-            message: toErrorMessage(
-              settleFailure.error,
-              "Active driver work did not settle.",
-            ),
+            message: toErrorMessage(settleFailure.error, "Active driver work did not settle."),
           });
           throw settleFailure.error;
         }
@@ -334,13 +328,11 @@ export class DriverCommandDispatcher {
         /* Ignore runtime error propagation failures */
       }
 
-      await this.#shutdown(socket, "driver.command_loop_failed").catch(
-        (shutdownError: unknown) => {
-          logger.error("driver.runtime.shutdown.failed", shutdownError, {
-            driverInstanceId: this.#driverInstanceId,
-          });
-        },
-      );
+      await this.#shutdown(socket, "driver.command_loop_failed").catch((shutdownError: unknown) => {
+        logger.error("driver.runtime.shutdown.failed", shutdownError, {
+          driverInstanceId: this.#driverInstanceId,
+        });
+      });
       await this.#joinActiveWork().catch((settleError: unknown) => {
         logger.warn("driver.runtime.active-work.settle-failed", {
           message: toErrorMessage(settleError, "Active driver work did not settle."),
@@ -423,25 +415,27 @@ export class DriverCommandDispatcher {
           cancellation,
           this.#activeRunGeneration,
           runId,
-        ).catch(async (error: unknown) => {
-          this.#activeWorkFailure ??= { error };
-          runtimeContext.logger.error("driver.runtime.input-task.failed", error, {
-            commandId: command.commandId,
-            driverInstanceId: this.#driverInstanceId,
+        )
+          .catch(async (error: unknown) => {
+            this.#activeWorkFailure ??= { error };
+            runtimeContext.logger.error("driver.runtime.input-task.failed", error, {
+              commandId: command.commandId,
+              driverInstanceId: this.#driverInstanceId,
+            });
+            await this.#shutdown(socket, "driver.input_task_failed").catch(
+              (shutdownError: unknown) => {
+                runtimeContext.logger.error("driver.runtime.shutdown.failed", shutdownError, {
+                  commandId: command.commandId,
+                });
+              },
+            );
+          })
+          .finally(() => {
+            if (this.#activeRunTask === activeRunTask) {
+              this.#activeRunTask = null;
+              this.#activeInputCancellation = null;
+            }
           });
-          await this.#shutdown(socket, "driver.input_task_failed").catch(
-            (shutdownError: unknown) => {
-              runtimeContext.logger.error("driver.runtime.shutdown.failed", shutdownError, {
-                commandId: command.commandId,
-              });
-            },
-          );
-        }).finally(() => {
-          if (this.#activeRunTask === activeRunTask) {
-            this.#activeRunTask = null;
-            this.#activeInputCancellation = null;
-          }
-        });
         this.#activeRunTask = activeRunTask;
         return;
       }
@@ -572,13 +566,11 @@ export class DriverCommandDispatcher {
           commandId: command.commandId,
           driverInstanceId: this.#driverInstanceId,
         });
-        await this.#shutdown(socket, "driver.mcp_task_failed").catch(
-          (shutdownError: unknown) => {
-            runtimeContext.logger.error("driver.runtime.shutdown.failed", shutdownError, {
-              commandId: command.commandId,
-            });
-          },
-        );
+        await this.#shutdown(socket, "driver.mcp_task_failed").catch((shutdownError: unknown) => {
+          runtimeContext.logger.error("driver.runtime.shutdown.failed", shutdownError, {
+            commandId: command.commandId,
+          });
+        });
       })
       .finally(() => {
         if (this.#activeMcpCommands.get(command.commandId)?.task === task) {
@@ -814,10 +806,7 @@ export class DriverCommandDispatcher {
     return task;
   }
 
-  async #deliverRunTerminal(
-    socket: DriverRuntimeIo,
-    terminal: RunTerminalDelivery,
-  ): Promise<void> {
+  async #deliverRunTerminal(socket: DriverRuntimeIo, terminal: RunTerminalDelivery): Promise<void> {
     const deadline = Date.now() + COMMAND_UPDATE_TIMEOUT_MS;
     let cause: unknown = new Error("Run terminal delivery deadline elapsed.");
 

--- a/src/core/driver-permission-broker.ts
+++ b/src/core/driver-permission-broker.ts
@@ -211,13 +211,10 @@ export class DriverPermissionBroker {
       });
 
       const requestedTask = pushLosslessEvents(socket, events);
-      const requestedDelivery = await settlePromiseWithTimeout(
-        requestedTask,
-        {
-          label: `Driver permission request ${input.requestId} event delivery`,
-          timeoutMs: this.#eventDeliveryTimeoutMs,
-        },
-      );
+      const requestedDelivery = await settlePromiseWithTimeout(requestedTask, {
+        label: `Driver permission request ${input.requestId} event delivery`,
+        timeoutMs: this.#eventDeliveryTimeoutMs,
+      });
 
       if (requestedDelivery.status !== "completed") {
         if (requestedDelivery.status === "timed_out") {
@@ -261,24 +258,21 @@ export class DriverPermissionBroker {
       }
 
       const resolutionTask = pushLosslessEvents(socket, [
-          {
-            kind: "permission.resolved",
-            payload: {
-              outcome: decision,
-              permissionRequests: [],
-              reason: resolution.reason,
-              requestId: input.requestId,
-            },
-          },
-          ...toResolutionDiagnostics(input, resolution.reason),
-        ]);
-      const resolutionDelivery = await settlePromiseWithTimeout(
-        resolutionTask,
         {
-          label: `Driver permission resolution ${input.requestId} event delivery`,
-          timeoutMs: this.#eventDeliveryTimeoutMs,
+          kind: "permission.resolved",
+          payload: {
+            outcome: decision,
+            permissionRequests: [],
+            reason: resolution.reason,
+            requestId: input.requestId,
+          },
         },
-      );
+        ...toResolutionDiagnostics(input, resolution.reason),
+      ]);
+      const resolutionDelivery = await settlePromiseWithTimeout(resolutionTask, {
+        label: `Driver permission resolution ${input.requestId} event delivery`,
+        timeoutMs: this.#eventDeliveryTimeoutMs,
+      });
 
       if (resolutionDelivery.status !== "completed") {
         if (resolutionDelivery.status === "timed_out") {

--- a/src/core/driver-process.ts
+++ b/src/core/driver-process.ts
@@ -35,11 +35,7 @@ import { createDriverPermissionRequestHandler } from "./driver-permission-policy
 import { pushLosslessEvents } from "./driver-runtime-io";
 import type { DriverRuntimeEventPort, DriverRuntimeRunPort } from "./driver-runtime-io";
 import { DriverRuntimeStateMachine } from "./driver-runtime-state";
-import {
-  createTimingEvent,
-  createTimingPhase,
-  toDurationMs,
-} from "./driver-runtime-timing";
+import { createTimingEvent, createTimingPhase, toDurationMs } from "./driver-runtime-timing";
 
 const DRIVER_VERSION = "0.1.0";
 const DRIVER_BACKEND_START_TIMEOUT_MS = 60_000;
@@ -413,11 +409,7 @@ export class DriverProcess {
   ): Promise<void> {
     const controller = new AbortController();
     const task = logger.span("driver.backend.stop", async () => {
-      await backend.stop(
-        this.createAgentDriverContext(socket, logger),
-        reason,
-        controller.signal,
-      );
+      await backend.stop(this.createAgentDriverContext(socket, logger), reason, controller.signal);
     });
     this.#backendStopController = controller;
     this.#backendStopTask = task;
@@ -575,7 +567,8 @@ export class DriverProcess {
     const retrying = shutdownTask === null && this.#shutdownController.signal.aborted;
 
     try {
-      await (shutdownTask ?? this.shutdown(socket, this.#shutdownReason ?? "runtime.socket.closed"));
+      await (shutdownTask ??
+        this.shutdown(socket, this.#shutdownReason ?? "runtime.socket.closed"));
     } catch (error) {
       if (retrying) {
         shutdownFailure = { error };

--- a/src/core/driver-runtime-io.ts
+++ b/src/core/driver-runtime-io.ts
@@ -35,9 +35,7 @@ export class DriverEventRejectedError extends Error {
  *
  * Callers retrying across separate delivery invocations must reuse this returned array.
  */
-export function withSourceEventIds(
-  events: readonly DriverEventInput[],
-): DriverEventInput[] {
+export function withSourceEventIds(events: readonly DriverEventInput[]): DriverEventInput[] {
   return events.map((event) =>
     typeof event.sourceEventId === "string" && event.sourceEventId.length > 0
       ? event
@@ -110,12 +108,15 @@ export async function pushLosslessEvents(
 }
 
 export interface DriverRuntimeCommandPort {
-  commandUpdate(input: {
-    commandId: string;
-    error?: RunError;
-    result?: RuntimeCommandResult;
-    status: "accepted" | "cancelled" | "completed" | "failed";
-  }, signal: AbortSignal): Promise<void>;
+  commandUpdate(
+    input: {
+      commandId: string;
+      error?: RunError;
+      result?: RuntimeCommandResult;
+      status: "accepted" | "cancelled" | "completed" | "failed";
+    },
+    signal: AbortSignal,
+  ): Promise<void>;
   nextCommand(signal: AbortSignal): Promise<RuntimeCommand | null>;
 }
 

--- a/src/core/driver-runtime-timing.ts
+++ b/src/core/driver-runtime-timing.ts
@@ -18,10 +18,7 @@ interface TimingEventInput {
   readonly traceId?: string | null;
 }
 
-export function toDurationMs(
-  startedAtMs: number,
-  completedAtMs: number = Date.now(),
-): number {
+export function toDurationMs(startedAtMs: number, completedAtMs: number = Date.now()): number {
   const durationMs = completedAtMs - startedAtMs;
 
   if (!Number.isFinite(durationMs)) {
@@ -31,10 +28,7 @@ export function toDurationMs(
   return Math.max(0, Math.round(durationMs));
 }
 
-export function createTimingPhase(
-  name: string,
-  durationMs: number,
-): RuntimeTimingPhase {
+export function createTimingPhase(name: string, durationMs: number): RuntimeTimingPhase {
   if (!Number.isFinite(durationMs)) {
     throw new Error("Driver runtime timing phase duration must be finite.");
   }
@@ -45,9 +39,7 @@ export function createTimingPhase(
   };
 }
 
-export function createTimingEvent(
-  input: TimingEventInput,
-): DriverEventInput {
+export function createTimingEvent(input: TimingEventInput): DriverEventInput {
   const completedAt = input.completedAt ?? new Date().toISOString();
   const completedAtMs = Date.parse(completedAt);
   const startedAtMs = Date.parse(input.startedAt);
@@ -59,9 +51,7 @@ export function createTimingEvent(
     payload: {
       completedAt,
       path: input.path,
-      phases: input.phases.map((phase) =>
-        createTimingPhase(phase.name, phase.durationMs),
-      ),
+      phases: input.phases.map((phase) => createTimingPhase(phase.name, phase.durationMs)),
       runId: input.runId,
       sessionId: input.sessionId,
       source: "driver",

--- a/src/host-ports/index.ts
+++ b/src/host-ports/index.ts
@@ -19,11 +19,14 @@ export interface AgentDriverCommandSource {
 }
 
 export interface AgentDriverEventSink {
-  commandUpdate(input: {
-    commandId: string;
-    result?: RuntimeCommandResult;
-    status: "accepted" | "cancelled" | "completed" | "failed";
-  }, signal: AbortSignal): Promise<void>;
+  commandUpdate(
+    input: {
+      commandId: string;
+      result?: RuntimeCommandResult;
+      status: "accepted" | "cancelled" | "completed" | "failed";
+    },
+    signal: AbortSignal,
+  ): Promise<void>;
   currentRunId?(): RunId | null;
   pushEvents(input: {
     events: DriverEventInput[];

--- a/src/infrastructure/runtime/driver-instance-socket.ts
+++ b/src/infrastructure/runtime/driver-instance-socket.ts
@@ -96,8 +96,7 @@ export class DriverInstanceSocket {
       }
 
       const code = event instanceof CloseEvent ? event.code : 1006;
-      const reason =
-        event instanceof CloseEvent ? event.reason : "runtime.socket.closed";
+      const reason = event instanceof CloseEvent ? event.reason : "runtime.socket.closed";
       this.#rpcAbortController.abort(new Error(reason || "runtime.socket.closed"));
       this.#client = null;
       this.#eventBatchMaxSize = null;
@@ -144,12 +143,15 @@ export class DriverInstanceSocket {
     return this.#activeRunId;
   }
 
-  async commandUpdate(input: {
-    commandId: string;
-    error?: RunError;
-    result?: RuntimeCommandResult;
-    status: "accepted" | "cancelled" | "completed" | "delivered" | "expired" | "failed";
-  }, signal: AbortSignal): Promise<void> {
+  async commandUpdate(
+    input: {
+      commandId: string;
+      error?: RunError;
+      result?: RuntimeCommandResult;
+      status: "accepted" | "cancelled" | "completed" | "delivered" | "expired" | "failed";
+    },
+    signal: AbortSignal,
+  ): Promise<void> {
     await this.#requireClient().driver.commandUpdate(
       {
         commandId: input.commandId,

--- a/src/runtime-events/index.ts
+++ b/src/runtime-events/index.ts
@@ -731,12 +731,7 @@ function readRunView(
   requireEnumValue(record, "status", runStatuses, context.kind);
 
   return {
-    completedAt: requireNullableTimestamp(
-      record,
-      "completedAt",
-      context.kind,
-      "run.completedAt",
-    ),
+    completedAt: requireNullableTimestamp(record, "completedAt", context.kind, "run.completedAt"),
     error:
       record["error"] === null ? null : readRunError(context.kind, record["error"], "run.error"),
     id: context.runId ?? null,
@@ -830,10 +825,7 @@ function readTimingPhases(value: unknown): RuntimeTimingPhase[] {
   });
 }
 
-function classifyIngressError(
-  input: unknown,
-  error: unknown,
-): RuntimeEventIngressRejection {
+function classifyIngressError(input: unknown, error: unknown): RuntimeEventIngressRejection {
   const message = error instanceof Error ? error.message : "Runtime event input is malformed.";
   const kind = readRuntimeEventInputKind(input);
 

--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -197,9 +197,7 @@ export function supportsSessionClose(agentCapabilities: AgentCapabilities | null
   return agentCapabilities?.sessionCapabilities?.close != null;
 }
 
-export function supportsAdditionalDirs(
-  agentCapabilities: AgentCapabilities | null,
-): boolean {
+export function supportsAdditionalDirs(agentCapabilities: AgentCapabilities | null): boolean {
   return agentCapabilities?.sessionCapabilities?.additionalDirectories != null;
 }
 

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -451,7 +451,10 @@ export class AcpDriverBackend implements AgentDriverBackend {
         failure = updateError;
       }
 
-      if (failure instanceof DriverTurnCancelledError || failure instanceof AcpPromptTerminalError) {
+      if (
+        failure instanceof DriverTurnCancelledError ||
+        failure instanceof AcpPromptTerminalError
+      ) {
         throw failure;
       }
 

--- a/src/runtimes/acp/acp-event-translator.ts
+++ b/src/runtimes/acp/acp-event-translator.ts
@@ -417,10 +417,7 @@ export class AcpTurnEventState {
     return events;
   }
 
-  #tool(
-    update: JsonObject | null,
-    type: "tool_call" | "tool_call_update",
-  ): DriverEventInput[] {
+  #tool(update: JsonObject | null, type: "tool_call" | "tool_call_update"): DriverEventInput[] {
     const toolCallId = readNonEmptyString(update, "toolCallId");
 
     if (toolCallId === null) {

--- a/src/runtimes/acp/acp-session-events.ts
+++ b/src/runtimes/acp/acp-session-events.ts
@@ -501,10 +501,8 @@ export function toUsageEvents(update: JsonObject | null): DriverEventInput[] {
   const rawSize = readNumber(update, "size");
   const cost = readRecord(update, "cost");
   const rawCostAmount = readNumber(cost, "amount");
-  const used =
-    rawUsed !== null && Number.isSafeInteger(rawUsed) && rawUsed >= 0 ? rawUsed : null;
-  const size =
-    rawSize !== null && Number.isSafeInteger(rawSize) && rawSize >= 0 ? rawSize : null;
+  const used = rawUsed !== null && Number.isSafeInteger(rawUsed) && rawUsed >= 0 ? rawUsed : null;
+  const size = rawSize !== null && Number.isSafeInteger(rawSize) && rawSize >= 0 ? rawSize : null;
   const costAmount = rawCostAmount !== null && rawCostAmount >= 0 ? rawCostAmount : null;
   const costCurrency = readNullableString(cost, "currency");
 

--- a/src/runtimes/acp/acp-session-setup.ts
+++ b/src/runtimes/acp/acp-session-setup.ts
@@ -43,10 +43,7 @@ export async function setupAcpSession(input: AcpSessionSetupInput): Promise<AcpS
   const existingSessionId = input.currentSessionId;
   const additionalDirectories = input.payload.execution.session.additionalDirectories;
 
-  if (
-    additionalDirectories.length > 0 &&
-    !supportsAdditionalDirs(input.agentCapabilities)
-  ) {
+  if (additionalDirectories.length > 0 && !supportsAdditionalDirs(input.agentCapabilities)) {
     throw new Error("ACP agent does not advertise additional directory support.");
   }
 

--- a/src/runtimes/acp/acp-terminal-manager.ts
+++ b/src/runtimes/acp/acp-terminal-manager.ts
@@ -471,20 +471,16 @@ export class AcpTerminalManager {
       return Promise.resolve();
     }
 
-    return (terminal.exitEventTask ??= this.#pushBestEffort(
-      context,
-      "driver.acp.terminal.exited",
-      [
-        {
-          kind: "terminal.exited",
-          payload: {
-            exitCode: terminal.exitStatus.exitCode,
-            signal: terminal.exitStatus.signal,
-            terminalId: terminal.id,
-          },
+    return (terminal.exitEventTask ??= this.#pushBestEffort(context, "driver.acp.terminal.exited", [
+      {
+        kind: "terminal.exited",
+        payload: {
+          exitCode: terminal.exitStatus.exitCode,
+          signal: terminal.exitStatus.signal,
+          terminalId: terminal.id,
         },
-      ],
-    ));
+      },
+    ]));
   }
 
   #resolveAllowedCwd(cwd: string): string {

--- a/src/runtimes/acp/v1-contract-adapter.ts
+++ b/src/runtimes/acp/v1-contract-adapter.ts
@@ -409,9 +409,8 @@ export class AcpV1ContractAdapter {
           throw unknown.error;
         }
 
-        const result = await this.#withReceipt(
-          retrying ? unknown.receivedAt : receivedAt,
-          () => this.#applySessionUpdate(runId, snapshot),
+        const result = await this.#withReceipt(retrying ? unknown.receivedAt : receivedAt, () =>
+          this.#applySessionUpdate(runId, snapshot),
         );
 
         if (retrying) {
@@ -586,10 +585,7 @@ export class AcpV1ContractAdapter {
     if (existing !== undefined) {
       const [interactionId, pending] = existing;
 
-      if (
-        pending.intent.runId !== runId ||
-        !isDeepStrictEqual(pending.intent.request, snapshot)
-      ) {
+      if (pending.intent.runId !== runId || !isDeepStrictEqual(pending.intent.request, snapshot)) {
         throw new Error(`ACP v1 permission request ${toolCallId} changed identity or content.`);
       }
 
@@ -808,9 +804,10 @@ export class AcpV1ContractAdapter {
       throw new Error("ACP v1 permission resolution selected an unavailable option.");
     }
 
-    const response: RequestPermissionResponse = nativeOptionId === undefined
-      ? { outcome: { outcome: "cancelled" } }
-      : { outcome: { optionId: nativeOptionId, outcome: "selected" } };
+    const response: RequestPermissionResponse =
+      nativeOptionId === undefined
+        ? { outcome: { outcome: "cancelled" } }
+        : { outcome: { optionId: nativeOptionId, outcome: "selected" } };
 
     this.#projection.releaseInteraction(interactionId);
     if (this.#unknownPermission?.intent === pending.intent) {
@@ -1243,20 +1240,18 @@ export class AcpV1ContractAdapter {
     }
 
     const item = itemSchema.parse({
-        audience: "participants",
-        changes: changes ?? existing?.changes,
-        createdAt: existing?.createdAt ?? now,
-        ...(nextStatus === "active" ? {} : { endedAt: existing?.endedAt ?? now }),
-        ...(nextStatus === "failed"
-          ? { error: existing?.error ?? toolError("File change") }
-          : {}),
-        id,
-        kind: "change",
-        provenance: provenance(event, { toolCallId }),
-        runId,
-        status: nextStatus,
-        updatedAt: now,
-      });
+      audience: "participants",
+      changes: changes ?? existing?.changes,
+      createdAt: existing?.createdAt ?? now,
+      ...(nextStatus === "active" ? {} : { endedAt: existing?.endedAt ?? now }),
+      ...(nextStatus === "failed" ? { error: existing?.error ?? toolError("File change") } : {}),
+      id,
+      kind: "change",
+      provenance: provenance(event, { toolCallId }),
+      runId,
+      status: nextStatus,
+      updatedAt: now,
+    });
 
     if (
       existing !== undefined &&

--- a/src/runtimes/claude/agent-sdk-event-writer.ts
+++ b/src/runtimes/claude/agent-sdk-event-writer.ts
@@ -338,10 +338,7 @@ export class ClaudeAgentSdkEventWriter {
     ]);
   }
 
-  async finishTools(
-    context: AgentDriverContext,
-    status: "completed" | "failed",
-  ): Promise<void> {
+  async finishTools(context: AgentDriverContext, status: "completed" | "failed"): Promise<void> {
     const toolCallIds = [...this.#toolStarted].filter((id) => !this.#toolEnded.has(id));
 
     if (toolCallIds.length === 0) {

--- a/src/runtimes/claude/agent-sdk-message-events.ts
+++ b/src/runtimes/claude/agent-sdk-message-events.ts
@@ -1,13 +1,7 @@
 import type { SDKFilesPersistedEvent, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 import type { DriverEventInput } from "../../protocol/events";
-import {
-  isRecord,
-  readString,
-  sumTokenCounts,
-  toCostAmount,
-  toTokenCount,
-} from "./agent-sdk-json";
+import { isRecord, readString, sumTokenCounts, toCostAmount, toTokenCount } from "./agent-sdk-json";
 import type { JsonObject } from "./agent-sdk-json";
 
 export function toClaudeFilesPersistedEvents(message: SDKFilesPersistedEvent): DriverEventInput[] {

--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -84,10 +84,7 @@ export class ClaudeAgentSdkMessageTranslator {
     }
   }
 
-  async finishTurn(
-    context: AgentDriverContext,
-    toolStatus: "completed" | "failed",
-  ): Promise<void> {
+  async finishTurn(context: AgentDriverContext, toolStatus: "completed" | "failed"): Promise<void> {
     await this.endActiveThought(context);
 
     for (const [messageId, runId] of this.#assistantMessageRunIds) {
@@ -176,8 +173,7 @@ export class ClaudeAgentSdkMessageTranslator {
         if (text !== null) {
           authoritativeText.push(text);
         }
-        const isDuplicateStreamedText =
-          text === null || this.#streamedTextMessages.has(messageId);
+        const isDuplicateStreamedText = text === null || this.#streamedTextMessages.has(messageId);
 
         if (text && !isDuplicateStreamedText) {
           this.#appendAssistantText(messageId, text);
@@ -283,9 +279,7 @@ export class ClaudeAgentSdkMessageTranslator {
   }
 
   #streamScopeKey(runId: RunId, message: SDKMessage): string {
-    const parentToolUseId = isRecord(message)
-      ? readString(message, "parent_tool_use_id")
-      : null;
+    const parentToolUseId = isRecord(message) ? readString(message, "parent_tool_use_id") : null;
     return `${runId}:${parentToolUseId ?? "main"}`;
   }
 

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -31,24 +31,22 @@ const CLAUDE_BUILT_IN_TOOL_NAMES = {
   write: "Write",
 } as const satisfies Record<DriverBuiltInToolName, string>;
 
-const CLAUDE_PROVIDER_OPTION_KEYS = new Set<string>(
-  [
-    "agentProgressSummaries",
-    "betas",
-    "effort",
-    "enableFileCheckpointing",
-    "fallbackModel",
-    "forwardSubagentText",
-    "includeHookEvents",
-    "maxBudgetUsd",
-    "maxThinkingTokens",
-    "maxTurns",
-    "outputFormat",
-    "taskBudget",
-    "thinking",
-    "title",
-  ] satisfies readonly (keyof ClaudeQueryOptions)[],
-);
+const CLAUDE_PROVIDER_OPTION_KEYS = new Set<string>([
+  "agentProgressSummaries",
+  "betas",
+  "effort",
+  "enableFileCheckpointing",
+  "fallbackModel",
+  "forwardSubagentText",
+  "includeHookEvents",
+  "maxBudgetUsd",
+  "maxThinkingTokens",
+  "maxTurns",
+  "outputFormat",
+  "taskBudget",
+  "thinking",
+  "title",
+] satisfies readonly (keyof ClaudeQueryOptions)[]);
 
 function createCanUseTool(context: AgentDriverContext): CanUseTool {
   return async (toolName, input, options): Promise<PermissionResult> => {

--- a/src/runtimes/claude/contract-adapter.ts
+++ b/src/runtimes/claude/contract-adapter.ts
@@ -285,10 +285,7 @@ export class ClaudeContractAdapter {
     this.#assertActive();
     this.#assertNativeSession(message);
 
-    if (
-      this.#finishingRuns.has(runId) ||
-      this.#projection.run(runId)?.status !== "active"
-    ) {
+    if (this.#finishingRuns.has(runId) || this.#projection.run(runId)?.status !== "active") {
       return false;
     }
 
@@ -514,10 +511,7 @@ export class ClaudeContractAdapter {
     );
 
     this.#assertActive();
-    if (
-      this.#finishingRuns.has(runId) ||
-      this.#projection.run(runId)?.status !== "active"
-    ) {
+    if (this.#finishingRuns.has(runId) || this.#projection.run(runId)?.status !== "active") {
       throw new Error("Claude permission request outlived its active Run.");
     }
 
@@ -980,9 +974,7 @@ export class ClaudeContractAdapter {
   ): Promise<void> {
     if (message.subtype === "files_persisted" && message.files.length > 0) {
       const changes = message.files.flatMap((file) =>
-        file.filename.trim().length === 0
-          ? []
-          : [{ operation: "update", path: file.filename }],
+        file.filename.trim().length === 0 ? [] : [{ operation: "update", path: file.filename }],
       );
 
       if (changes.length === 0) {

--- a/src/runtimes/contract-projection.ts
+++ b/src/runtimes/contract-projection.ts
@@ -83,11 +83,7 @@ export interface ContractProjectionOptions {
   readonly sessionId: string;
 }
 
-type TextPreviewChannel =
-  | "message.text"
-  | "reasoning.text"
-  | "terminal.stderr"
-  | "terminal.stdout";
+type TextPreviewChannel = "message.text" | "reasoning.text" | "terminal.stderr" | "terminal.stdout";
 
 function itemKey(runId: string, itemId: string): string {
   return `${runId}\u0000${itemId}`;
@@ -249,7 +245,9 @@ export class ContractProjection {
 
     if (existing !== undefined) {
       if (!isDeepStrictEqual(existing, run)) {
-        throw new Error(`Contract projection run ${run.id} is already attached with different state.`);
+        throw new Error(
+          `Contract projection run ${run.id} is already attached with different state.`,
+        );
       }
 
       return;
@@ -315,7 +313,9 @@ export class ContractProjection {
       const interaction = interactionSchema.parse(stable.value);
 
       if (interaction.runId !== stable.runId) {
-        throw new Error(`Contract projection interaction ${interaction.id} belongs to a different run.`);
+        throw new Error(
+          `Contract projection interaction ${interaction.id} belongs to a different run.`,
+        );
       }
 
       const existing = this.#interactions.get(interaction.id);
@@ -334,9 +334,7 @@ export class ContractProjection {
       const operation = operations[0];
 
       if (operation?.op !== "put" || operation.entity !== "interaction") {
-        throw new Error(
-          `Authority write ${stable.event} did not retain its Interaction intent.`,
-        );
+        throw new Error(`Authority write ${stable.event} did not retain its Interaction intent.`);
       }
 
       return this.#interactions.get(operation.value.id) ?? operation.value;
@@ -832,7 +830,9 @@ export class ContractProjection {
 
     if (pending >= MAX_PENDING_MUTATIONS) {
       return Promise.reject(
-        new RangeError(`Contract projection mutation queue exceeds ${MAX_PENDING_MUTATIONS} entries.`),
+        new RangeError(
+          `Contract projection mutation queue exceeds ${MAX_PENDING_MUTATIONS} entries.`,
+        ),
       );
     }
 
@@ -1026,12 +1026,7 @@ export class ContractProjection {
     }
   }
 
-  #appendItemText(
-    item: Item,
-    channel: TextPreviewChannel,
-    text: string,
-    updatedAt: string,
-  ): Item {
+  #appendItemText(item: Item, channel: TextPreviewChannel, text: string, updatedAt: string): Item {
     if (item.kind === "message" && channel === "message.text") {
       return itemSchema.parse({
         ...item,
@@ -1106,12 +1101,7 @@ export class ContractProjection {
     return next;
   }
 
-  #replaceItemText(
-    item: Item,
-    channel: TextPreviewChannel,
-    text: string,
-    updatedAt: string,
-  ): Item {
+  #replaceItemText(item: Item, channel: TextPreviewChannel, text: string, updatedAt: string): Item {
     if (item.kind === "terminal" && channel === "terminal.stdout") {
       return itemSchema.parse({
         ...item,

--- a/src/runtimes/driver-event-publisher.ts
+++ b/src/runtimes/driver-event-publisher.ts
@@ -51,9 +51,7 @@ function isLossless(event: DriverEventInput): boolean {
 
 function isRunTerminal(event: DriverEventInput): boolean {
   return (
-    event.kind === "run.cancelled" ||
-    event.kind === "run.completed" ||
-    event.kind === "run.failed"
+    event.kind === "run.cancelled" || event.kind === "run.completed" || event.kind === "run.failed"
   );
 }
 
@@ -61,9 +59,7 @@ function scopeEvent(event: DriverEventInput, activeRunId: RunId | null): DriverE
   const { runId, sourceEventId, ...content } = event;
   const frozenRunId = runId === undefined ? activeRunId : runId;
   const explicitSourceId =
-    typeof sourceEventId === "string" && sourceEventId.length > 0
-      ? sourceEventId
-      : null;
+    typeof sourceEventId === "string" && sourceEventId.length > 0 ? sourceEventId : null;
 
   return {
     ...content,
@@ -219,9 +215,7 @@ export class DriverEventPublisher {
     const losslessCount = terminalBatch ? 0 : losslessEvents.length;
 
     if (
-      this.#pendingLosslessCount +
-        this.#queuedLosslessCount +
-        losslessCount >
+      this.#pendingLosslessCount + this.#queuedLosslessCount + losslessCount >
       MAX_PENDING_DRIVER_EVENTS
     ) {
       throw new Error(`Driver event queue exceeds ${MAX_PENDING_DRIVER_EVENTS} events.`);
@@ -233,9 +227,7 @@ export class DriverEventPublisher {
       admittedEvents = losslessEvents;
     } else if (losslessEvents.length === 0) {
       const capacity =
-        MAX_PENDING_DRIVER_EVENTS -
-        this.#pendingLosslessCount -
-        this.#queuedEventCount;
+        MAX_PENDING_DRIVER_EVENTS - this.#pendingLosslessCount - this.#queuedEventCount;
 
       if (capacity <= 0) {
         return null;
@@ -245,10 +237,7 @@ export class DriverEventPublisher {
     } else {
       const bestEffortCount = events.length - losslessEvents.length;
       const includeBestEffort =
-        this.#pendingLosslessCount +
-          this.#queuedEventCount +
-          losslessCount +
-          bestEffortCount <=
+        this.#pendingLosslessCount + this.#queuedEventCount + losslessCount + bestEffortCount <=
         MAX_PENDING_DRIVER_EVENTS;
       admittedEvents = includeBestEffort ? events : losslessEvents;
     }
@@ -374,11 +363,7 @@ export class DriverEventPublisher {
   }
 
   #requestPendingDrain(context: AgentDriverContext, reason: string): void {
-    if (
-      this.#pendingEvents.length === 0 &&
-      this.#queue.length === 0 &&
-      this.#drainTask === null
-    ) {
+    if (this.#pendingEvents.length === 0 && this.#queue.length === 0 && this.#drainTask === null) {
       return;
     }
 
@@ -427,10 +412,7 @@ export class DriverEventPublisher {
     context: AgentDriverContext,
     wakeReason?: string,
   ): Promise<void> {
-    const queuedEvents = [
-      ...this.#pendingEvents,
-      ...entries.flatMap((entry) => entry.events),
-    ];
+    const queuedEvents = [...this.#pendingEvents, ...entries.flatMap((entry) => entry.events)];
     const remainingLossless = queuedEvents.filter(({ event }) => isLossless(event));
     const ownerErrors = new Map<symbol, unknown>();
     const deadline = AbortSignal.timeout(DRIVER_EVENT_DELIVERY_TIMEOUT_MS);
@@ -456,7 +438,7 @@ export class DriverEventPublisher {
     });
 
     try {
-      for (let index = 0; index < queuedEvents.length; ) {
+      for (let index = 0; index < queuedEvents.length;) {
         const lossless = isLossless(queuedEvents[index]!.event);
         let end = index + 1;
 

--- a/src/runtimes/openai/app-server-driver-backend.ts
+++ b/src/runtimes/openai/app-server-driver-backend.ts
@@ -450,11 +450,7 @@ export class OpenAiAppServerDriverBackend implements AgentDriverBackend {
     this.#events.releaseTurnState();
   }
 
-  async stop(
-    context: AgentDriverContext,
-    reason: string,
-    signal: AbortSignal,
-  ): Promise<void> {
+  async stop(context: AgentDriverContext, reason: string, signal: AbortSignal): Promise<void> {
     const client = this.#client;
     const cancellation = raceWithAbort(this.cancelActiveTurn(context, reason), signal);
 

--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -95,10 +95,7 @@ export class OpenAiAppServerItemEventBridge {
     ]);
   }
 
-  async onFilePatch(
-    context: AgentDriverContext,
-    params: JsonObject,
-  ): Promise<void> {
+  async onFilePatch(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const itemId = readNonEmptyString(params, "itemId");
     const turnId = readNonEmptyString(params, "turnId");
 
@@ -207,10 +204,7 @@ export class OpenAiAppServerItemEventBridge {
     await this.#push(context, "driver.openai.plan.delta", [this.#plans.createUpdatedEvent()]);
   }
 
-  async onReasoningDelta(
-    context: AgentDriverContext,
-    params: JsonObject,
-  ): Promise<void> {
+  async onReasoningDelta(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const itemId = readNonEmptyString(params, "itemId");
     const delta = readString(params, "delta") ?? readString(params, "part");
 
@@ -239,10 +233,7 @@ export class OpenAiAppServerItemEventBridge {
     await this.#push(context, "driver.openai.reasoning.summary", events);
   }
 
-  async onReasoningPart(
-    context: AgentDriverContext,
-    params: JsonObject,
-  ): Promise<void> {
+  async onReasoningPart(context: AgentDriverContext, params: JsonObject): Promise<void> {
     const summaryIndex = params["summaryIndex"];
 
     if (typeof summaryIndex !== "number" || !Number.isInteger(summaryIndex) || summaryIndex < 1) {
@@ -429,11 +420,7 @@ export class OpenAiAppServerItemEventBridge {
     }
 
     if (filteredFinalText !== null) {
-      this.#appendCitationDiag(
-        events,
-        messageId,
-        filteredFinalText.privateCitationCount,
-      );
+      this.#appendCitationDiag(events, messageId, filteredFinalText.privateCitationCount);
     }
 
     if (filteredFinalText !== null && filteredFinalText.text.length > currentText.length) {
@@ -564,11 +551,7 @@ export class OpenAiAppServerItemEventBridge {
     events.push(this.#plans.createUpdatedEvent());
   }
 
-  #appendReasoningEnd(
-    events: DriverEventInput[],
-    item: JsonObject,
-    itemId: string,
-  ): void {
+  #appendReasoningEnd(events: DriverEventInput[], item: JsonObject, itemId: string): void {
     if (readString(item, "type") !== "reasoning") {
       return;
     }

--- a/src/runtimes/openai/contract-adapter.ts
+++ b/src/runtimes/openai/contract-adapter.ts
@@ -263,9 +263,7 @@ function toFileChanges(item: JsonObject): FileChange[] {
     if (type === "update" && movePath !== null) {
       return [
         {
-          ...(diff === null || diff.length === 0
-            ? {}
-            : { diff: { text: diff, type: "text" } }),
+          ...(diff === null || diff.length === 0 ? {} : { diff: { text: diff, type: "text" } }),
           oldPath: path,
           operation: "move",
           path: movePath,
@@ -275,15 +273,8 @@ function toFileChanges(item: JsonObject): FileChange[] {
 
     return [
       {
-        ...(diff === null || diff.length === 0
-          ? {}
-          : { diff: { text: diff, type: "text" } }),
-        operation:
-          type === "add"
-            ? "create"
-            : type === "delete"
-              ? "delete"
-              : "update",
+        ...(diff === null || diff.length === 0 ? {} : { diff: { text: diff, type: "text" } }),
+        operation: type === "add" ? "create" : type === "delete" ? "delete" : "update",
         path,
       },
     ];
@@ -479,7 +470,10 @@ export class OpenAiContractAdapter {
       if (existing.runId !== run.id || existing.threadId !== input.threadId) {
         throw new Error(`OpenAI turn ${input.turnId} is already registered to another run.`);
       }
-      if (!isDeepStrictEqual(existing.run, run) || !isDeepStrictEqual(existing.cause, input.cause)) {
+      if (
+        !isDeepStrictEqual(existing.run, run) ||
+        !isDeepStrictEqual(existing.cause, input.cause)
+      ) {
         throw new Error(`OpenAI turn ${input.turnId} is registered with different state.`);
       }
 
@@ -939,7 +933,8 @@ export class OpenAiContractAdapter {
 
       if (status === "completed") {
         const plan = activeItems.find(
-          (item) => item.kind === "plan" && item.id === "turn-plan" && !completedItemIds.has(item.id),
+          (item) =>
+            item.kind === "plan" && item.id === "turn-plan" && !completedItemIds.has(item.id),
         );
 
         if (plan !== undefined) {
@@ -1881,10 +1876,7 @@ export class OpenAiContractAdapter {
 
       await this.#replayTurnEnd(turnId);
 
-      if (
-        !this.#pendingTurnNotifications.has(turnId) &&
-        !this.#pendingTurnEnds.has(turnId)
-      ) {
+      if (!this.#pendingTurnNotifications.has(turnId) && !this.#pendingTurnEnds.has(turnId)) {
         return;
       }
     }

--- a/src/surfaces/cma-sdk/index.ts
+++ b/src/surfaces/cma-sdk/index.ts
@@ -149,7 +149,7 @@ function findSseSeparator(
     return value[index] === 10 ? 1 : 0;
   };
 
-  for (let index = start; index < length; ) {
+  for (let index = start; index < length;) {
     const first = lineBreakLength(index);
 
     if (first === 0) {

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -68,12 +68,15 @@ async function settleWithTimeout<T>(
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let onAbort: (() => void) | undefined;
   const timeout = new Promise<PromiseTimeoutResult<T>>((resolve) => {
-    timeoutId = setTimeout(() => {
-      resolve({
-        error: new AsyncTimeoutError(options.label, options.timeoutMs),
-        status: "timed_out",
-      });
-    }, Math.min(options.timeoutMs, MAX_TIMER_MS));
+    timeoutId = setTimeout(
+      () => {
+        resolve({
+          error: new AsyncTimeoutError(options.label, options.timeoutMs),
+          status: "timed_out",
+        });
+      },
+      Math.min(options.timeoutMs, MAX_TIMER_MS),
+    );
   });
   const aborted = new Promise<PromiseTimeoutResult<T>>((resolve) => {
     if (options.signal === undefined) {
@@ -128,10 +131,13 @@ export async function sleepPromise(ms: number, signal?: AbortSignal): Promise<vo
   signal?.throwIfAborted();
 
   await new Promise<void>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, Math.min(ms, MAX_TIMER_MS));
+    const timeoutId = setTimeout(
+      () => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      Math.min(ms, MAX_TIMER_MS),
+    );
     const onAbort = () => {
       clearTimeout(timeoutId);
       reject(signal?.reason);

--- a/tests/acp-client-request-handler.test.ts
+++ b/tests/acp-client-request-handler.test.ts
@@ -64,9 +64,9 @@ describe("ACP client request handler", () => {
 
     await handler.waitForTerminalExit({ sessionId: "native-session-1", terminalId });
 
-    expect(
-      handler.terminalOutput({ sessionId: "native-session-1", terminalId }).output,
-    ).toBe("/artifact/bin:/runtime/bin");
+    expect(handler.terminalOutput({ sessionId: "native-session-1", terminalId }).output).toBe(
+      "/artifact/bin:/runtime/bin",
+    );
     await handler.releaseTerminal(context, { sessionId: "native-session-1", terminalId });
   });
 

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -26,9 +26,7 @@ function createInitializeResult(protocolVersion: number | string | null) {
 
 describe("ACP runtime configuration", () => {
   test("accepts the configured ACP protocol version only", () => {
-    expect(() =>
-      assertProtocolVersion(createInitializeResult(ACP_PROTOCOL_VERSION)),
-    ).not.toThrow();
+    expect(() => assertProtocolVersion(createInitializeResult(ACP_PROTOCOL_VERSION))).not.toThrow();
     expect(() =>
       assertProtocolVersion(createInitializeResult(String(ACP_PROTOCOL_VERSION))),
     ).toThrow();

--- a/tests/acp-event-translator.test.ts
+++ b/tests/acp-event-translator.test.ts
@@ -353,50 +353,53 @@ describe("ACP runtime event translation", () => {
       { content: [{ terminalId: "terminal-late", type: "terminal" }] },
       { content: expect.stringContaining("terminal-late") },
     ],
-  ] as const)("keeps a terminal tool completed while merging a later %s patch", (_name, patch, expected) => {
-    const state = new AcpTurnEventState();
-    state.begin({ messageId: "message-1", runId: "run-1", sessionId: "session-1" });
-    const initial = state.translateUpdate({
-      update: {
-        kind: "shell",
-        rawInput: { command: "true" },
-        sessionUpdate: "tool_call",
-        status: "completed",
-        title: "Run command",
-        toolCallId: "tool-terminal",
-      },
-    });
-    const initialPayload = eventPayload(requireEvent(initial, "tool.call.updated"));
-    const events = state.translateUpdate({
-      update: {
-        ...patch,
-        sessionUpdate: "tool_call_update",
-        status: "running",
-        toolCallId: "tool-terminal",
-      },
-    });
-    const update = requireEvent(events, "tool.call.updated");
-
-    expect(update.delivery).toBe("lossless");
-    expect(eventPayload(update)).toMatchObject({
-      kind: "shell",
-      rawInput: initialPayload["rawInput"],
-      status: "completed",
-      title: "Run command",
-      ...expected,
-    });
-    expect(events.filter((event) => event.kind === "item.completed")).toHaveLength(0);
-    expect(
-      state.translateUpdate({
+  ] as const)(
+    "keeps a terminal tool completed while merging a later %s patch",
+    (_name, patch, expected) => {
+      const state = new AcpTurnEventState();
+      state.begin({ messageId: "message-1", runId: "run-1", sessionId: "session-1" });
+      const initial = state.translateUpdate({
+        update: {
+          kind: "shell",
+          rawInput: { command: "true" },
+          sessionUpdate: "tool_call",
+          status: "completed",
+          title: "Run command",
+          toolCallId: "tool-terminal",
+        },
+      });
+      const initialPayload = eventPayload(requireEvent(initial, "tool.call.updated"));
+      const events = state.translateUpdate({
         update: {
           ...patch,
           sessionUpdate: "tool_call_update",
           status: "running",
           toolCallId: "tool-terminal",
         },
-      }),
-    ).toEqual([]);
-  });
+      });
+      const update = requireEvent(events, "tool.call.updated");
+
+      expect(update.delivery).toBe("lossless");
+      expect(eventPayload(update)).toMatchObject({
+        kind: "shell",
+        rawInput: initialPayload["rawInput"],
+        status: "completed",
+        title: "Run command",
+        ...expected,
+      });
+      expect(events.filter((event) => event.kind === "item.completed")).toHaveLength(0);
+      expect(
+        state.translateUpdate({
+          update: {
+            ...patch,
+            sessionUpdate: "tool_call_update",
+            status: "running",
+            toolCallId: "tool-terminal",
+          },
+        }),
+      ).toEqual([]);
+    },
+  );
 
   test.each([
     ["completed", "running", "without content"],

--- a/tests/acp-provider-fixtures.test.ts
+++ b/tests/acp-provider-fixtures.test.ts
@@ -3,10 +3,7 @@ import type { StopReason } from "@agentclientprotocol/sdk";
 import { readFileSync } from "node:fs";
 
 import type { DriverEventInput } from "../src/protocol/events";
-import {
-  AcpTurnEventState,
-  toSessionReadyEvents,
-} from "../src/runtimes/acp/acp-event-translator";
+import { AcpTurnEventState, toSessionReadyEvents } from "../src/runtimes/acp/acp-event-translator";
 import type { AcpTurnEventStateInput } from "../src/runtimes/acp/acp-event-translator";
 
 interface CompletePromptFixture {

--- a/tests/acp-v1-contract-adapter.test.ts
+++ b/tests/acp-v1-contract-adapter.test.ts
@@ -558,18 +558,12 @@ describe("ACP V1 Contract adapter", () => {
         toolCall: { title: "Run command", toolCallId: "tool-resolved-unknown" },
       } satisfies RequestPermissionRequest;
       const limit = new TextEncoder().encode(JSON.stringify(request)).byteLength;
-      const harness = createHarness(
-        5 * 60 * 1_000,
-        undefined,
-        limit,
-        undefined,
-        async (update) => {
-          if (loseResult && update.event === "permission/requested") {
-            loseResult = false;
-            throw new Error("authority result lost");
-          }
-        },
-      );
+      const harness = createHarness(5 * 60 * 1_000, undefined, limit, undefined, async (update) => {
+        if (loseResult && update.event === "permission/requested") {
+          loseResult = false;
+          throw new Error("authority result lost");
+        }
+      });
       await registerRun(harness.adapter);
 
       await expect(harness.adapter.openPermission(RUN_ID, request)).rejects.toBeInstanceOf(
@@ -602,9 +596,7 @@ describe("ACP V1 Contract adapter", () => {
 
       harness.advance(1_000);
       await expect(harness.adapter.openPermission(RUN_ID, request)).resolves.toBe(interactionId);
-      const retries = harness.authority.filter(
-        (update) => update.event === "permission/requested",
-      );
+      const retries = harness.authority.filter((update) => update.event === "permission/requested");
       expect(retries).toEqual([first, first]);
       expect(harness.snapshot().interactions.find(({ id }) => id === interactionId)?.status).toBe(
         "resolved",
@@ -943,9 +935,9 @@ describe("ACP V1 Contract adapter", () => {
       harness.adapter.registerTerminal(RUN_ID, "terminal-time", request),
     ).rejects.toBeInstanceOf(AuthorityOutcomeUnknownError);
     harness.advance(1_000);
-    await expect(
-      harness.adapter.registerTerminal(RUN_ID, "terminal-time", request),
-    ).resolves.toBe("terminal:terminal-time");
+    await expect(harness.adapter.registerTerminal(RUN_ID, "terminal-time", request)).resolves.toBe(
+      "terminal:terminal-time",
+    );
 
     expect(mutationIds).toEqual([mutationIds[0], mutationIds[0]]);
   });

--- a/tests/agent-driver-kernel.test.ts
+++ b/tests/agent-driver-kernel.test.ts
@@ -877,50 +877,53 @@ describe("AgentDriverKernelCore", () => {
   test.each([
     ["successful", null],
     ["failed", new Error("cleanup failed")],
-  ] as const)("joins %s startup cleanup from every concurrent stop", async (_name, cleanupError) => {
-    const backend = createBackend();
-    const cleanupEntered = Promise.withResolvers<void>();
-    const releaseCleanup = Promise.withResolvers<void>();
-    let stopCount = 0;
-    backend.start = async () => {
-      throw new Error("startup failed");
-    };
-    backend.stop = async () => {
-      stopCount += 1;
-      cleanupEntered.resolve();
-      await releaseCleanup.promise;
+  ] as const)(
+    "joins %s startup cleanup from every concurrent stop",
+    async (_name, cleanupError) => {
+      const backend = createBackend();
+      const cleanupEntered = Promise.withResolvers<void>();
+      const releaseCleanup = Promise.withResolvers<void>();
+      let stopCount = 0;
+      backend.start = async () => {
+        throw new Error("startup failed");
+      };
+      backend.stop = async () => {
+        stopCount += 1;
+        cleanupEntered.resolve();
+        await releaseCleanup.promise;
 
-      if (cleanupError !== null) {
-        throw cleanupError;
+        if (cleanupError !== null) {
+          throw cleanupError;
+        }
+      };
+      const kernel = new AgentDriverKernelCore({ backendFactory: () => backend });
+      const events = kernel.events()[Symbol.asyncIterator]();
+      const startOutcome = kernel.start(bootPayload).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      await cleanupEntered.promise;
+      const stopOutcome = Promise.all([kernel.stop("first stop"), kernel.stop("second stop")]).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(
+        await Promise.race([stopOutcome.then(() => true), Bun.sleep(10).then(() => false)]),
+      ).toBe(false);
+
+      releaseCleanup.resolve();
+      const startupError = await startOutcome;
+      expect(startupError).toMatchObject({ message: "startup failed" });
+      expect(await stopOutcome).toBe(startupError);
+
+      expect(stopCount).toBe(1);
+      if (cleanupError === null) {
+        await expect(events.next()).resolves.toEqual({ done: true, value: undefined });
       }
-    };
-    const kernel = new AgentDriverKernelCore({ backendFactory: () => backend });
-    const events = kernel.events()[Symbol.asyncIterator]();
-    const startOutcome = kernel.start(bootPayload).then(
-      () => null,
-      (error: unknown) => error,
-    );
-
-    await cleanupEntered.promise;
-    const stopOutcome = Promise.all([kernel.stop("first stop"), kernel.stop("second stop")]).then(
-      () => null,
-      (error: unknown) => error,
-    );
-
-    expect(
-      await Promise.race([stopOutcome.then(() => true), Bun.sleep(10).then(() => false)]),
-    ).toBe(false);
-
-    releaseCleanup.resolve();
-    const startupError = await startOutcome;
-    expect(startupError).toMatchObject({ message: "startup failed" });
-    expect(await stopOutcome).toBe(startupError);
-
-    expect(stopCount).toBe(1);
-    if (cleanupError === null) {
-      await expect(events.next()).resolves.toEqual({ done: true, value: undefined });
-    }
-  });
+    },
+  );
 
   test("serializes concurrent stop calls with an in-flight start", async () => {
     const backend = createBackend();
@@ -1315,45 +1318,41 @@ describe("AgentDriverKernelCore", () => {
     expect(stopCount).toBe(1);
   });
 
-  test(
-    "never reports a successful stop while an owned input task is still running",
-    async () => {
-      const backend = createBackend();
-      const inputEntered = Promise.withResolvers<void>();
-      const releaseInput = Promise.withResolvers<void>();
-      let inputSettled = false;
-      backend.handleInput = async () => {
-        inputEntered.resolve();
-        await releaseInput.promise;
-        inputSettled = true;
-      };
-      backend.cancelActiveTurn = async () => {};
-      const kernel = new AgentDriverKernelCore({ backendFactory: () => backend });
+  test("never reports a successful stop while an owned input task is still running", async () => {
+    const backend = createBackend();
+    const inputEntered = Promise.withResolvers<void>();
+    const releaseInput = Promise.withResolvers<void>();
+    let inputSettled = false;
+    backend.handleInput = async () => {
+      inputEntered.resolve();
+      await releaseInput.promise;
+      inputSettled = true;
+    };
+    backend.cancelActiveTurn = async () => {};
+    const kernel = new AgentDriverKernelCore({ backendFactory: () => backend });
 
-      await kernel.start(bootPayload);
-      const input = kernel
-        .dispatch({
-          commandId: "stuck-input",
-          input: { text: "wait" },
-          kind: "input.start",
-          requestId: "stuck-request",
-          runId: DRIVER_TEST_IDS.runId,
-        })
-        .catch(() => {});
-      await inputEntered.promise;
+    await kernel.start(bootPayload);
+    const input = kernel
+      .dispatch({
+        commandId: "stuck-input",
+        input: { text: "wait" },
+        kind: "input.start",
+        requestId: "stuck-request",
+        runId: DRIVER_TEST_IDS.runId,
+      })
+      .catch(() => {});
+    await inputEntered.promise;
 
-      const first = await Promise.allSettled([kernel.stop("first stop")]);
-      const second = await Promise.allSettled([kernel.stop("second stop")]);
-      const settledBeforeRelease = inputSettled;
-      releaseInput.resolve();
-      await input;
+    const first = await Promise.allSettled([kernel.stop("first stop")]);
+    const second = await Promise.allSettled([kernel.stop("second stop")]);
+    const settledBeforeRelease = inputSettled;
+    releaseInput.resolve();
+    await input;
 
-      expect(first[0]?.status).toBe("rejected");
-      expect(second[0]?.status).toBe("rejected");
-      expect(settledBeforeRelease).toBe(false);
-    },
-    10_000,
-  );
+    expect(first[0]?.status).toBe("rejected");
+    expect(second[0]?.status).toBe("rejected");
+    expect(settledBeforeRelease).toBe(false);
+  }, 10_000);
 
   test("keeps cleanup event delivery available across a transient stop failure", async () => {
     const backend = createBackend();
@@ -1394,10 +1393,7 @@ describe("AgentDriverKernelCore", () => {
     }
 
     expect(stopCount).toBe(2);
-    expect(received.map((event) => event.kind)).toEqual([
-      "run.completed",
-      "diagnostic.reported",
-    ]);
+    expect(received.map((event) => event.kind)).toEqual(["run.completed", "diagnostic.reported"]);
   });
 
   test.each([

--- a/tests/async.test.ts
+++ b/tests/async.test.ts
@@ -93,9 +93,9 @@ describe("async lifecycle utilities", () => {
   test("propagates an operation failure while an abort race is active", async () => {
     const failure = new Error("operation failed first");
 
-    await expect(
-      raceWithAbort(Promise.reject(failure), new AbortController().signal),
-    ).rejects.toBe(failure);
+    await expect(raceWithAbort(Promise.reject(failure), new AbortController().signal)).rejects.toBe(
+      failure,
+    );
   });
 
   test.each([

--- a/tests/claude-agent-sdk-driver-backend.test.ts
+++ b/tests/claude-agent-sdk-driver-backend.test.ts
@@ -169,11 +169,7 @@ describe("Claude Agent SDK driver backend", () => {
       { text: "second" },
       DRIVER_TEST_IDS.secondRunId,
     );
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(coldQueries).toBe(2);
@@ -396,11 +392,7 @@ describe("Claude Agent SDK driver backend", () => {
       if (action === "cancel") {
         await harness.backend.cancelActiveTurn(harness.context, "test.cancel");
       } else {
-        await harness.backend.stop(
-          harness.context,
-          "test.stop",
-          new AbortController().signal,
-        );
+        await harness.backend.stop(harness.context, "test.stop", new AbortController().signal);
       }
       options.resolve({});
 
@@ -411,11 +403,7 @@ describe("Claude Agent SDK driver backend", () => {
           ["run.cancelled", "run.completed", "run.failed"].includes(event.kind),
         ),
       ).toMatchObject([{ kind: "run.cancelled", runId: DRIVER_TEST_IDS.runId }]);
-      await harness.backend.stop(
-        harness.context,
-        "test.complete",
-        new AbortController().signal,
-      );
+      await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
       await harness.logger.destroy();
     },
   );
@@ -443,11 +431,7 @@ describe("Claude Agent SDK driver backend", () => {
     await expect(
       harness.backend.handleInput(harness.context, { text: "hello" }, DRIVER_TEST_IDS.runId),
     ).rejects.toThrow("event sink unavailable");
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(closes).toBe(1);
@@ -491,11 +475,7 @@ describe("Claude Agent SDK driver backend", () => {
 
     await harness.backend.cancelActiveTurn(harness.context, "test.cancel");
     await expect(handling).rejects.toBeInstanceOf(DriverTurnCancelledError);
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(closes).toBe(1);
@@ -536,11 +516,7 @@ describe("Claude Agent SDK driver backend", () => {
     await harness.backend.cancelActiveTurn(harness.context, "test.cancel");
     releaseFinish.resolve();
     await expect(handling).resolves.toBeUndefined();
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(closes).toBe(1);
@@ -587,11 +563,7 @@ describe("Claude Agent SDK driver backend", () => {
       await expect(
         harness.backend.handleInput(harness.context, { text: "finish" }, DRIVER_TEST_IDS.runId),
       ).rejects.toThrow("terminal delivery unavailable");
-      await harness.backend.stop(
-        harness.context,
-        "test.complete",
-        new AbortController().signal,
-      );
+      await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
       await harness.logger.destroy();
 
       expect(terminalAttempts).toEqual([[terminal]]);
@@ -645,23 +617,11 @@ describe("Claude Agent SDK driver backend", () => {
       },
     });
 
-    await harness.backend.handleInput(
-      harness.context,
-      { text: "first" },
-      DRIVER_TEST_IDS.runId,
-    );
+    await harness.backend.handleInput(harness.context, { text: "first" }, DRIVER_TEST_IDS.runId);
     await expect(
-      harness.backend.handleInput(
-        harness.context,
-        { text: "second" },
-        DRIVER_TEST_IDS.secondRunId,
-      ),
+      harness.backend.handleInput(harness.context, { text: "second" }, DRIVER_TEST_IDS.secondRunId),
     ).rejects.toThrow("different native session");
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(
@@ -716,11 +676,7 @@ describe("Claude Agent SDK driver backend", () => {
       { text: "terminal" },
       DRIVER_TEST_IDS.secondRunId,
     );
-    await harness.backend.stop(
-      harness.context,
-      "test.complete",
-      new AbortController().signal,
-    );
+    await harness.backend.stop(harness.context, "test.complete", new AbortController().signal);
     await harness.logger.destroy();
 
     expect(lateFrameRead).toBe(false);

--- a/tests/claude-agent-sdk-json.test.ts
+++ b/tests/claude-agent-sdk-json.test.ts
@@ -24,10 +24,7 @@ const invalidTokenCounts = [
   ...nonFiniteNumbers,
 ] as const;
 
-const invalidCosts = [
-  { label: "negative", value: -0.01 },
-  ...nonFiniteNumbers,
-] as const;
+const invalidCosts = [{ label: "negative", value: -0.01 }, ...nonFiniteNumbers] as const;
 
 describe("Claude Agent SDK number reader", () => {
   test.each(nonFiniteNumbers)("ignores non-finite runtime value $label", ({ value }) => {
@@ -63,10 +60,7 @@ describe("Claude Agent SDK number reader", () => {
 
   test("drops a derived total that exceeds the safe integer range", () => {
     expect(
-      toClaudeUsageUpdatedEvents(
-        { input_tokens: Number.MAX_SAFE_INTEGER, output_tokens: 1 },
-        null,
-      ),
+      toClaudeUsageUpdatedEvents({ input_tokens: Number.MAX_SAFE_INTEGER, output_tokens: 1 }, null),
     ).toMatchObject([
       {
         payload: {
@@ -79,9 +73,7 @@ describe("Claude Agent SDK number reader", () => {
   });
 
   test.each(invalidCosts)("drops $label costs", ({ value }) => {
-    expect(
-      toClaudeUsageUpdatedEvents({ input_tokens: 1, output_tokens: 2 }, value),
-    ).toMatchObject([
+    expect(toClaudeUsageUpdatedEvents({ input_tokens: 1, output_tokens: 2 }, value)).toMatchObject([
       {
         payload: { costAmount: null, costCurrency: null, totalTokens: 3 },
       },

--- a/tests/claude-agent-sdk-live.test.ts
+++ b/tests/claude-agent-sdk-live.test.ts
@@ -6,12 +6,7 @@ import { join } from "node:path";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 import { applyCommittedMutation, validateSessionSnapshot } from "../src/contract";
-import type {
-  AuthorityOperation,
-  CommittedMutation,
-  Run,
-  SessionSnapshot,
-} from "../src/contract";
+import type { AuthorityOperation, CommittedMutation, Run, SessionSnapshot } from "../src/contract";
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverEventInput } from "../src/protocol/events";
@@ -26,11 +21,7 @@ import {
   FakeDriverRuntimeIo,
   bootPayload,
 } from "./driver-runtime-boundary-fixtures";
-import {
-  textDeltaFrom,
-  waitForTerminalTurnEvent,
-  withLiveTimeout,
-} from "./live-driver-events";
+import { textDeltaFrom, waitForTerminalTurnEvent, withLiveTimeout } from "./live-driver-events";
 
 const LIVE_API_KEY_ENV = "AGENT_DRIVER_LIVE_ANTHROPIC_API_KEY";
 const PROVIDER_API_KEY_ENV = "ANTHROPIC_API_KEY";
@@ -233,9 +224,7 @@ function payloadString(event: DriverEventInput | undefined, key: string): string
 
 function toolCallId(events: readonly DriverEventInput[], title: string): string | null {
   return payloadString(
-    events.find(
-      (event) => event.kind === "item.started" && hasPayloadValue(event, "title", title),
-    ),
+    events.find((event) => event.kind === "item.started" && hasPayloadValue(event, "title", title)),
     "itemId",
   );
 }
@@ -654,8 +643,7 @@ describe("Claude Agent SDK live provider", () => {
         });
         const runningTool = await waitForLiveEvent(
           iterator,
-          (event) =>
-            event.kind === "item.started" && hasPayloadValue(event, "title", "Bash"),
+          (event) => event.kind === "item.started" && hasPayloadValue(event, "title", "Bash"),
           "running Bash tool",
         );
         const toolCallId = payloadString(runningTool, "itemId");
@@ -682,12 +670,7 @@ describe("Claude Agent SDK live provider", () => {
           (event) => event.kind === "run.cancelled",
           "cancelled run terminal event",
         );
-        await sendPing(
-          kernel,
-          fromIterator(iterator),
-          "after-cancel",
-          DRIVER_TEST_IDS.secondRunId,
-        );
+        await sendPing(kernel, fromIterator(iterator), "after-cancel", DRIVER_TEST_IDS.secondRunId);
       } finally {
         await stopLiveKernel(kernel, "test.stop");
       }
@@ -723,8 +706,7 @@ describe("Claude Agent SDK live provider", () => {
         });
         const runningTool = await waitForLiveEvent(
           firstEvents,
-          (event) =>
-            event.kind === "item.started" && hasPayloadValue(event, "title", "Bash"),
+          (event) => event.kind === "item.started" && hasPayloadValue(event, "title", "Bash"),
           "running Bash tool before shutdown",
         );
         const toolCallId = payloadString(runningTool, "itemId");

--- a/tests/claude-agent-sdk-provider-fixtures.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures.test.ts
@@ -374,9 +374,7 @@ describe("Claude Agent SDK provider fixtures", () => {
       },
       {
         message: {
-          content: [
-            { id: "tool-1", input: { path: "complete" }, name: "Read", type: "tool_use" },
-          ],
+          content: [{ id: "tool-1", input: { path: "complete" }, name: "Read", type: "tool_use" }],
         },
         type: "assistant",
         uuid: "assistant-1",

--- a/tests/claude-contract-adapter.test.ts
+++ b/tests/claude-contract-adapter.test.ts
@@ -691,10 +691,15 @@ describe("Claude Contract adapter", () => {
     };
     const first = harness.adapter.openPermission(RUN_ID, "Bash", { command: "pwd" }, options);
     await interactionWriting.promise;
-    const replay = harness.adapter.openPermission(RUN_ID, "Bash", { command: "pwd" }, {
-      ...options,
-      signal: replayController.signal,
-    });
+    const replay = harness.adapter.openPermission(
+      RUN_ID,
+      "Bash",
+      { command: "pwd" },
+      {
+        ...options,
+        signal: replayController.signal,
+      },
+    );
 
     replayController.abort();
     releaseInteraction.resolve();
@@ -719,10 +724,15 @@ describe("Claude Contract adapter", () => {
       options,
     );
     const replayController = new AbortController();
-    await harness.adapter.openPermission(RUN_ID, "Bash", { command: "pwd" }, {
-      ...options,
-      signal: replayController.signal,
-    });
+    await harness.adapter.openPermission(
+      RUN_ID,
+      "Bash",
+      { command: "pwd" },
+      {
+        ...options,
+        signal: replayController.signal,
+      },
+    );
     const interaction = harness.snapshot().interactions[0];
     const allowOnceId =
       interaction?.kind === "permission"
@@ -751,11 +761,16 @@ describe("Claude Contract adapter", () => {
     controller.abort();
 
     await expect(
-      harness.adapter.openPermission(RUN_ID, "Bash", { command: "pwd" }, {
-        requestId: "request-aborted",
-        signal: controller.signal,
-        toolUseID: "tool-aborted",
-      }),
+      harness.adapter.openPermission(
+        RUN_ID,
+        "Bash",
+        { command: "pwd" },
+        {
+          requestId: "request-aborted",
+          signal: controller.signal,
+          toolUseID: "tool-aborted",
+        },
+      ),
     ).rejects.toMatchObject({ name: "AbortError" });
     expect(harness.authority).toHaveLength(0);
     expect(harness.snapshot().items).toHaveLength(0);
@@ -894,11 +909,16 @@ describe("Claude Contract adapter", () => {
     });
     await registerRun(harness.adapter);
     const controller = new AbortController();
-    const opening = harness.adapter.openPermission(RUN_ID, "Bash", { command: "pwd" }, {
-      requestId: "request-abort-opening",
-      signal: controller.signal,
-      toolUseID: "tool-abort-opening",
-    });
+    const opening = harness.adapter.openPermission(
+      RUN_ID,
+      "Bash",
+      { command: "pwd" },
+      {
+        requestId: "request-abort-opening",
+        signal: controller.signal,
+        toolUseID: "tool-abort-opening",
+      },
+    );
     await interactionWriting.promise;
 
     controller.abort();

--- a/tests/contract-projection.test.ts
+++ b/tests/contract-projection.test.ts
@@ -15,7 +15,10 @@ import type {
   SessionSnapshot,
 } from "../src/contract";
 import { isDriverId } from "../src/protocol/id";
-import { ContractProjection, type ContractAuthorityUpdate } from "../src/runtimes/contract-projection";
+import {
+  ContractProjection,
+  type ContractAuthorityUpdate,
+} from "../src/runtimes/contract-projection";
 
 function protocolId(value: number): string {
   return value.toString().padStart(26, "0");
@@ -1834,27 +1837,30 @@ test.each([
       return [item, item];
     },
   ],
-] as const)("Contract projection rejects terminal snapshots with %s", async (_name, terminalItems) => {
-  const timestamp = "2026-07-16T08:00:00.000Z";
-  const projection = new ContractProjection({
-    authority: async () => {},
-    now: () => new Date(timestamp),
-    preview: () => {},
-    sessionId: SESSION_ID,
-  });
-  projection.attachRun(activeRun(timestamp));
+] as const)(
+  "Contract projection rejects terminal snapshots with %s",
+  async (_name, terminalItems) => {
+    const timestamp = "2026-07-16T08:00:00.000Z";
+    const projection = new ContractProjection({
+      authority: async () => {},
+      now: () => new Date(timestamp),
+      preview: () => {},
+      sessionId: SESSION_ID,
+    });
+    projection.attachRun(activeRun(timestamp));
 
-  await expect(
-    projection.finishRun({
-      cause: { providerEventId: "turn/completed", type: "provider" },
-      event: "turn/completed",
-      runId: RUN_ID,
-      status: "completed",
-      terminalItems: terminalItems(timestamp),
-    }),
-  ).rejects.toThrow("invalid terminal Item");
-  expect(projection.run(RUN_ID)?.status).toBe("active");
-});
+    await expect(
+      projection.finishRun({
+        cause: { providerEventId: "turn/completed", type: "provider" },
+        event: "turn/completed",
+        runId: RUN_ID,
+        status: "completed",
+        terminalItems: terminalItems(timestamp),
+      }),
+    ).rejects.toThrow("invalid terminal Item");
+    expect(projection.run(RUN_ID)?.status).toBe("active");
+  },
+);
 
 test("Contract projection never ends a Run before a later Interaction", async () => {
   let now = new Date("2026-07-16T08:00:00.000Z");

--- a/tests/driver-event-publisher.test.ts
+++ b/tests/driver-event-publisher.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  pushLosslessEvents,
-  withSourceEventIds,
-} from "../src/core/driver-runtime-io";
+import { pushLosslessEvents, withSourceEventIds } from "../src/core/driver-runtime-io";
 import { toDriverEventEnvelopes } from "../src/infrastructure/runtime/driver-instance-socket";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverEventInput } from "../src/protocol/events";
@@ -73,10 +70,7 @@ function kinds(batches: readonly (readonly DriverEventInput[])[]): string[][] {
 
 function createContext(input: {
   currentRunId?: () => RunId | null;
-  pushEvents: (
-    events: DriverEventInput[],
-    signal?: AbortSignal,
-  ) => Promise<DriverEventBatchOutput>;
+  pushEvents: (events: DriverEventInput[], signal?: AbortSignal) => Promise<DriverEventBatchOutput>;
 }) {
   return createAgentDriverContext({
     eventSink: {
@@ -168,10 +162,7 @@ describe("DriverEventPublisher", () => {
         },
       };
 
-      const delivery = pushLosslessEvents(port, [
-        createEvent("message.started"),
-        mutable,
-      ]);
+      const delivery = pushLosslessEvents(port, [createEvent("message.started"), mutable]);
       await firstSendEntered.promise;
       mutable.payload.metadata.label = "changed-during-send";
       releaseFirstSend.resolve();
@@ -180,14 +171,10 @@ describe("DriverEventPublisher", () => {
       expect(
         attempts.map((events) =>
           events.map(
-            (event) =>
-              (event.payload as { metadata?: { label?: string } }).metadata?.label ?? null,
+            (event) => (event.payload as { metadata?: { label?: string } }).metadata?.label ?? null,
           ),
         ),
-      ).toEqual([
-        [null, "original"],
-        ["original"],
-      ]);
+      ).toEqual([[null, "original"], ["original"]]);
       expect(attempts[1]?.[0]?.sourceEventId).toBe(attempts[0]?.[1]?.sourceEventId);
 
       if (sourceEventId !== undefined) {
@@ -270,13 +257,9 @@ describe("DriverEventPublisher", () => {
         },
       });
       const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
-      const retained = Array.from({ length: 1_024 }, () =>
-        createEvent("message.started"),
-      );
+      const retained = Array.from({ length: 1_024 }, () => createEvent("message.started"));
 
-      await expect(publisher.push(context, "fill", retained)).rejects.toThrow(
-        "socket unavailable",
-      );
+      await expect(publisher.push(context, "fill", retained)).rejects.toThrow("socket unavailable");
       await expect(
         publisher.push(context, "terminal", [createRunTerminal(kind)]),
       ).resolves.toBeUndefined();
@@ -359,9 +342,7 @@ describe("DriverEventPublisher", () => {
       createRunTerminal("run.completed"),
     ];
 
-    await expect(publisher.push(context, "fill", retained)).rejects.toThrow(
-      "socket unavailable",
-    );
+    await expect(publisher.push(context, "fill", retained)).rejects.toThrow("socket unavailable");
     await expect(publisher.push(context, "terminal", closing)).resolves.toBeUndefined();
 
     expect(attempts[1]).toHaveLength(1_027);
@@ -515,9 +496,7 @@ describe("DriverEventPublisher", () => {
     const pushes = Array.from({ length: 1_024 }, () =>
       publisher.push(context, "singleton", [createEvent("message.started")]),
     );
-    pushes.push(
-      publisher.push(context, "terminal", [createRunTerminal("run.completed")]),
-    );
+    pushes.push(publisher.push(context, "terminal", [createRunTerminal("run.completed")]));
 
     await Promise.all(pushes);
 
@@ -569,9 +548,7 @@ describe("DriverEventPublisher", () => {
     const poison = publisher.push(context, "poison", [
       { kind: "invalid.kind", payload: {} } as unknown as DriverEventInput,
     ]);
-    const terminal = publisher.push(context, "terminal", [
-      createRunTerminal("run.completed"),
-    ]);
+    const terminal = publisher.push(context, "terminal", [createRunTerminal("run.completed")]);
 
     const outcomes = await Promise.allSettled([poison, terminal]);
 
@@ -682,9 +659,7 @@ describe("DriverEventPublisher", () => {
       "socket unavailable",
     );
     activeRunId = DRIVER_TEST_IDS.secondRunId;
-    await expect(publisher.push(context, "run-2", [terminal])).rejects.toThrow(
-      "run terminal slot",
-    );
+    await expect(publisher.push(context, "run-2", [terminal])).rejects.toThrow("run terminal slot");
     await oldRunRecovered.promise;
     await Bun.sleep(0);
     await publisher.push(context, "run-2.retry", [terminal]);
@@ -783,8 +758,7 @@ describe("DriverEventPublisher", () => {
       });
       const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
       const raw = createUnscopedRunTerminal("run.completed");
-      const terminal =
-        eventRunId === undefined ? raw : { ...raw, runId: eventRunId };
+      const terminal = eventRunId === undefined ? raw : { ...raw, runId: eventRunId };
 
       await expect(publisher.push(context, "terminal", [terminal])).rejects.toThrow(
         "socket unavailable",
@@ -804,59 +778,56 @@ describe("DriverEventPublisher", () => {
   test.each([
     ["joins the pending terminal for the same", "source-terminal-1", true],
     ["keeps the pending occurrence for a different", "source-terminal-2", false],
-  ] as const)(
-    "%s explicit source ID",
-    async (_name, retrySourceEventId, joinsPending) => {
-      const attempts: DriverEventInput[][] = [];
-      const delivered = Promise.withResolvers<void>();
-      const context = createContext({
-        currentRunId: () => DRIVER_TEST_IDS.runId,
-        pushEvents: async (events) => {
-          attempts.push(events);
+  ] as const)("%s explicit source ID", async (_name, retrySourceEventId, joinsPending) => {
+    const attempts: DriverEventInput[][] = [];
+    const delivered = Promise.withResolvers<void>();
+    const context = createContext({
+      currentRunId: () => DRIVER_TEST_IDS.runId,
+      pushEvents: async (events) => {
+        attempts.push(events);
 
-          if (attempts.length === 1) {
-            throw new Error("socket unavailable");
-          }
+        if (attempts.length === 1) {
+          throw new Error("socket unavailable");
+        }
 
-          delivered.resolve();
-          return {
-            accepted: events.map((event, index) => ({
-              eventId: event.sourceEventId,
-              seq: index + 1,
-              type: event.kind,
-            })),
-          };
-        },
-      });
-      const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
-      const terminal = {
-        ...createUnscopedRunTerminal("run.completed"),
-        sourceEventId: "source-terminal-1",
-      };
+        delivered.resolve();
+        return {
+          accepted: events.map((event, index) => ({
+            eventId: event.sourceEventId,
+            seq: index + 1,
+            type: event.kind,
+          })),
+        };
+      },
+    });
+    const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
+    const terminal = {
+      ...createUnscopedRunTerminal("run.completed"),
+      sourceEventId: "source-terminal-1",
+    };
 
-      await expect(publisher.push(context, "terminal", [terminal])).rejects.toThrow(
-        "socket unavailable",
-      );
-      const retry = publisher.push(context, "terminal.retry", [
-        { ...terminal, sourceEventId: retrySourceEventId },
-      ]);
+    await expect(publisher.push(context, "terminal", [terminal])).rejects.toThrow(
+      "socket unavailable",
+    );
+    const retry = publisher.push(context, "terminal.retry", [
+      { ...terminal, sourceEventId: retrySourceEventId },
+    ]);
 
-      if (joinsPending) {
-        await expect(retry).resolves.toBeUndefined();
-      } else {
-        await expect(retry).rejects.toThrow("run terminal slot");
-        await delivered.promise;
-        await Bun.sleep(0);
-      }
+    if (joinsPending) {
+      await expect(retry).resolves.toBeUndefined();
+    } else {
+      await expect(retry).rejects.toThrow("run terminal slot");
+      await delivered.promise;
+      await Bun.sleep(0);
+    }
 
-      expect(attempts).toHaveLength(2);
-      expect(attempts.map(([event]) => event?.sourceEventId)).toEqual([
-        "source-terminal-1",
-        "source-terminal-1",
-      ]);
-      await context.logger.destroy();
-    },
-  );
+    expect(attempts).toHaveLength(2);
+    expect(attempts.map(([event]) => event?.sourceEventId)).toEqual([
+      "source-terminal-1",
+      "source-terminal-1",
+    ]);
+    await context.logger.destroy();
+  });
 
   test.each([
     ["ordinary lossless", "ordinary"],
@@ -886,9 +857,7 @@ describe("DriverEventPublisher", () => {
         },
       });
       const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
-      const retained = Array.from({ length: 1_024 }, () =>
-        createEvent("message.started"),
-      );
+      const retained = Array.from({ length: 1_024 }, () => createEvent("message.started"));
 
       await expect(publisher.push(context, "fill", retained)).rejects.toThrow(
         "socket unavailable 1",
@@ -913,10 +882,7 @@ describe("DriverEventPublisher", () => {
       }
 
       expect(
-        await Promise.race([
-          recovered.promise.then(() => true),
-          Bun.sleep(50).then(() => false),
-        ]),
+        await Promise.race([recovered.promise.then(() => true), Bun.sleep(50).then(() => false)]),
       ).toBe(true);
       expect(attempts).toHaveLength(3);
       expect(attempts[2]?.map((event) => event.sourceEventId)).toEqual(
@@ -958,18 +924,14 @@ describe("DriverEventPublisher", () => {
         },
       });
       const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
-      const retained = Array.from({ length: 1_024 }, () =>
-        createEvent("message.started"),
-      );
+      const retained = Array.from({ length: 1_024 }, () => createEvent("message.started"));
       const first = publisher.push(context, "fill", retained);
 
       await firstSendEntered.promise;
       const trigger = publisher.push(
         context,
         "wake",
-        triggerKind === "lossless"
-          ? [createEvent("message.completed")]
-          : [createDelta("wake")],
+        triggerKind === "lossless" ? [createEvent("message.completed")] : [createDelta("wake")],
       );
 
       if (triggerKind === "lossless") {
@@ -981,10 +943,7 @@ describe("DriverEventPublisher", () => {
       releaseFirstSend.resolve();
       await expect(first).rejects.toThrow("socket unavailable");
       expect(
-        await Promise.race([
-          recovered.promise.then(() => true),
-          Bun.sleep(50).then(() => false),
-        ]),
+        await Promise.race([recovered.promise.then(() => true), Bun.sleep(50).then(() => false)]),
       ).toBe(true);
       expect(attempts).toHaveLength(2);
       expect(attempts[1]?.map((event) => event.sourceEventId)).toEqual(
@@ -1085,9 +1044,7 @@ describe("DriverEventPublisher", () => {
     const firstBatch = [createEvent("message.started"), createEvent("message.completed")];
     const laterEvent = createEvent("message.started");
 
-    await expect(publisher.push(context, "first", firstBatch)).rejects.toThrow(
-      "made no progress",
-    );
+    await expect(publisher.push(context, "first", firstBatch)).rejects.toThrow("made no progress");
     await publisher.push(context, "retry", [laterEvent]);
 
     expect(kinds(attempts)).toEqual([
@@ -1237,9 +1194,7 @@ describe("DriverEventPublisher", () => {
       pushEvents: async (events) => {
         attempt += 1;
         observed.push({
-          messageIds: events.map(
-            (event) => (event.payload as { messageId: string }).messageId,
-          ),
+          messageIds: events.map((event) => (event.payload as { messageId: string }).messageId),
           sourceEventIds: events.map((event) => event.sourceEventId),
         });
 
@@ -1334,7 +1289,11 @@ describe("DriverEventPublisher", () => {
     const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
 
     await expect(
-      publisher.push(context, "oversized", Array.from({ length: 1_025 }, () => event)),
+      publisher.push(
+        context,
+        "oversized",
+        Array.from({ length: 1_025 }, () => event),
+      ),
     ).rejects.toThrow("exceeds 1024 events");
     expect(payloadReads).toBe(0);
     await context.logger.destroy();
@@ -1418,17 +1377,9 @@ describe("DriverEventPublisher", () => {
       "does not match",
     ],
     ["NaN seq", [{ seq: Number.NaN, type: "message.started" }], "safe integer"],
-    [
-      "infinite seq",
-      [{ seq: Number.POSITIVE_INFINITY, type: "message.started" }],
-      "safe integer",
-    ],
+    ["infinite seq", [{ seq: Number.POSITIVE_INFINITY, type: "message.started" }], "safe integer"],
     ["fractional seq", [{ seq: 40.5, type: "message.started" }], "safe integer"],
-    [
-      "unsafe seq",
-      [{ seq: Number.MAX_SAFE_INTEGER + 1, type: "message.started" }],
-      "safe integer",
-    ],
+    ["unsafe seq", [{ seq: Number.MAX_SAFE_INTEGER + 1, type: "message.started" }], "safe integer"],
     ["negative seq", [{ seq: -1, type: "message.started" }], "non-negative"],
   ] as const)(
     "retains the full batch after a %s receipt prefix",
@@ -1454,9 +1405,7 @@ describe("DriverEventPublisher", () => {
       const firstBatch = [createEvent("message.started"), createEvent("message.completed")];
       const laterEvent = createEvent("message.started");
 
-      await expect(publisher.push(context, "malformed", firstBatch)).rejects.toThrow(
-        expectedError,
-      );
+      await expect(publisher.push(context, "malformed", firstBatch)).rejects.toThrow(expectedError);
       expect(publisher.lastAcceptedSeq()).toBe(0);
       await publisher.push(context, "retry", [laterEvent]);
 

--- a/tests/driver-instance-socket.test.ts
+++ b/tests/driver-instance-socket.test.ts
@@ -255,9 +255,7 @@ describe("DriverInstanceSocket lifecycle", () => {
       startedAt: new Date(0).toISOString(),
     });
     const firstWire = PendingWebSocket.instances[0]!;
-    firstWire.dispatchEvent(
-      new CloseEvent("close", { code: 1006, reason: "connection lost" }),
-    );
+    firstWire.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "connection lost" }));
 
     await socket.connect();
 
@@ -288,15 +286,11 @@ describe("DriverInstanceSocket lifecycle", () => {
     await socket.connect();
     await socket.hello(helloInput);
     const firstWire = PendingWebSocket.instances[0]!;
-    firstWire.dispatchEvent(
-      new CloseEvent("close", { code: 1006, reason: "connection lost" }),
-    );
+    firstWire.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "connection lost" }));
     await socket.connect();
     await socket.hello(helloInput);
 
-    firstWire.dispatchEvent(
-      new CloseEvent("close", { code: 1006, reason: "stale close" }),
-    );
+    firstWire.dispatchEvent(new CloseEvent("close", { code: 1006, reason: "stale close" }));
 
     await expect(
       socket.heartbeat({ at: new Date(0).toISOString(), reason: "interval" }),
@@ -385,78 +379,77 @@ describe("DriverInstanceSocket lifecycle", () => {
   test.each([
     ["completeRun", "/driver/completeRun", "/driver/failRun"],
     ["failRun", "/driver/failRun", "/driver/completeRun"],
-  ] as const)("retries a failed %s send without changing the selected terminal", async (
-    selected,
-    sent,
-    skipped,
-  ) => {
-    globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
-    const socket = new DriverInstanceSocket(driverBootPayload, {
-      onClose: () => {},
-    });
-    await socket.connect();
-    socket.beginRun(DRIVER_TEST_IDS.runId);
-    const failure = {
-      code: "test.failure",
-      details: {},
-      message: "failed",
-      retryable: false,
-    };
-    const deliver = () =>
-      selected === "completeRun" ? socket.completeRun() : socket.failRun(failure);
-    const deliverOpposite = () =>
-      selected === "completeRun" ? socket.failRun(failure) : socket.completeRun();
-    RpcWebSocket.sendFailurePath = sent;
+  ] as const)(
+    "retries a failed %s send without changing the selected terminal",
+    async (selected, sent, skipped) => {
+      globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
+      const socket = new DriverInstanceSocket(driverBootPayload, {
+        onClose: () => {},
+      });
+      await socket.connect();
+      socket.beginRun(DRIVER_TEST_IDS.runId);
+      const failure = {
+        code: "test.failure",
+        details: {},
+        message: "failed",
+        retryable: false,
+      };
+      const deliver = () =>
+        selected === "completeRun" ? socket.completeRun() : socket.failRun(failure);
+      const deliverOpposite = () =>
+        selected === "completeRun" ? socket.failRun(failure) : socket.completeRun();
+      RpcWebSocket.sendFailurePath = sent;
 
-    await expect(deliver()).rejects.toThrow("test wire send failed");
-    await expect(deliverOpposite()).resolves.toBeUndefined();
-    await expect(deliver()).resolves.toBeUndefined();
-    await expect(deliver()).resolves.toBeUndefined();
+      await expect(deliver()).rejects.toThrow("test wire send failed");
+      await expect(deliverOpposite()).resolves.toBeUndefined();
+      await expect(deliver()).resolves.toBeUndefined();
+      await expect(deliver()).resolves.toBeUndefined();
 
-    const paths = (PendingWebSocket.instances[0] as RpcWebSocket).paths;
-    expect(paths.filter((path) => path === sent)).toHaveLength(2);
-    expect(paths).not.toContain(skipped);
-  });
+      const paths = (PendingWebSocket.instances[0] as RpcWebSocket).paths;
+      expect(paths.filter((path) => path === sent)).toHaveLength(2);
+      expect(paths).not.toContain(skipped);
+    },
+  );
 
   test.each([
     ["completeRun", "/driver/completeRun"],
     ["failRun", "/driver/failRun"],
-  ] as const)("shares an in-flight %s task and retries after a lost response", async (
-    selected,
-    path,
-  ) => {
-    globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
-    const socket = new DriverInstanceSocket(driverBootPayload, {
-      onClose: () => {},
-    });
-    await socket.connect();
-    socket.beginRun(DRIVER_TEST_IDS.runId);
-    const failure = {
-      code: "test.failure",
-      details: {},
-      message: "failed",
-      retryable: false,
-    };
-    const deliver = (signal?: AbortSignal) =>
-      selected === "completeRun" ? socket.completeRun(signal) : socket.failRun(failure, signal);
-    const controller = new AbortController();
-    const reason = new Error("run terminal response lost");
-    RpcWebSocket.lostResponsePath = path;
+  ] as const)(
+    "shares an in-flight %s task and retries after a lost response",
+    async (selected, path) => {
+      globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
+      const socket = new DriverInstanceSocket(driverBootPayload, {
+        onClose: () => {},
+      });
+      await socket.connect();
+      socket.beginRun(DRIVER_TEST_IDS.runId);
+      const failure = {
+        code: "test.failure",
+        details: {},
+        message: "failed",
+        retryable: false,
+      };
+      const deliver = (signal?: AbortSignal) =>
+        selected === "completeRun" ? socket.completeRun(signal) : socket.failRun(failure, signal);
+      const controller = new AbortController();
+      const reason = new Error("run terminal response lost");
+      RpcWebSocket.lostResponsePath = path;
 
-    const first = deliver(controller.signal);
-    await RpcWebSocket.stalled.promise;
-    const concurrent = deliver();
+      const first = deliver(controller.signal);
+      await RpcWebSocket.stalled.promise;
+      const concurrent = deliver();
 
-    expect(concurrent).toBe(first);
-    expect((PendingWebSocket.instances[0] as RpcWebSocket).paths).toEqual([path]);
+      expect(concurrent).toBe(first);
+      expect((PendingWebSocket.instances[0] as RpcWebSocket).paths).toEqual([path]);
 
-    controller.abort(reason);
-    await expect(first).rejects.toBe(reason);
-    await expect(concurrent).rejects.toBe(reason);
-    await expect(deliver()).resolves.toBeUndefined();
+      controller.abort(reason);
+      await expect(first).rejects.toBe(reason);
+      await expect(concurrent).rejects.toBe(reason);
+      await expect(deliver()).resolves.toBeUndefined();
 
-    expect((PendingWebSocket.instances[0] as RpcWebSocket).paths).toEqual([path, path]);
-  });
+      expect((PendingWebSocket.instances[0] as RpcWebSocket).paths).toEqual([path, path]);
+    },
+  );
 
   test("freezes a failed run payload across failed delivery attempts", async () => {
     globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
@@ -784,9 +777,7 @@ describe("DriverProcess lifecycle", () => {
       const driver = new DriverProcess(driverBootPayload, () => backend);
       const run = driver.run();
 
-      await (stallBackendStart
-        ? backendStartEntered.promise
-        : RpcWebSocket.stalled.promise);
+      await (stallBackendStart ? backendStartEntered.promise : RpcWebSocket.stalled.promise);
       const shutdown = process
         .listeners("SIGTERM")
         .find((listener) => !existingSignalListeners.has(listener));

--- a/tests/driver-permission-broker.test.ts
+++ b/tests/driver-permission-broker.test.ts
@@ -156,9 +156,9 @@ describe("DriverPermissionBroker", () => {
   test.each([0, -1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
     "rejects invalid pending limits %p",
     (limit) => {
-      expect(
-        () => new DriverPermissionBroker(() => null, { maxPendingRequests: limit }),
-      ).toThrow("limits must be positive safe integers");
+      expect(() => new DriverPermissionBroker(() => null, { maxPendingRequests: limit })).toThrow(
+        "limits must be positive safe integers",
+      );
       expect(
         () => new DriverPermissionBroker(() => null, { maxPendingRequestBytes: limit }),
       ).toThrow("limits must be positive safe integers");
@@ -168,9 +168,9 @@ describe("DriverPermissionBroker", () => {
   test.each([-1, 1.5, Number.POSITIVE_INFINITY, Number.NaN])(
     "rejects invalid permission timeout %p",
     (timeoutMs) => {
-      expect(
-        () => new DriverPermissionBroker(() => null, { requestTimeoutMs: timeoutMs }),
-      ).toThrow("request timeout must be a non-negative safe integer");
+      expect(() => new DriverPermissionBroker(() => null, { requestTimeoutMs: timeoutMs })).toThrow(
+        "request timeout must be a non-negative safe integer",
+      );
       expect(
         () => new DriverPermissionBroker(() => null, { eventDeliveryTimeoutMs: timeoutMs }),
       ).toThrow("event delivery timeout must be a non-negative safe integer");
@@ -472,12 +472,19 @@ describe("DriverPermissionBroker", () => {
   );
 
   test.each([
-    ["approved", "allow_once", (broker: DriverPermissionBroker) =>
-      broker.resolve(permissionInput.requestId, "allow_once")],
-    ["cancelled", "reject_once", (broker: DriverPermissionBroker) => {
-      broker.rejectAll();
-      return true;
-    }],
+    [
+      "approved",
+      "allow_once",
+      (broker: DriverPermissionBroker) => broker.resolve(permissionInput.requestId, "allow_once"),
+    ],
+    [
+      "cancelled",
+      "reject_once",
+      (broker: DriverPermissionBroker) => {
+        broker.rejectAll();
+        return true;
+      },
+    ],
   ] as const)(
     "does not reuse an old %s request id before resolution delivery finishes",
     async (_reason, firstDecision, resolveFirst) => {
@@ -746,7 +753,10 @@ describe("DriverPermissionBroker", () => {
       phase: "requested",
       requestId: permissionInput.requestId,
     });
-    expect((outcome as Error).cause).toHaveProperty("message", expect.stringContaining("made no progress"));
+    expect((outcome as Error).cause).toHaveProperty(
+      "message",
+      expect.stringContaining("made no progress"),
+    );
     expect(broker.hasPending()).toBe(false);
   });
 
@@ -811,9 +821,9 @@ describe("DriverPermissionBroker", () => {
     const broker = new DriverPermissionBroker(() => null);
     const socket = createRecordingSocket();
 
-    await expect(
-      broker.request(socket, permissionInput, controller.signal),
-    ).resolves.toBe("reject_once");
+    await expect(broker.request(socket, permissionInput, controller.signal)).resolves.toBe(
+      "reject_once",
+    );
 
     expect(broker.hasPending()).toBe(false);
     expect(socket.pushedEvents).toMatchObject([

--- a/tests/driver-runtime-boundary.test.ts
+++ b/tests/driver-runtime-boundary.test.ts
@@ -69,11 +69,7 @@ describe("driver runtime boundary", () => {
       startedAt,
       traceId: "trace-1",
     });
-    const [envelope] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.runId,
-    );
+    const [envelope] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
 
     expect(envelope).toMatchObject({
       occurredAt: completedAt,
@@ -95,11 +91,7 @@ describe("driver runtime boundary", () => {
       occurredAt: "2026-07-17T16:00:00.000+08:00",
       payload: { startedAt: "2026-07-17T08:00:00.000Z" },
     } as const;
-    const [envelope] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.runId,
-    );
+    const [envelope] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
 
     expect(envelope?.occurredAt).toBe(draft.occurredAt);
     expect(parseDriverEventEnvelope(envelope)).toEqual(envelope);
@@ -121,9 +113,7 @@ describe("driver runtime boundary", () => {
     } as const;
     expect(() =>
       toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.secondRunId),
-    ).toThrow(
-      "Run ID must be a valid ULID.",
-    );
+    ).toThrow("Run ID must be a valid ULID.");
   });
 
   test("driver socket rejects provider turn ids outside an active platform run", () => {
@@ -161,11 +151,7 @@ describe("driver runtime boundary", () => {
       },
       runId: DRIVER_TEST_IDS.thirdRunId,
     } as const;
-    const [event] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.secondRunId,
-    );
+    const [event] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.secondRunId);
 
     expect(event?.event.runId).toBe(DRIVER_TEST_IDS.thirdRunId);
   });
@@ -178,11 +164,7 @@ describe("driver runtime boundary", () => {
         startedAt: new Date(1_000).toISOString(),
       },
     } as const;
-    const [envelope] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.runId,
-    );
+    const [envelope] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
 
     expect(envelope?.event.correlationId).toBe("request-1");
     expect(parseDriverEventEnvelope(envelope).event.correlationId).toBe("request-1");
@@ -198,16 +180,8 @@ describe("driver runtime boundary", () => {
         role: "agent",
       },
     } as const;
-    const [first] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.runId,
-    );
-    const [second] = toDriverEventEnvelopes(
-      driverBootPayload,
-      draft,
-      DRIVER_TEST_IDS.runId,
-    );
+    const [first] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
+    const [second] = toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId);
 
     expect(isDriverId(first?.event.sourceEventId)).toBe(true);
     expect(isDriverId(second?.event.sourceEventId)).toBe(true);
@@ -232,8 +206,7 @@ describe("driver runtime boundary", () => {
       },
     }));
     const envelopes = drafts.map(
-      (draft) =>
-        toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId)[0],
+      (draft) => toDriverEventEnvelopes(driverBootPayload, draft, DRIVER_TEST_IDS.runId)[0],
     );
 
     expect(new Set(envelopes.map((event) => event?.event.sourceEventId)).size).toBe(chunks.length);
@@ -591,9 +564,7 @@ describe("driver runtime boundary", () => {
       const runtimeState = new DriverRuntimeStateMachine("ready");
       let boundarySignal: AbortSignal | undefined;
       const socket = new FakeDriverRuntimeIo(
-        boundary === "poll"
-          ? []
-          : [{ commandId: "accepted-never-settles", kind: "turn.cancel" }],
+        boundary === "poll" ? [] : [{ commandId: "accepted-never-settles", kind: "turn.cancel" }],
       );
       if (boundary === "poll") {
         socket.nextCommand = async (signal) => {
@@ -1407,9 +1378,7 @@ describe("driver runtime boundary", () => {
               serverId: "mcp-linear",
               toolName: "createIssue",
             };
-      const socket = new FakeDriverRuntimeIo([
-        command,
-      ]);
+      const socket = new FakeDriverRuntimeIo([command]);
       const recordUpdate = socket.commandUpdate.bind(socket);
       const terminalAttempts: string[] = [];
       socket.commandUpdate = async (update) => {
@@ -1787,8 +1756,7 @@ describe("driver runtime boundary", () => {
         isShuttingDown: () =>
           kind === "input"
             ? socket.updates.some(
-                (update) =>
-                  update.commandId === next.commandId && update.status === "completed",
+                (update) => update.commandId === next.commandId && update.status === "completed",
               )
             : socket.isDrained(),
         mcpExecute: async (command) => {

--- a/tests/openai-app-server-event-bridge.test.ts
+++ b/tests/openai-app-server-event-bridge.test.ts
@@ -279,9 +279,7 @@ describe("OpenAi app-server event bridge", () => {
     expect(
       harness
         .events()
-        .filter((event) =>
-          ["run.cancelled", "run.completed", "run.failed"].includes(event.kind),
-        ),
+        .filter((event) => ["run.cancelled", "run.completed", "run.failed"].includes(event.kind)),
     ).toMatchObject([{ kind: "run.cancelled", runId: DRIVER_TEST_IDS.runId }]);
     await harness.logger.destroy();
   });

--- a/tests/openai-app-server-live.test.ts
+++ b/tests/openai-app-server-live.test.ts
@@ -4,12 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { applyCommittedMutation, validateSessionSnapshot } from "../src/contract";
-import type {
-  AuthorityOperation,
-  CommittedMutation,
-  Run,
-  SessionSnapshot,
-} from "../src/contract";
+import type { AuthorityOperation, CommittedMutation, Run, SessionSnapshot } from "../src/contract";
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
 import { OPENAI_DEFAULT_MODEL_ID } from "../src/models";
 import { createBufferedSinkLogger } from "../src/observability";
@@ -30,11 +25,7 @@ import {
   FakeDriverRuntimeIo,
   bootPayload,
 } from "./driver-runtime-boundary-fixtures";
-import {
-  textDeltaFrom,
-  waitForTerminalTurnEvent,
-  withLiveTimeout,
-} from "./live-driver-events";
+import { textDeltaFrom, waitForTerminalTurnEvent, withLiveTimeout } from "./live-driver-events";
 
 const LIVE_ENABLED_ENV = "AGENT_DRIVER_LIVE_OPENAI";
 const LIVE_API_KEY_ENV = "AGENT_DRIVER_LIVE_OPENAI_API_KEY";
@@ -83,8 +74,8 @@ async function copyLocalAuth(homePath: string): Promise<void> {
     return;
   }
 
-  const sourceHome = readEnvString(OPENAI_RUNTIME_HOME_ENV) ??
-    join(homedir(), OPENAI_RUNTIME_HOME_DIR);
+  const sourceHome =
+    readEnvString(OPENAI_RUNTIME_HOME_ENV) ?? join(homedir(), OPENAI_RUNTIME_HOME_DIR);
   const target = join(homePath, "auth.json");
 
   await copyFile(join(sourceHome, "auth.json"), target);
@@ -690,8 +681,7 @@ describe("OpenAI app-server live provider", () => {
         });
         await waitForLiveEvent(
           iterator,
-          (event) =>
-            event.kind === "item.started" && hasPayloadValue(event, "title", "Shell"),
+          (event) => event.kind === "item.started" && hasPayloadValue(event, "title", "Shell"),
           "running tool event",
         );
         await withLiveTimeout({
@@ -714,12 +704,7 @@ describe("OpenAI app-server live provider", () => {
           (event) => event.kind === "run.cancelled",
           "cancelled run terminal event",
         );
-        await sendPing(
-          kernel,
-          fromIterator(iterator),
-          "after-cancel",
-          DRIVER_TEST_IDS.secondRunId,
-        );
+        await sendPing(kernel, fromIterator(iterator), "after-cancel", DRIVER_TEST_IDS.secondRunId);
       } finally {
         await stopLiveKernel(kernel, "test.stop");
       }
@@ -755,8 +740,7 @@ describe("OpenAI app-server live provider", () => {
         });
         await waitForLiveEvent(
           firstEvents,
-          (event) =>
-            event.kind === "item.started" && hasPayloadValue(event, "title", "Shell"),
+          (event) => event.kind === "item.started" && hasPayloadValue(event, "title", "Shell"),
           "running tool before shutdown",
         );
         await stopLiveKernel(firstKernel, "live.active-stop");

--- a/tests/openai-app-server-startup.test.ts
+++ b/tests/openai-app-server-startup.test.ts
@@ -217,11 +217,7 @@ describe("OpenAI app-server startup", () => {
         const lifecycle =
           operation === "cancel"
             ? harness.backend.cancelActiveTurn(harness.context, "test.cancel")
-            : harness.backend.stop(
-                harness.context,
-                "test.stop",
-                new AbortController().signal,
-              );
+            : harness.backend.stop(harness.context, "test.stop", new AbortController().signal);
 
         await Bun.sleep(10);
         harness.releaseTurnTiming();
@@ -306,11 +302,7 @@ describe("OpenAI app-server startup", () => {
       );
     } finally {
       permissionGate.resolve();
-      await harness.backend.stop(
-        harness.context,
-        "test complete",
-        new AbortController().signal,
-      );
+      await harness.backend.stop(harness.context, "test complete", new AbortController().signal);
       await harness.logger.destroy();
     }
   });

--- a/tests/openai-contract-adapter.test.ts
+++ b/tests/openai-contract-adapter.test.ts
@@ -562,17 +562,20 @@ describe("OpenAI Contract adapter", () => {
       [{ data: "aGVsbG8=", mediaType: "text/plain", type: "inline_blob" as const }],
       "inline Blob",
     ],
-  ] as const)("rejects an oversized attachment %s before Authority", async (_, limits, input, error) => {
-    const harness = createHarness({ admissionLimits: limits });
+  ] as const)(
+    "rejects an oversized attachment %s before Authority",
+    async (_, limits, input, error) => {
+      const harness = createHarness({ admissionLimits: limits });
 
-    await expect(
-      harness.adapter.attachTurn({
-        ...turnAttachment(),
-        run: { ...turnAttachment().run, input: [...input] },
-      }),
-    ).rejects.toThrow(error);
-    expect(harness.authority).toHaveLength(0);
-  });
+      await expect(
+        harness.adapter.attachTurn({
+          ...turnAttachment(),
+          run: { ...turnAttachment().run, input: [...input] },
+        }),
+      ).rejects.toThrow(error);
+      expect(harness.authority).toHaveLength(0);
+    },
+  );
 
   test("projects streaming text as Preview and repairs dropped Preview with the final Item", async () => {
     const harness = createHarness({ previewReplaceIntervalMs: 1_000 });
@@ -1631,17 +1634,20 @@ describe("OpenAI Contract adapter", () => {
       },
       "inline Blob",
     ],
-  ] as const)("rejects an oversized projected %s before Authority", async (_, limits, params, error) => {
-    const harness = createHarness({ admissionLimits: limits });
-    await registerTurn(harness.adapter);
-    const before = harness.authority.length;
+  ] as const)(
+    "rejects an oversized projected %s before Authority",
+    async (_, limits, params, error) => {
+      const harness = createHarness({ admissionLimits: limits });
+      await registerTurn(harness.adapter);
+      const before = harness.authority.length;
 
-    await expect(harness.adapter.handleNotification("item/completed", params)).rejects.toThrow(
-      error,
-    );
-    expect(harness.authority).toHaveLength(before);
-    expect(harness.snapshot().items).toHaveLength(0);
-  });
+      await expect(harness.adapter.handleNotification("item/completed", params)).rejects.toThrow(
+        error,
+      );
+      expect(harness.authority).toHaveLength(before);
+      expect(harness.snapshot().items).toHaveLength(0);
+    },
+  );
 
   test("preserves multi-agent routing and status in Agent Tool items", async () => {
     const harness = createHarness();


### PR DESCRIPTION
Closes #61

## Summary

- Enforce `vp fmt --check` through both `just check` and pull request CI.
- Apply the current `vp fmt --write` output across source and test files.

## Why

Pull request checks previously allowed formatting drift.

## Impact

The only behavioral change is the new formatting gate.

The remaining file changes are generated formatting updates.

## Validation

- `vp fmt . --check`
- `just check`
- 1060 passing tests, 20 credential-gated skips, and 0 failures.
- Driver artifact existence, size, executable bit, and Bun shebang checks.
