### PR TITLE
perf: reduce streaming runtime overhead

### DIFF
--- a/src/runtimes/driver-event-publisher.ts
+++ b/src/runtimes/driver-event-publisher.ts
@@ -140,7 +140,7 @@ export class DriverEventPublisher {
       }
 
       this.#enqueue(entry);
-      return entry.promise;
+      return entry.losslessCount === 0 && !entry.terminalBatch ? undefined : entry.promise;
     } catch (error) {
       this.#requestPendingDrain(context, reason);
       throw error;

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -148,18 +148,29 @@ export function limitNdjsonLines(maxMessageBytes = MAX_APP_SERVER_MESSAGE_BYTES)
 
   return new Transform({
     transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback) {
-      for (const byte of chunk) {
-        if (byte === 0x0a) {
-          pendingBytes = 0;
-          continue;
-        }
+      let lineStart = 0;
 
-        pendingBytes += 1;
+      for (
+        let newline = chunk.indexOf(0x0a);
+        newline >= 0;
+        newline = chunk.indexOf(0x0a, lineStart)
+      ) {
+        pendingBytes += newline - lineStart;
 
         if (pendingBytes > maxMessageBytes) {
           callback(new Error(`App-server message exceeds ${maxMessageBytes} bytes.`));
           return;
         }
+
+        pendingBytes = 0;
+        lineStart = newline + 1;
+      }
+
+      pendingBytes += chunk.length - lineStart;
+
+      if (pendingBytes > maxMessageBytes) {
+        callback(new Error(`App-server message exceeds ${maxMessageBytes} bytes.`));
+        return;
       }
 
       callback(null, chunk);

--- a/tests/driver-event-publisher.test.ts
+++ b/tests/driver-event-publisher.test.ts
@@ -506,6 +506,35 @@ describe("DriverEventPublisher", () => {
     await context.logger.destroy();
   });
 
+  test("does not block best-effort producers on transport acknowledgements", async () => {
+    const firstSendEntered = Promise.withResolvers<void>();
+    const releaseFirstSend = Promise.withResolvers<void>();
+    const context = createContext({
+      pushEvents: async (events) => {
+        firstSendEntered.resolve();
+        await releaseFirstSend.promise;
+
+        return {
+          accepted: events.map((event, index) => ({
+            eventId: event.sourceEventId,
+            seq: index + 1,
+            type: event.kind,
+          })),
+        };
+      },
+    });
+    const publisher = new DriverEventPublisher("openai-runtime", () => "session-ref");
+    const first = publisher.push(context, "first", [createDelta("a")]);
+
+    await firstSendEntered.promise;
+    const blocked = await Promise.race([first.then(() => false), Bun.sleep(10).then(() => true)]);
+    releaseFirstSend.resolve();
+    await publisher.push(context, "flush", [createEvent("message.completed")]);
+
+    expect(blocked).toBe(false);
+    await context.logger.destroy();
+  });
+
   test("bounds the number of closing events in a run terminal batch", async () => {
     let sends = 0;
     const context = createContext({

--- a/tests/openai-app-server-client.test.ts
+++ b/tests/openai-app-server-client.test.ts
@@ -123,6 +123,20 @@ setInterval(() => {}, 1000);
     await expect(Array.fromAsync(output)).rejects.toThrow("exceeds 4 bytes");
   });
 
+  test("resets the stdout message limit at newlines across chunk boundaries", async () => {
+    const output = Readable.from([Buffer.from("1234\n12"), Buffer.from("34\n")]).pipe(
+      limitNdjsonLines(4),
+    );
+
+    expect(Buffer.concat(await Array.fromAsync(output)).toString()).toBe("1234\n1234\n");
+  });
+
+  test("rejects an oversized stdout message ending at a newline", async () => {
+    const output = Readable.from([Buffer.from("12345\n")]).pipe(limitNdjsonLines(4));
+
+    await expect(Array.fromAsync(output)).rejects.toThrow("exceeds 4 bytes");
+  });
+
   test("rejects a child process spawn failure without an unhandled error", async () => {
     const harness = await createClientHarness(() => "");
     process.env["MOSOO_OPENAI_RUNTIME_EXECUTABLE"] = join(harness.directory, "missing");


### PR DESCRIPTION
## Summary

- Let best-effort-only event pushes return after admission to the existing bounded publisher queue.
- Keep lossless and terminal pushes waiting for transport acknowledgement.
- Replace the OpenAI NDJSON guard's JavaScript byte loop with native `Buffer.indexOf` newline scanning.
- Add focused regression coverage for acknowledgement blocking and line-limit boundaries.

## Root cause

Provider notification handling awaited every best-effort transport acknowledgement, which serialized streaming throughput on transport latency and prevented the existing queue from coalescing concurrent deltas.

The app-server stdout guard also crossed every byte through JavaScript even though only newline positions are needed to enforce the per-line limit.

## Impact

- A synthetic 200-delta stream with 10 ms transport latency dropped from 201 sends and 2088.8 ms to 3 sends and 35.5 ms.
- A 128 MiB long-line scan dropped from 2035.2 ms to 2.9 ms.
- A 128 MiB workload with 256-byte lines dropped from 2037.0 ms to 14.9 ms.
- A live OpenAI long-output profile confirmed the remaining local parsing and notification work is only tens of milliseconds relative to model latency.

## Validation

- `bun test`: 1063 passed, 20 skipped, 0 failed.
- `vp check`: formatting and lint passed.
- `vp run tc`: TypeScript passed.
- `vp run build`: production build passed.
- Local-auth OpenAI live smoke passed with a terminal `run.completed` event.

Closes #63
