### PR TITLE
build(npm): prepare package for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,9 @@ One Agent Driver protocol for Claude Agent SDK, Codex app-server, and Agent Clie
 <br />
 <br />
 
-<!-- Static badges below render cleanly before the package is published to npm.
-     Once the first npm release exists, swap in the dynamic versions:
-     checks:    https://img.shields.io/github/actions/workflow/status/langgenius/mosoo-agent-driver/pr.yml?label=checks
-     version:   https://img.shields.io/npm/v/agent-driver?label=version
-     downloads: https://img.shields.io/npm/dm/agent-driver?label=downloads -->
-
-[![Build](https://img.shields.io/badge/tests-passing-3fb911)](#checks)
-[![Version](https://img.shields.io/badge/version-0.1.0-orange)](./package.json)
+[![Build](https://img.shields.io/github/actions/workflow/status/langgenius/mosoo-agent-driver/pr.yml?label=checks)](https://github.com/langgenius/mosoo-agent-driver/actions/workflows/pr.yml)
+[![Version](https://img.shields.io/npm/v/%40mosoo%2Fagent-driver?label=version)](https://www.npmjs.com/package/@mosoo/agent-driver)
+[![Downloads](https://img.shields.io/npm/dm/%40mosoo%2Fagent-driver?label=downloads)](https://www.npmjs.com/package/@mosoo/agent-driver)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE.txt)
 
 [![Built by langgenius](https://img.shields.io/badge/built%20by-langgenius-6fd305)](https://github.com/langgenius)
@@ -28,7 +23,7 @@ One Agent Driver protocol for Claude Agent SDK, Codex app-server, and Agent Clie
 
 ---
 
-`mosoo-agent-driver` is the standalone Agent Driver and AI agent harness kernel for sandbox-hosted coding agent sessions. It runs inside the sandbox and drives one session from boot to stop. The core product is the **Driver Kernel**: runtime-neutral commands, events, host ports, provider backends, and the provider registry. The package manifest uses the name `agent-driver`, but the package has not been published to npm yet.
+`mosoo-agent-driver` is the repository for the `@mosoo/agent-driver` package: a standalone Agent Driver and AI agent harness kernel for sandbox-hosted coding agent sessions. It runs inside the sandbox and drives one session from boot to stop. The core product is the **Driver Kernel**: runtime-neutral commands, events, host ports, provider backends, and the provider registry.
 
 An experimental, unsupported Anthropic Managed Agents (CMA)-shaped library adapter is layered on top of the Driver Kernel through projections. It is not a compatibility or conformance claim, and it is not part of mosoo's production API. Provider backends emit Driver runtime events and consume Driver commands; they do not emit CMA events directly.
 
@@ -55,7 +50,7 @@ The Driver does not open a sandbox-local control listener. In mosoo's production
 
 ## AI Agent Harness Architecture
 
-Different model vendors ship different agent runtimes — the Claude Agent SDK, OpenAI's app-server protocol, and ACP-based agents — and each speaks its own event vocabulary. `agent-driver` unifies them at the kernel level so the host integrates **one** protocol instead of three.
+Different model vendors ship different agent runtimes — the Claude Agent SDK, OpenAI's app-server protocol, and ACP-based agents — and each speaks its own event vocabulary. `@mosoo/agent-driver` unifies them at the kernel level so the host integrates **one** protocol instead of three.
 
 - **Kernel-level unification.** Three launchable transports — `openai-app-server` (OpenAI runtime), `claude-agent-sdk`, and `acp-fallback` — project onto a single Driver event protocol. The host writes against one set of commands and events regardless of which backend is behind the session. The container currently configures OpenCode as the default ACP process, while the ACP command remains configurable.
 - **Runtime-neutral by design.** The Driver Kernel owns command dispatch, runtime event emission, provider lifecycle, the permission flow, and diagnostics. Hosts own credentials, files, skills, MCP, policy, logging, persistence, and transport through well-defined host ports. The library is safe to import and never starts the process runner on its own.
@@ -65,15 +60,15 @@ Different model vendors ship different agent runtimes — the Claude Agent SDK, 
 ## Package Entries
 
 - Command `agent-driver`: Bun process runner, built to `dist/driver.mjs`; in mosoo it consumes the private boot payload and dials the API control socket.
-- Package root `agent-driver`: Driver Kernel, provider registry, host ports, commands, events, diagnostics, the in-memory CMA store, and CMA projection exports.
-- `agent-driver/boot`: process boot payload, protocol version, boot environment names, and host snapshot contracts.
-- `agent-driver/runtime`: runtime-neutral runtime, transport, and native resume contracts.
-- `agent-driver/paths`: sandbox path constants and path normalization helpers shared by host integrations.
-- `agent-driver/events`: canonical driver event envelope contracts.
-- `agent-driver/contract`: vendor-neutral Authority, Preview, control, synchronization, and JSON-RPC contracts.
-- `agent-driver/orpc`: Driver-to-`DriverInstance` ORPC wire input/output contracts.
-- `agent-driver/cma-http`: experimental, unsupported CMA-shaped HTTP handler.
-- `agent-driver/cma-sdk`: experimental, unsupported CMA-shaped client.
+- Package root `@mosoo/agent-driver`: Driver Kernel, provider registry, host ports, commands, events, diagnostics, the in-memory CMA store, and CMA projection exports.
+- `@mosoo/agent-driver/boot`: process boot payload, protocol version, boot environment names, and host snapshot contracts.
+- `@mosoo/agent-driver/runtime`: runtime-neutral runtime, transport, and native resume contracts.
+- `@mosoo/agent-driver/paths`: sandbox path constants and path normalization helpers shared by host integrations.
+- `@mosoo/agent-driver/events`: canonical driver event envelope contracts.
+- `@mosoo/agent-driver/contract`: vendor-neutral Authority, Preview, control, synchronization, and JSON-RPC contracts.
+- `@mosoo/agent-driver/orpc`: Driver-to-`DriverInstance` ORPC wire input/output contracts.
+- `@mosoo/agent-driver/cma-http`: experimental, unsupported CMA-shaped HTTP handler.
+- `@mosoo/agent-driver/cma-sdk`: experimental, unsupported CMA-shaped client.
 
 ## Runtime Contract
 
@@ -90,23 +85,22 @@ Contract-owned IDs use ULIDs, and internal absolute timestamps use timezone-qual
 
 ## Quick Start
 
-`agent-driver` targets [Bun](https://bun.sh), with [Vite+](https://viteplus.dev) as the development toolchain and command entry point.
+`@mosoo/agent-driver` targets [Bun](https://bun.sh), with [Vite+](https://viteplus.dev) as the development toolchain and command entry point.
 Vite+ provisions the Bun version declared by `packageManager`; Bun remains the runtime, package manager, test runner, and binary bundler underneath it.
-The package is not currently available from npm, so work from this repository checkout, install dependencies, and run the test suite:
+Install the package in a Bun project:
 
 ```sh
-vp install --frozen-lockfile
-vp run test
+bun add @mosoo/agent-driver
 ```
 
-The smallest library example wires the experimental CMA-shaped HTTP handler to the in-memory store and talks to it with the bundled client — no network socket required. Drop the following into `tests/quickstart.test.ts` and run `vp run test tests/quickstart.test.ts`:
+The smallest library example wires the experimental CMA-shaped HTTP handler to the in-memory store and talks to it with the bundled client — no network socket required. Drop the following into `quickstart.test.ts` and run `bun test quickstart.test.ts`:
 
 ```ts
 import { expect, test } from "bun:test";
 
-import { createCmaMemoryStore } from "agent-driver";
-import { createCmaHttpHandler } from "agent-driver/cma-http";
-import { createCmaSdkClient } from "agent-driver/cma-sdk";
+import { createCmaMemoryStore } from "@mosoo/agent-driver";
+import { createCmaHttpHandler } from "@mosoo/agent-driver/cma-http";
+import { createCmaSdkClient } from "@mosoo/agent-driver/cma-sdk";
 
 test("create an agent, environment, and session over the CMA surface", async () => {
   // 1. An in-memory store stands in for the host's persistence port.
@@ -144,9 +138,9 @@ This exercises the implemented `/v1/environments`, `/v1/agents`, and `/v1/sessio
 
 ### How it is used in mosoo
 
-`agent-driver` is the **runtime kernel of the mosoo agent runtime**. When mosoo starts an agent session, it writes the private boot payload, boots this driver inside a sandbox, and waits on the matching `DriverInstance` Durable Object. The Driver dials outward, selects a provider backend from the registry, drives the session, and sends its runtime-neutral Driver protocol over ORPC. The host supplies credentials, files, skills, MCP, policy, and persistence through host ports.
+`@mosoo/agent-driver` is the **runtime kernel of the mosoo agent runtime**. When mosoo starts an agent session, it writes the private boot payload, boots this driver inside a sandbox, and waits on the matching `DriverInstance` Durable Object. The Driver dials outward, selects a provider backend from the registry, drives the session, and sends its runtime-neutral Driver protocol over ORPC. The host supplies credentials, files, skills, MCP, policy, and persistence through host ports.
 
-[mosoo](https://github.com/langgenius/mosoo) and this Driver repository are already public. mosoo exposes its production client contract through the [Public Thread API](https://github.com/langgenius/mosoo/blob/main/docs/prd/public-thread-api-surface.md) under `/api/v1`, not through the experimental CMA-shaped adapter. The `agent-driver` npm package has not been published yet.
+[mosoo](https://github.com/langgenius/mosoo) and this Driver repository are public. mosoo exposes its production client contract through the [Public Thread API](https://github.com/langgenius/mosoo/blob/main/docs/prd/public-thread-api-surface.md) under `/api/v1`, not through the experimental CMA-shaped adapter. The reusable Driver library and CLI are distributed as `@mosoo/agent-driver` on npmjs.
 
 ## Commands
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "agent-driver",
+      "name": "@mosoo/agent-driver",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.2.1",
         "@anthropic-ai/claude-agent-sdk": "0.3.211",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,24 @@
 {
-  "name": "agent-driver",
+  "name": "@mosoo/agent-driver",
   "version": "0.1.0",
   "private": false,
   "description": "Runtime-neutral Agent Driver and AI agent harness for Claude Agent SDK, Codex app-server, and ACP inside isolated sandboxes.",
+  "homepage": "https://github.com/langgenius/mosoo-agent-driver",
+  "bugs": {
+    "url": "https://github.com/langgenius/mosoo-agent-driver/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/langgenius/mosoo-agent-driver.git"
+  },
   "bin": {
     "agent-driver": "./dist/driver.mjs"
   },
   "files": [
     "dist",
     "src",
-    "Containerfile",
-    ".containerignore",
-    "README.md"
+    "assets"
   ],
   "type": "module",
   "types": "./dist/types/index.d.ts",
@@ -20,10 +26,6 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "default": "./src/index.ts"
-    },
-    "./bin/driver": {
-      "types": "./dist/types/bin/driver.d.ts",
-      "default": "./src/bin/driver.ts"
     },
     "./boot": {
       "types": "./dist/types/boot.d.ts",
@@ -62,6 +64,10 @@
       "default": "./src/cma-sdk.ts"
     }
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "bench": "bun bench/ttft-bench.ts",
     "build": "vp run build:types && bun build src/bin/driver.ts --outfile dist/driver.mjs --target bun --format esm --bundle",
@@ -69,6 +75,7 @@
     "check": "vp run tc && vp run test && vp run build",
     "image:build": "vp run build && buildah build -t agent-driver:local .",
     "lint": "vp lint src tests",
+    "prepack": "vp run build",
     "tc": "vp exec tsc --noEmit",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
@@ -92,6 +99,9 @@
     "@types/node": "^25.8.0",
     "typescript": "^6.0.3",
     "vite-plus": "0.2.5"
+  },
+  "engines": {
+    "bun": ">=1.3.14"
   },
   "packageManager": "bun@1.3.14"
 }

--- a/src/bin/driver-process.ts
+++ b/src/bin/driver-process.ts
@@ -24,6 +24,7 @@ import {
 } from "../runtimes/provider-registry";
 import { materializeResolvedSkills } from "../runtimes/skill-materialization";
 import { promiseWithTimeout } from "../utils/async";
+import { AGENT_DRIVER_VERSION } from "../core/version";
 import { DriverCommandDispatcher } from "../core/driver-command-dispatcher";
 import { pushDriverDiagnosticEvent } from "../core/driver-diagnostics";
 import { DriverHeartbeatLoop } from "../core/driver-heartbeat-loop";
@@ -34,7 +35,6 @@ import type { DriverRuntimeEventPort, DriverRuntimeRunPort } from "../core/drive
 import { DriverRuntimeStateMachine } from "../core/driver-runtime-state";
 import { createTimingEvent, createTimingPhase, toDurationMs } from "../core/driver-runtime-timing";
 
-const DRIVER_VERSION = "0.1.0";
 const DRIVER_BACKEND_START_TIMEOUT_MS = 60_000;
 const DRIVER_SHUTDOWN_TIMEOUT_MS = 5_000;
 
@@ -113,7 +113,7 @@ export class DriverProcess {
 
         logger.debug("driver.runtime.hello.sending", {
           capabilities: [...capabilities],
-          driverVersion: DRIVER_VERSION,
+          driverVersion: AGENT_DRIVER_VERSION,
           protocolVersion: DRIVER_PROTOCOL_VERSION,
           startedAt: this.#startedAt,
         });
@@ -122,7 +122,7 @@ export class DriverProcess {
         const hello = await logger.span("runtime.socket.hello", async () =>
           socket.hello({
             capabilities: [...capabilities],
-            driverVersion: DRIVER_VERSION,
+            driverVersion: AGENT_DRIVER_VERSION,
             protocolVersion: DRIVER_PROTOCOL_VERSION,
             startedAt: this.#startedAt,
           }),

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,3 @@
+import packageMetadata from "../../package.json" with { type: "json" };
+
+export const AGENT_DRIVER_VERSION = packageMetadata.version;

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -20,6 +20,7 @@ import type { DriverRuntime } from "../../protocol/runtime";
 import type { DriverStartInput } from "../../protocol/start";
 import type { RuntimeCommandInput } from "../../runtime-command";
 import { raceWithAbort, settlePromiseWithTimeout } from "../../utils/async";
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 import type { AgentDriverBackend, AgentDriverContext } from "../../core/agent-driver-backend";
 import { DriverEventPublisher } from "../driver-event-publisher";
 import {
@@ -202,7 +203,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
               clientInfo: {
                 name: "mosoo-driver",
                 title: "mosoo Driver",
-                version: "0.1.0",
+                version: AGENT_DRIVER_VERSION,
               },
               protocolVersion: ACP_PROTOCOL_VERSION,
             },

--- a/src/runtimes/claude/agent-sdk-query-options.ts
+++ b/src/runtimes/claude/agent-sdk-query-options.ts
@@ -11,6 +11,7 @@ import type { DriverBootMcpServer } from "../../protocol/boot";
 import type { DriverBuiltInToolName } from "../../protocol/boot";
 import type { JsonObject } from "../../protocol/json";
 import type { DriverStartInput } from "../../protocol/start";
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 import type { AgentDriverContext } from "../../core/agent-driver-backend";
 import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import { toMcpServerKey } from "../mcp/server-key";
@@ -122,7 +123,7 @@ function toClaudeEnv(payload: DriverStartInput, claudeConfigDir: string): NodeJS
   return {
     ...process.env,
     ...payload.execution.environment.variables,
-    CLAUDE_AGENT_SDK_CLIENT_APP: "mosoo-driver/0.1.0",
+    CLAUDE_AGENT_SDK_CLIENT_APP: `mosoo-driver/${AGENT_DRIVER_VERSION}`,
     CLAUDE_CONFIG_DIR: claudeConfigDir,
   };
 }

--- a/src/runtimes/mcp/remote-http-mcp-executor.ts
+++ b/src/runtimes/mcp/remote-http-mcp-executor.ts
@@ -11,6 +11,7 @@ import type { AuthProvider, CallToolResult } from "@modelcontextprotocol/client"
 import type { DriverStartInput } from "../../protocol/start";
 import type { McpExecuteCommand } from "../../runtime-command";
 import { settlePromiseWithTimeout } from "../../utils/async";
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 
 type SessionMcpServer = DriverStartInput["execution"]["session"]["mcpServers"][number];
 type ActiveMcpServer = Extract<SessionMcpServer, { authorizationState: "active" }>;
@@ -191,7 +192,7 @@ export async function executeRemoteHttpMcpCommand(
   };
   const client = new Client({
     name: "mosoo-driver",
-    version: "0.1.0",
+    version: AGENT_DRIVER_VERSION,
   });
   const transport = new StreamableHTTPClientTransport(new URL(server.proxyUrl), {
     authProvider,

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -10,6 +10,7 @@ import type { TransformCallback } from "node:stream";
 import { toDurationMs } from "../../core/driver-runtime-timing";
 import type { DriverStartInput } from "../../protocol/start";
 import { raceWithAbort, settlePromiseWithTimeout } from "../../utils/async";
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 import type { AgentDriverContext } from "../../core/agent-driver-backend";
 import { buildRuntimeChildProcessEnv } from "../child-process-env";
 import { killProcessGroup } from "../child-process";
@@ -336,7 +337,7 @@ export class OpenAiAppServerClient {
           clientInfo: {
             name: "mosoo_driver",
             title: "mosoo Driver",
-            version: "0.1.0",
+            version: AGENT_DRIVER_VERSION,
           },
         },
         signal,

--- a/tests/driver-artifact-contract.test.ts
+++ b/tests/driver-artifact-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 import { OPENAI_APP_SERVER_SCHEMA_VERSION } from "../src/runtimes/openai/generated/app-server-protocol-types";
+import { AGENT_DRIVER_VERSION } from "../src/core/version";
 
 type DriverPackageExportTarget =
   | string
@@ -12,15 +13,20 @@ type DriverPackageExportTarget =
 
 interface DriverPackageJson {
   readonly bin?: Record<string, string>;
+  readonly bugs?: { readonly url?: string };
   readonly dependencies?: Record<string, string>;
   readonly devDependencies?: Record<string, string>;
   readonly description?: string;
+  readonly engines?: Record<string, string>;
   readonly exports?: Record<string, DriverPackageExportTarget>;
   readonly files?: readonly string[];
+  readonly homepage?: string;
   readonly license?: string;
   readonly name?: string;
   readonly packageManager?: string;
   readonly private?: boolean;
+  readonly publishConfig?: Record<string, string>;
+  readonly repository?: { readonly type?: string; readonly url?: string };
   readonly scripts?: Record<string, string>;
   readonly types?: string;
   readonly type?: string;
@@ -29,7 +35,6 @@ interface DriverPackageJson {
 
 const PUBLIC_EXPORTS = [
   ".",
-  "./bin/driver",
   "./boot",
   "./cma-http",
   "./cma-sdk",
@@ -50,22 +55,31 @@ function readDriverPackageJson(): DriverPackageJson {
 }
 
 describe("driver artifact contract", () => {
-  test("uses the independent agent-driver package identity", () => {
+  test("uses the public mosoo package identity", () => {
     const packageJson = readDriverPackageJson();
 
-    expect(packageJson.name).toBe("agent-driver");
+    expect(packageJson.name).toBe("@mosoo/agent-driver");
     expect(packageJson.private).toBe(false);
-    expect(packageJson.version).toBe("0.1.0");
+    expect(packageJson.version).toBe(AGENT_DRIVER_VERSION);
     expect(packageJson.description).toContain("Agent Driver");
     expect(packageJson.license).toBe("Apache-2.0");
     expect(packageJson.packageManager).toBe("bun@1.3.14");
+    expect(packageJson.engines).toEqual({ bun: ">=1.3.14" });
+    expect(packageJson.repository).toEqual({
+      type: "git",
+      url: "git+https://github.com/langgenius/mosoo-agent-driver.git",
+    });
+    expect(packageJson.bugs?.url).toBe("https://github.com/langgenius/mosoo-agent-driver/issues");
+    expect(packageJson.homepage).toBe("https://github.com/langgenius/mosoo-agent-driver");
+    expect(packageJson.publishConfig).toEqual({
+      access: "public",
+      registry: "https://registry.npmjs.org/",
+    });
     expect(packageJson.bin).toEqual({
       "agent-driver": "./dist/driver.mjs",
     });
     expect(packageJson.types).toBe("./dist/types/index.d.ts");
-    expect(packageJson.files).toEqual(
-      expect.arrayContaining(["dist", "src", "Containerfile", ".containerignore", "README.md"]),
-    );
+    expect(packageJson.files).toEqual(["dist", "src", "assets"]);
     expect(packageJson.files).not.toContain("tests/fixtures");
   });
 
@@ -80,10 +94,24 @@ describe("driver artifact contract", () => {
       default: "./src/index.ts",
       types: "./dist/types/index.d.ts",
     });
-    expect(packageJson.exports?.["./bin/driver"]).toEqual({
-      default: "./src/bin/driver.ts",
-      types: "./dist/types/bin/driver.d.ts",
-    });
+    expect(packageJson.exports).not.toHaveProperty("./bin/driver");
+  });
+
+  test("uses package.json as the runtime version source", () => {
+    const packageJson = readDriverPackageJson();
+    const runtimeVersionSources = [
+      "../src/bin/driver-process.ts",
+      "../src/runtimes/acp/acp-driver-backend.ts",
+      "../src/runtimes/claude/agent-sdk-query-options.ts",
+      "../src/runtimes/mcp/remote-http-mcp-executor.ts",
+      "../src/runtimes/openai/app-server-client.ts",
+    ];
+
+    expect(readText("../src/core/version.ts")).toContain('from "../../package.json"');
+    for (const source of runtimeVersionSources) {
+      expect(readText(source)).toContain("AGENT_DRIVER_VERSION");
+      expect(readText(source)).not.toContain(`"${packageJson.version}"`);
+    }
   });
 
   test("keeps the root library entry free of boot and transport internals", () => {
@@ -92,7 +120,7 @@ describe("driver artifact contract", () => {
     expect(publicApi).toContain("./core/agent-driver-kernel");
     expect(publicApi).toContain("./runtimes/provider-registry");
     expect(publicApi).toContain("./protocol/runtime");
-    expect(publicApi).not.toContain("./core/driver-process");
+    expect(publicApi).not.toContain("./bin/driver-process");
     expect(publicApi).not.toContain("./protocol/boot");
     expect(publicApi).not.toContain("./protocol/orpc");
     expect(publicApi).not.toContain("./protocol/paths");
@@ -119,6 +147,7 @@ describe("driver artifact contract", () => {
     expect(containerfile).toContain("ENV MOSOO_ACP_FALLBACK_COMMAND=opencode");
     expect(containerignore).toContain("!dist/driver.mjs");
     expect(imageBuildScript).toBe("vp run build && buildah build -t agent-driver:local .");
+    expect(packageJson.scripts?.["prepack"]).toBe("vp run build");
   });
 
   test("pins the OpenAI runtime, SDK, and app-server schema to one stable version", () => {

--- a/tests/public-api-consumer.ts
+++ b/tests/public-api-consumer.ts
@@ -3,11 +3,11 @@ import type {
   AgentDriverKernel,
   CmaStore,
   DriverStartInput,
-} from "agent-driver";
-import type { SessionSnapshot } from "agent-driver/contract";
-import type { CmaHttpHandler } from "agent-driver/cma-http";
-import type { CmaSdkClient } from "agent-driver/cma-sdk";
-import type { DriverEventInput } from "agent-driver/events";
+} from "@mosoo/agent-driver";
+import type { SessionSnapshot } from "@mosoo/agent-driver/contract";
+import type { CmaHttpHandler } from "@mosoo/agent-driver/cma-http";
+import type { CmaSdkClient } from "@mosoo/agent-driver/cma-sdk";
+import type { DriverEventInput } from "@mosoo/agent-driver/events";
 
 export interface PublicApiConsumer {
   readonly backend: AgentDriverBackend;

--- a/tests/public-api-exports.snapshot.json
+++ b/tests/public-api-exports.snapshot.json
@@ -147,10 +147,6 @@
       "pushDriverDiagnosticEvent"
     ]
   },
-  "./bin/driver": {
-    "types": [],
-    "values": []
-  },
   "./boot": {
     "types": [
       "AccountId",


### PR DESCRIPTION
## Summary

- configure @mosoo/agent-driver as a public scoped npm package
- use package.json as the single runtime version source
- update package documentation, consumer imports, and artifact contract snapshots

## Why

The repository package metadata and runtime client versions still used the pre-publication agent-driver identity and duplicated version literals. This prepares one coherent npm package contract without adding release automation in the same change.

## Impact

Consumers will install and import @mosoo/agent-driver. The internal process runner remains available through the agent-driver CLI and is no longer exposed as a library subpath.

## Validation

- vp fmt on changed files
- vp run lint
- vp run tc
- vp run test: 1073 passed, 20 skipped
- vp run build

## Out of scope

- GitHub Actions release workflow
- release runbook

Closes #71