### PR TITLE
perf(container): remove npm cache from runtime image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -39,7 +39,8 @@ RUN OPENAI_RUNTIME_PACKAGE="@openai/co""dex@${OPENAI_RUNTIME_VERSION}" \
     && CLAUDE_ARCH_PACKAGE="$(node -p "'@anthropic-ai/claude-agent-sdk-' + (process.arch === 'arm64' ? 'linux-arm64' : 'linux-x64')")" \
     && CLAUDE_BIN="/usr/local/lib/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/${CLAUDE_ARCH_PACKAGE}/claude" \
     && test -x "$CLAUDE_BIN" \
-    && ln -sf "$CLAUDE_BIN" /usr/local/bin/mosoo-claude-code
+    && ln -sf "$CLAUDE_BIN" /usr/local/bin/mosoo-claude-code \
+    && npm cache clean --force
 
 ENV MOSOO_CLAUDE_CODE_EXECUTABLE=/usr/local/bin/mosoo-claude-code
 ENV MOSOO_ACP_FALLBACK_COMMAND=opencode


### PR DESCRIPTION
## What changed

- remove npm's download cache from the existing runtime-package image layer
- keep all installed Claude, Codex, OpenCode, Python, pip, and Driver artifacts unchanged

## Why

The cache is build-time residue that is never read at runtime. Keeping it inflates every cold image transfer without adding a runtime capability.

## Before / after

Measured on `linux/amd64` from Driver main `0db020a`, with a byte-identical Driver bundle:

- uncompressed image: 2,360,829,157 B -> 1,788,930,473 B (-24.22%)
- `docker save | gzip -n -1`: 1,068,600,282 B -> 693,094,196 B (-35.14%)

## Verification

- `vp fmt --check`
- `vp run lint`
- `vp run tc`
- `vp run test` (1,063 passed, 20 live-provider tests skipped)
- `vp run build` and executable artifact checks
- image smoke: Driver, Claude, Codex, OpenCode, Python, and pip

This PR makes an image-size claim only; it does not claim a causal TTFT improvement.
