### PR TITLE
chore(brand): lowercase standalone mosoo brand mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="./assets/logo.svg" alt="Mosoo" width="138" height="138" />
+<img src="./assets/logo.svg" alt="mosoo" width="138" height="138" />
 
 <h1>mosoo-agent-driver</h1>
 
@@ -30,13 +30,13 @@ One Agent Driver protocol for Claude Agent SDK, Codex app-server, and Agent Clie
 
 `mosoo-agent-driver` is the standalone Agent Driver and AI agent harness kernel for sandbox-hosted coding agent sessions. It runs inside the sandbox and drives one session from boot to stop. The core product is the **Driver Kernel**: runtime-neutral commands, events, host ports, provider backends, and the provider registry. The package manifest uses the name `agent-driver`, but the package has not been published to npm yet.
 
-An experimental, unsupported Anthropic Managed Agents (CMA)-shaped library adapter is layered on top of the Driver Kernel through projections. It is not a compatibility or conformance claim, and it is not part of Mosoo's production API. Provider backends emit Driver runtime events and consume Driver commands; they do not emit CMA events directly.
+An experimental, unsupported Anthropic Managed Agents (CMA)-shaped library adapter is layered on top of the Driver Kernel through projections. It is not a compatibility or conformance claim, and it is not part of mosoo's production API. Provider backends emit Driver runtime events and consume Driver commands; they do not emit CMA events directly.
 
-## Current Mosoo topology
+## Current mosoo topology
 
 ```mermaid
 flowchart LR
-    Runtime["Mosoo Runtime"]
+    Runtime["mosoo Runtime"]
     Boot["Private boot payload file<br/>controlUrl + one-time token + trace context"]
     Driver["agent-driver<br/>inside Sandbox"]
     Ingress["API Worker<br/>/api/driver/socket"]
@@ -51,7 +51,7 @@ flowchart LR
     Driver -->|"launches and supervises"| Backend
 ```
 
-The Driver does not open a sandbox-local control listener. In Mosoo's production path, Runtime writes the private boot payload, passes its path in `MOSOO_DRIVER_BOOT_PAYLOAD_FILE`, and starts `agent-driver`; boot configuration is not injected through standard input. The Driver reads and removes the file, converts the payload's `controlUrl` to `ws:` or `wss:`, and actively dials `/api/driver/socket`. The API Worker routes the upgrade to the `DriverConnection` binding backed by the matching `DriverInstance` Durable Object. That object validates and claims the one-time boot token and owns the ORPC command, readiness, heartbeat, event, and log lifecycle.
+The Driver does not open a sandbox-local control listener. In mosoo's production path, Runtime writes the private boot payload, passes its path in `MOSOO_DRIVER_BOOT_PAYLOAD_FILE`, and starts `agent-driver`; boot configuration is not injected through standard input. The Driver reads and removes the file, converts the payload's `controlUrl` to `ws:` or `wss:`, and actively dials `/api/driver/socket`. The API Worker routes the upgrade to the `DriverConnection` binding backed by the matching `DriverInstance` Durable Object. That object validates and claims the one-time boot token and owns the ORPC command, readiness, heartbeat, event, and log lifecycle.
 
 ## AI Agent Harness Architecture
 
@@ -59,12 +59,12 @@ Different model vendors ship different agent runtimes — the Claude Agent SDK, 
 
 - **Kernel-level unification.** Three launchable transports — `openai-app-server` (OpenAI runtime), `claude-agent-sdk`, and `acp-fallback` — project onto a single Driver event protocol. The host writes against one set of commands and events regardless of which backend is behind the session. The container currently configures OpenCode as the default ACP process, while the ACP command remains configurable.
 - **Runtime-neutral by design.** The Driver Kernel owns command dispatch, runtime event emission, provider lifecycle, the permission flow, and diagnostics. Hosts own credentials, files, skills, MCP, policy, logging, persistence, and transport through well-defined host ports. The library is safe to import and never starts the process runner on its own.
-- **Experimental Managed Agents-shaped adapter.** The library exports an HTTP handler, thin client, projections, and in-memory store for a subset of Anthropic Managed Agents (CMA)-shaped routes and events. This preview is unsupported: it has no compatibility, conformance, completeness, or stability guarantee, and Mosoo does not mount it as a production API.
+- **Experimental Managed Agents-shaped adapter.** The library exports an HTTP handler, thin client, projections, and in-memory store for a subset of Anthropic Managed Agents (CMA)-shaped routes and events. This preview is unsupported: it has no compatibility, conformance, completeness, or stability guarantee, and mosoo does not mount it as a production API.
 - **Typed public entries.** Every public entry ships a matching declaration file under `dist/types`, and the package carries **no** `@mosoo/*` runtime dependencies — it is self-contained and portable.
 
 ## Package Entries
 
-- Command `agent-driver`: Bun process runner, built to `dist/driver.mjs`; in Mosoo it consumes the private boot payload and dials the API control socket.
+- Command `agent-driver`: Bun process runner, built to `dist/driver.mjs`; in mosoo it consumes the private boot payload and dials the API control socket.
 - Package root `agent-driver`: Driver Kernel, provider registry, host ports, commands, events, diagnostics, the in-memory CMA store, and CMA projection exports.
 - `agent-driver/boot`: process boot payload, protocol version, boot environment names, and host snapshot contracts.
 - `agent-driver/runtime`: runtime-neutral runtime, transport, and native resume contracts.
@@ -140,13 +140,13 @@ test("create an agent, environment, and session over the CMA surface", async () 
 });
 ```
 
-This exercises the implemented `/v1/environments`, `/v1/agents`, and `/v1/sessions` preview routes. It does not establish CMA compatibility, and Mosoo does not mount this handler. An embedding application must supply its own authorization, durable store, network server, and Driver command dispatcher.
+This exercises the implemented `/v1/environments`, `/v1/agents`, and `/v1/sessions` preview routes. It does not establish CMA compatibility, and mosoo does not mount this handler. An embedding application must supply its own authorization, durable store, network server, and Driver command dispatcher.
 
-### How it is used in Mosoo
+### How it is used in mosoo
 
-`agent-driver` is the **runtime kernel of the Mosoo agent runtime**. When Mosoo starts an agent session, it writes the private boot payload, boots this driver inside a sandbox, and waits on the matching `DriverInstance` Durable Object. The Driver dials outward, selects a provider backend from the registry, drives the session, and sends its runtime-neutral Driver protocol over ORPC. The host supplies credentials, files, skills, MCP, policy, and persistence through host ports.
+`agent-driver` is the **runtime kernel of the mosoo agent runtime**. When mosoo starts an agent session, it writes the private boot payload, boots this driver inside a sandbox, and waits on the matching `DriverInstance` Durable Object. The Driver dials outward, selects a provider backend from the registry, drives the session, and sends its runtime-neutral Driver protocol over ORPC. The host supplies credentials, files, skills, MCP, policy, and persistence through host ports.
 
-[Mosoo](https://github.com/langgenius/mosoo) and this Driver repository are already public. Mosoo exposes its production client contract through the [Public Thread API](https://github.com/langgenius/mosoo/blob/main/docs/prd/public-thread-api-surface.md) under `/api/v1`, not through the experimental CMA-shaped adapter. The `agent-driver` npm package has not been published yet.
+[mosoo](https://github.com/langgenius/mosoo) and this Driver repository are already public. mosoo exposes its production client contract through the [Public Thread API](https://github.com/langgenius/mosoo/blob/main/docs/prd/public-thread-api-surface.md) under `/api/v1`, not through the experimental CMA-shaped adapter. The `agent-driver` npm package has not been published yet.
 
 ## Commands
 
@@ -167,9 +167,9 @@ vp run image:build
 - Host applications own credential, file, skill, MCP, policy, logging, persistence, and transport implementations.
 - Provider backends depend on Driver contracts and host ports only.
 - The library root is safe to import and must not start the process runner.
-- The package must not depend on Mosoo workspace packages at runtime.
-- Mosoo control traffic uses the outbound ORPC WebSocket to `DriverInstance`; the Driver does not expose a sandbox-local control listener.
-- The CMA-shaped exports are an experimental library adapter, not a Mosoo production endpoint or a compatibility guarantee.
+- The package must not depend on mosoo workspace packages at runtime.
+- mosoo control traffic uses the outbound ORPC WebSocket to `DriverInstance`; the Driver does not expose a sandbox-local control listener.
+- The CMA-shaped exports are an experimental library adapter, not a mosoo production endpoint or a compatibility guarantee.
 
 ## Checks
 

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -201,7 +201,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
               clientCapabilities: buildClientCapabilities(),
               clientInfo: {
                 name: "mosoo-driver",
-                title: "Mosoo Driver",
+                title: "mosoo Driver",
                 version: "0.1.0",
               },
               protocolVersion: ACP_PROTOCOL_VERSION,

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -89,7 +89,7 @@ function createCanUseTool(context: AgentDriverContext): CanUseTool {
 
     return {
       behavior: "deny",
-      message: "Rejected by Mosoo permission review.",
+      message: "Rejected by mosoo permission review.",
       toolUseID: options.toolUseID,
     };
   };

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -335,7 +335,7 @@ export class OpenAiAppServerClient {
           },
           clientInfo: {
             name: "mosoo_driver",
-            title: "Mosoo Driver",
+            title: "mosoo Driver",
             version: "0.1.0",
           },
         },

--- a/src/runtimes/openai/auth-state.ts
+++ b/src/runtimes/openai/auth-state.ts
@@ -205,7 +205,7 @@ export async function materializeOpenAiModelProviderConfig(
       [input.provider]: {
         base_url: baseUrl,
         env_key: OPENAI_COMPATIBLE_API_KEY_ENV_NAME,
-        name: "Mosoo OpenAI-Compatible",
+        name: "mosoo OpenAI-Compatible",
         wire_api: "responses",
       },
     };

--- a/tests/acp-event-translator-session-update.test.ts
+++ b/tests/acp-event-translator-session-update.test.ts
@@ -404,7 +404,7 @@ describe("ACP runtime event translation", () => {
     });
   });
 
-  test("normalizes ACP config options to the Mosoo session config contract", () => {
+  test("normalizes ACP config options to the mosoo session config contract", () => {
     const events = toSessionReadyEvents({
       mode: "created",
       nativeSessionId: "native-session-1",
@@ -504,7 +504,7 @@ describe("ACP runtime event translation", () => {
     });
   });
 
-  test("normalizes ACP commands to the Mosoo session commands contract", () => {
+  test("normalizes ACP commands to the mosoo session commands contract", () => {
     const state = new AcpTurnEventState();
     const events = state.translateUpdate({
       update: {
@@ -533,7 +533,7 @@ describe("ACP runtime event translation", () => {
     ]);
   });
 
-  test("normalizes ACP usage sources to the Mosoo usage contract", () => {
+  test("normalizes ACP usage sources to the mosoo usage contract", () => {
     const state = new AcpTurnEventState();
 
     state.begin({

--- a/tests/claude-agent-sdk-query-options.test.ts
+++ b/tests/claude-agent-sdk-query-options.test.ts
@@ -98,7 +98,7 @@ describe("Claude Agent SDK query options", () => {
     expect(merged.mcpServers).toEqual(base.mcpServers);
   });
 
-  test("maps Mosoo built-in tool toggles into Claude SDK tool names", () => {
+  test("maps mosoo built-in tool toggles into Claude SDK tool names", () => {
     const payload = createDriverStartInputFromBootPayload({
       ...driverBootPayload,
       execution: {

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -133,7 +133,7 @@ describe("driver artifact contract", () => {
     );
   });
 
-  test("keeps the standalone package out of Mosoo workspace dependencies", () => {
+  test("keeps the standalone package out of mosoo workspace dependencies", () => {
     const packageJson = readDriverPackageJson();
     const deps = Object.keys(packageJson.dependencies ?? {});
     const tsconfig = readText("../tsconfig.json");

--- a/tests/openai-app-server-auth-state.test.ts
+++ b/tests/openai-app-server-auth-state.test.ts
@@ -94,7 +94,7 @@ describe("OpenAI app-server auth state", () => {
     expect(modelProviders["openai-compatible"]).toEqual({
       base_url: "https://compat.example/v1",
       env_key: "OPENAI_COMPATIBLE_API_KEY",
-      name: "Mosoo OpenAI-Compatible",
+      name: "mosoo OpenAI-Compatible",
       wire_api: "chat",
     });
     expect(requireRecord(config["features"], "runtime features")).toMatchObject({

--- a/tests/opencode-acp-contract.test.ts
+++ b/tests/opencode-acp-contract.test.ts
@@ -149,7 +149,7 @@ describe("OpenCode ACP contract", () => {
             clientCapabilities: buildClientCapabilities(),
             clientInfo: {
               name: "mosoo-driver-contract-test",
-              title: "Mosoo Driver Contract Test",
+              title: "mosoo Driver Contract Test",
               version: "0.1.0",
             },
             protocolVersion: ACP_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

- Mechanically replace every standalone-word `Mosoo` brand mention with all-lowercase `mosoo` (25 replacements across 10 files: README, doc comments, and test fixture strings).
- `MOSOO_*` environment variables and `Mosoo`-prefixed identifiers are intentionally unchanged.

## Why

- Brand style: the product name is written all-lowercase (`mosoo`) wherever it is displayed or mentioned (internal tracker YEF-879).

## Verification

- `tsc --noEmit` passes.
- `bun test`: 1071 pass; the single failure in `tests/acp-file-system.test.ts` is pre-existing (fails identically on a pristine checkout, environment-related).
