### PR TITLE
fix(claude): keep a streamed reply on one message when message_start is lost

### DIFF
--- a/src/runtimes/claude/agent-sdk-message-state.ts
+++ b/src/runtimes/claude/agent-sdk-message-state.ts
@@ -9,6 +9,23 @@ interface ClaudeAssistantFinalCandidate {
   readonly ordinal: number;
 }
 
+interface ClaudeStreamMessageAnchor {
+  /**
+   * True when the anchor came from a message_start frame carrying the native
+   * message id. An unconfirmed anchor was inferred from the first streamed
+   * content frame after message_start was lost, so its native key is a
+   * synthetic burst key derived from that frame's envelope uuid.
+   */
+  readonly confirmed: boolean;
+  readonly nativeId: string;
+}
+
+// Envelope uuids are per-frame, so a burst key must never collide with a
+// native id a later assistant envelope could present on its own.
+function toStreamBurstNativeId(nativeMessageId: string): string {
+  return `stream-burst:${nativeMessageId}`;
+}
+
 function toClaudeThoughtId(messageId: string): string {
   return `${messageId}:thought`;
 }
@@ -27,14 +44,17 @@ export class ClaudeAgentSdkMessageState {
   readonly #assistantMessageRunIds = new Map<MessageId, RunId>();
   readonly #assistantMessageSequences = new Map<RunId, number>();
   readonly #blockToolCallIds = new Map<string, Map<number, string>>();
+  readonly #assistantNativeAliases = new Map<string, string>();
   readonly #lastCompletedAssistantMessages = new Map<RunId, ClaudeAssistantFinalCandidate>();
+  readonly #pendingAssistantStreamAnchors = new Map<string, ClaudeStreamMessageAnchor>();
   readonly #streamedTextMessages = new Set<string>();
-  readonly #streamingNativeMessageIds = new Map<string, string>();
+  readonly #streamingNativeMessageIds = new Map<string, ClaudeStreamMessageAnchor>();
   readonly #textByAssistantMessageId = new Map<MessageId, string>();
 
   reset(): void {
     this.#activeAssistantMessageIds.clear();
     this.#activeThoughtIds.clear();
+    this.#assistantNativeAliases.clear();
     this.#authoritativeAssistantMessageIds.clear();
     this.#assistantMessageIds.reset();
     this.#assistantMessageOrdinals.clear();
@@ -42,6 +62,7 @@ export class ClaudeAgentSdkMessageState {
     this.#assistantMessageSequences.clear();
     this.#blockToolCallIds.clear();
     this.#lastCompletedAssistantMessages.clear();
+    this.#pendingAssistantStreamAnchors.clear();
     this.#streamedTextMessages.clear();
     this.#streamingNativeMessageIds.clear();
     this.#textByAssistantMessageId.clear();
@@ -138,15 +159,98 @@ export class ClaudeAgentSdkMessageState {
   }
 
   setStreamingNativeMessageId(scope: string, nativeMessageId: string): void {
-    this.#streamingNativeMessageIds.set(scope, nativeMessageId);
+    this.#streamingNativeMessageIds.set(scope, { confirmed: true, nativeId: nativeMessageId });
+    this.#pendingAssistantStreamAnchors.delete(scope);
   }
 
   streamingNativeMessageId(scope: string): string | undefined {
-    return this.#streamingNativeMessageIds.get(scope);
+    return this.#streamingNativeMessageIds.get(scope)?.nativeId;
+  }
+
+  /**
+   * Resolves the native key for a streamed content frame. The Anthropic wire
+   * carries one message per scope between message boundaries, so the first
+   * content frame after a lost message_start pins the scope to a burst key
+   * instead of letting every frame's envelope uuid mint a new message.
+   */
+  anchorStreamingNativeMessageId(scope: string, nativeMessageId: string | null): string | null {
+    const anchor = this.#streamingNativeMessageIds.get(scope);
+
+    if (anchor !== undefined) {
+      return anchor.nativeId;
+    }
+
+    if (nativeMessageId === null) {
+      return null;
+    }
+
+    const burstNativeId = toStreamBurstNativeId(nativeMessageId);
+    this.#streamingNativeMessageIds.set(scope, { confirmed: false, nativeId: burstNativeId });
+    this.#pendingAssistantStreamAnchors.delete(scope);
+    return burstNativeId;
   }
 
   clearStreamingNativeMessageId(scope: string): void {
+    const anchor = this.#streamingNativeMessageIds.get(scope);
     this.#streamingNativeMessageIds.delete(scope);
+
+    // The aggregated assistant envelope for this burst arrives after
+    // message_stop; park the anchor so that envelope can bind to the streamed
+    // message instead of minting a duplicate.
+    if (anchor !== undefined) {
+      this.#pendingAssistantStreamAnchors.set(scope, anchor);
+    }
+  }
+
+  /**
+   * Resolves the native key an aggregated assistant envelope should use. An
+   * unconfirmed streamed burst in the same scope is that envelope's own
+   * stream (per-scope bursts are serial), so bind to it and consume the
+   * anchor — one envelope aggregates one burst. A confirmed anchor proves
+   * the stream's identity and the envelope's native id wins.
+   */
+  resolveAssistantMessageNativeId(scope: string, nativeMessageId: string | null): string | null {
+    if (nativeMessageId !== null) {
+      const alias = this.#assistantNativeAliases.get(nativeMessageId);
+
+      if (alias !== undefined) {
+        return alias;
+      }
+    }
+
+    const pending = this.#pendingAssistantStreamAnchors.get(scope);
+
+    if (pending !== undefined) {
+      this.#pendingAssistantStreamAnchors.delete(scope);
+      return pending.confirmed
+        ? (nativeMessageId ?? pending.nativeId)
+        : this.#bindAssistantNativeAlias(pending.nativeId, nativeMessageId);
+    }
+
+    const live = this.#streamingNativeMessageIds.get(scope);
+
+    if (live === undefined) {
+      return nativeMessageId;
+    }
+
+    if (live.confirmed) {
+      // The envelope arrived before message_stop; keep the confirmed anchor
+      // so the remaining stream frames stay on the same message.
+      return nativeMessageId ?? live.nativeId;
+    }
+
+    this.#streamingNativeMessageIds.delete(scope);
+    return this.#bindAssistantNativeAlias(live.nativeId, nativeMessageId);
+  }
+
+  #bindAssistantNativeAlias(burstNativeId: string, nativeMessageId: string | null): string {
+    if (nativeMessageId !== null) {
+      // A replayed envelope re-presents the same native id after the anchor
+      // is consumed; remember the binding so it stays on the same message.
+      this.#assistantNativeAliases.set(nativeMessageId, burstNativeId);
+    }
+
+    return burstNativeId;
   }
 
   setToolCallId(messageId: string, index: number, toolCallId: string): void {

--- a/src/runtimes/claude/agent-sdk-message-translator.ts
+++ b/src/runtimes/claude/agent-sdk-message-translator.ts
@@ -122,7 +122,10 @@ export class ClaudeAgentSdkMessageTranslator {
   ): Promise<void> {
     const messageId = this.#state.assistantMessageId(
       runId,
-      this.#state.readNativeMessageId(message),
+      this.#state.resolveAssistantMessageNativeId(
+        this.#state.streamScopeKey(runId, message),
+        this.#state.readNativeMessageId(message),
+      ),
     );
     const content = Array.isArray(message.message.content) ? message.message.content : [];
     const authoritativeText: string[] = [];
@@ -205,10 +208,20 @@ export class ClaudeAgentSdkMessageTranslator {
       return;
     }
 
+    // Content frames pin the scope to one message even when message_start was
+    // lost; boundary frames only read the anchor so a bare message_stop does
+    // not mint a message from its own envelope uuid.
+    const isContentFrame =
+      eventType === "content_block_start" || eventType === "content_block_delta";
     const messageId = this.#state.assistantMessageId(
       runId,
-      this.#state.streamingNativeMessageId(streamScopeKey) ??
-        this.#state.readNativeMessageId(message),
+      isContentFrame
+        ? this.#state.anchorStreamingNativeMessageId(
+            streamScopeKey,
+            this.#state.readNativeMessageId(message),
+          )
+        : (this.#state.streamingNativeMessageId(streamScopeKey) ??
+            this.#state.readNativeMessageId(message)),
     );
 
     if (eventType === "content_block_start") {

--- a/tests/claude-agent-sdk-provider-fixtures-terminal.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures-terminal.test.ts
@@ -551,55 +551,64 @@ describe("Claude Agent SDK provider fixtures", () => {
     expect(payload).not.toHaveProperty("finalMessageText");
   });
 
-  test("isolates interleaved tool and thought streams by message UUID", async () => {
+  test("isolates parallel tool blocks by index and thought streams by message boundary", async () => {
+    // Envelope uuids are per-frame on the real wire, so identity within a
+    // scope comes from the burst anchor: parallel tool blocks of one message
+    // are told apart by content-block index, and a message_stop boundary
+    // separates one message's thought stream from the next.
     const { context, events, logger, translator } = createHarness();
     const stream = (uuid: string, event: Record<string, unknown>) =>
       ({ event, type: "stream_event", uuid }) as unknown as SDKMessage;
     const messages = [
-      stream("tool-message-a", {
+      stream("frame-1", {
         content_block: { id: "tool-a", name: "Bash", type: "tool_use" },
         index: 0,
         type: "content_block_start",
       }),
-      stream("tool-message-b", {
+      stream("frame-2", {
         content_block: { id: "tool-b", name: "Bash", type: "tool_use" },
-        index: 0,
+        index: 1,
         type: "content_block_start",
       }),
-      stream("tool-message-a", {
+      stream("frame-3", {
         delta: { partial_json: '{"a":', type: "input_json_delta" },
         index: 0,
         type: "content_block_delta",
       }),
-      stream("tool-message-b", { type: "message_stop" }),
-      stream("tool-message-a", {
+      stream("frame-4", {
+        delta: { partial_json: '{"b":1}', type: "input_json_delta" },
+        index: 1,
+        type: "content_block_delta",
+      }),
+      stream("frame-5", {
         delta: { partial_json: "1}", type: "input_json_delta" },
         index: 0,
         type: "content_block_delta",
       }),
-      stream("thought-message-a", {
+      stream("frame-6", { type: "message_stop" }),
+      stream("frame-7", {
         content_block: { thinking: "", type: "thinking" },
         index: 0,
         type: "content_block_start",
       }),
-      stream("thought-message-b", {
-        content_block: { thinking: "", type: "thinking" },
-        index: 0,
-        type: "content_block_start",
-      }),
-      stream("thought-message-a", {
+      stream("frame-8", {
         delta: { thinking: "A1", type: "thinking_delta" },
         index: 0,
         type: "content_block_delta",
       }),
-      stream("thought-message-b", {
-        delta: { thinking: "B1", type: "thinking_delta" },
+      stream("frame-9", {
+        delta: { thinking: "A2", type: "thinking_delta" },
         index: 0,
         type: "content_block_delta",
       }),
-      stream("thought-message-b", { type: "message_stop" }),
-      stream("thought-message-a", {
-        delta: { thinking: "A2", type: "thinking_delta" },
+      stream("frame-10", { type: "message_stop" }),
+      stream("frame-11", {
+        content_block: { thinking: "", type: "thinking" },
+        index: 0,
+        type: "content_block_start",
+      }),
+      stream("frame-12", {
+        delta: { thinking: "B1", type: "thinking_delta" },
         index: 0,
         type: "content_block_delta",
       }),
@@ -638,6 +647,7 @@ describe("Claude Agent SDK provider fixtures", () => {
 
     expect(toolArguments).toEqual([
       { rawInput: '{"a":', toolCallId: "tool-a" },
+      { rawInput: '{"b":1}', toolCallId: "tool-b" },
       { rawInput: "1}", toolCallId: "tool-a" },
     ]);
     expect(thoughts["A1"]).toBe(thoughts["A2"]);

--- a/tests/claude-agent-sdk-provider-fixtures-transcript.test.ts
+++ b/tests/claude-agent-sdk-provider-fixtures-transcript.test.ts
@@ -348,7 +348,105 @@ describe("Claude Agent SDK provider fixtures", () => {
     },
   );
 
-  test("closes every interleaved assistant message before the Run terminal", async () => {
+  test("keeps a start-less streamed reply on one message through its assistant envelope", async () => {
+    // YEF-884 wire shape: message_start was lost, every frame carries its own
+    // envelope uuid, and the aggregated assistant envelope (with the native
+    // message id) arrives before message_stop. The reply must stay one
+    // message instead of rendering as "P" / "ong. …" / full-text duplicates.
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          delta: { text: "P", type: "text_delta" },
+          index: 0,
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "frame-delta-1",
+      },
+      {
+        event: {
+          delta: { text: "ong. What would you like to work on?", type: "text_delta" },
+          index: 0,
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "frame-delta-2",
+      },
+      {
+        message: {
+          content: [{ text: "Pong. What would you like to work on?", type: "text" }],
+          id: "msg-pong",
+        },
+        type: "assistant",
+        uuid: "envelope-1",
+      },
+      {
+        event: { index: 0, type: "content_block_stop" },
+        type: "stream_event",
+        uuid: "frame-stop-1",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "frame-stop-2",
+      },
+      {
+        result: "Pong. What would you like to work on?",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const translated = events();
+    const textMessages = translated.flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+      return typeof contentDelta === "string" && typeof messageId === "string"
+        ? [{ contentDelta, messageId }]
+        : [];
+    });
+    const started = translated
+      .filter((event) => event.kind === "message.started" && isRecord(event.payload))
+      .map((event) => (event.payload as Record<string, unknown>)["messageId"]);
+    const snapshot = translated.find(
+      (event) => event.kind === "message.added" && isRecord(event.payload),
+    );
+    const snapshotPayload =
+      snapshot === undefined || !isRecord(snapshot.payload) ? null : snapshot.payload;
+    const runCompleted = translated.find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(textMessages.map((entry) => entry.contentDelta)).toEqual([
+      "P",
+      "ong. What would you like to work on?",
+    ]);
+    expect(new Set(textMessages.map((entry) => entry.messageId)).size).toBe(1);
+    expect(started).toHaveLength(1);
+    expect(snapshotPayload?.["messageId"]).toBe(textMessages[0]?.messageId);
+    expect(snapshotPayload?.["content"]).toEqual([
+      { text: "Pong. What would you like to work on?", type: "text" },
+    ]);
+    expect(payload?.["finalMessageId"]).toBe(textMessages[0]?.messageId);
+    expect(payload?.["finalMessageText"]).toBe("Pong. What would you like to work on?");
+  });
+
+  test("anchors uuid-fractured stream fragments to one closed assistant message", async () => {
+    // One scope streams one message at a time; per-envelope uuids must not
+    // fracture a burst whose message_start frame was lost (YEF-884).
     const { context, events, logger, translator } = createHarness();
     const messages = [
       {
@@ -393,12 +491,20 @@ describe("Claude Agent SDK provider fixtures", () => {
       .slice(0, terminalIndex)
       .filter((event) => event.kind === "message.completed" && isRecord(event.payload))
       .map((event) => (event.payload as Record<string, unknown>)["messageId"]);
+    const deltaMessageIds = translated
+      .filter((event) => event.kind === "message.delta" && isRecord(event.payload))
+      .map((event) => (event.payload as Record<string, unknown>)["messageId"]);
 
-    expect(started).toHaveLength(2);
+    expect(started).toHaveLength(1);
     expect(completed).toEqual(started);
+    expect(new Set(deltaMessageIds)).toEqual(new Set(started));
   });
 
-  test("keeps duplicate text scoped to its native assistant message", async () => {
+  test("binds the aggregated assistant envelope to an unconfirmed streamed burst", async () => {
+    // Without a message_start frame the streamed burst is anchored to an
+    // envelope uuid; the aggregated assistant envelope that follows in the
+    // same scope is that burst's own aggregation and must not mint a
+    // duplicate message (YEF-884).
     const { context, events, logger, translator } = createHarness();
     const messages = [
       {
@@ -420,6 +526,82 @@ describe("Claude Agent SDK provider fixtures", () => {
         },
         type: "assistant",
         uuid: "assistant-final-b",
+      },
+      {
+        result: "相同文本",
+        subtype: "success",
+        total_cost_usd: 0,
+        type: "result",
+        usage: {},
+        uuid: "result-1",
+      },
+    ] as unknown as SDKMessage[];
+
+    for (const message of messages) {
+      await translator.handleSdkMessage(context, message, "run-1" as RunId);
+    }
+    await logger.destroy();
+
+    const textMessages = events().flatMap((event) => {
+      if (event.kind !== "message.delta" || !isRecord(event.payload)) {
+        return [];
+      }
+
+      const contentDelta = event.payload["contentDelta"];
+      const messageId = event.payload["messageId"];
+      return typeof contentDelta === "string" && typeof messageId === "string"
+        ? [{ contentDelta, messageId }]
+        : [];
+    });
+    const snapshot = events().find(
+      (event) => event.kind === "message.added" && isRecord(event.payload),
+    );
+    const snapshotPayload =
+      snapshot === undefined || !isRecord(snapshot.payload) ? null : snapshot.payload;
+    const runCompleted = events().find((event) => event.kind === "run.completed");
+    const payload =
+      runCompleted === undefined || !isRecord(runCompleted.payload) ? null : runCompleted.payload;
+
+    expect(textMessages.map((entry) => entry.contentDelta)).toEqual(["相同文本"]);
+    expect(snapshotPayload?.["messageId"]).toBe(textMessages[0]?.messageId);
+    expect(payload?.["finalMessageId"]).toBe(textMessages[0]?.messageId);
+    expect(payload?.["finalMessageText"]).toBe("相同文本");
+  });
+
+  test("keeps duplicate text on distinct messages when the stream identity is confirmed", async () => {
+    // A message_start frame proves the streamed message's native id, so an
+    // assistant envelope with a different native id is a genuinely separate
+    // message even when the text repeats.
+    const { context, events, logger, translator } = createHarness();
+    const messages = [
+      {
+        event: {
+          message: { id: "msg-progress" },
+          type: "message_start",
+        },
+        type: "stream_event",
+        uuid: "stream-1",
+      },
+      {
+        event: {
+          delta: { text: "相同文本", type: "text_delta" },
+          type: "content_block_delta",
+        },
+        type: "stream_event",
+        uuid: "stream-2",
+      },
+      {
+        event: { type: "message_stop" },
+        type: "stream_event",
+        uuid: "stream-3",
+      },
+      {
+        message: {
+          content: [{ text: "相同文本", type: "text" }],
+          id: "msg-final",
+        },
+        type: "assistant",
+        uuid: "assistant-final",
       },
       {
         result: "相同文本",


### PR DESCRIPTION
## Summary

- Anchor a stream scope to a synthetic burst key on the first content-bearing frame, so every frame of a streamed burst resolves to the same assistant message even when the `message_start` frame was lost. Previously each `content_block_delta` fell back to its own envelope uuid and minted a separate message.
- Let the aggregated `assistant` envelope consume an unconfirmed burst anchor (live or parked at `message_stop`) so it binds to the streamed message instead of re-emitting the full text as a new message; replayed envelopes stay bound via a native-id alias. Confirmed anchors from `message_start` keep today's semantics: an envelope with a different native id remains a distinct message, so final-message binding is unchanged.

## Why

- YEF-884: a "ping" reply rendered as three assistant messages — `'P'`, `'ong. What would you like to work on?'`, and the duplicated full text — in both the session event log and the live view. Captured the real wire with Claude Code CLI 2.1.170 (`--output-format stream-json --include-partial-messages`): every envelope carries a fresh uuid (including each delta), and the aggregated assistant envelope arrives with the native message id before `message_stop`. Once `message_start` is missed (prewarm attach race), uuid-keyed identity fractures the reply exactly as reported. #52 keyed messages by the API message id when `message_start` is present; this closes the remaining fallback gap.
- The read-time repair for already-persisted rows lands separately in langgenius/mosoo (fold supersede); this change stops new fractured events at the source.

## Verification

- `bun test` (1074 pass; the one failing ACP file-system test also fails on a clean checkout in this environment), `bun run tc`, `bun run lint`, `bun run fmt`.
- New regression test replays the captured YEF-884 wire shape (start-less per-uuid frames, envelope before `message_stop`) and asserts one message id across started/delta/snapshot/completed plus correct final-message binding.
- Updated the two degraded-stream tests that encoded uuid-as-identity: parallel tool blocks are isolated by content-block index within one burst, thought streams by message boundary — matching the real wire, where envelope uuids are per-frame and cannot identify a message.

## Risk

- Behavior changes only for degraded streams (missing `message_start`); healthy streams resolve identically to today. Roll back by reverting the single commit.
