### PR TITLE
fix(acp): report cache token buckets under the anthropic_bucketed usage contract

### DIFF
--- a/src/runtimes/acp/acp-lifecycle-events.ts
+++ b/src/runtimes/acp/acp-lifecycle-events.ts
@@ -11,7 +11,9 @@ import {
   toModelEvents,
 } from "./acp-session-update-events";
 
-const ACP_USAGE_CONTRACT = "openai_total_with_cached_breakdown";
+// OpenCode's ACP usage reports fresh input tokens with cache read/write as
+// separate buckets (Anthropic-style), not an input total that includes them.
+const ACP_USAGE_CONTRACT = "anthropic_bucketed";
 
 export function toInitializeEvents(result: InitializeResponse): DriverEventInput[] {
   const events: DriverEventInput[] = [
@@ -152,26 +154,38 @@ export function normalizePromptUsage(raw: unknown): JsonObject | null {
     return null;
   }
 
-  const rawTotal = readNumber(raw, "totalTokens") ?? readNumber(raw, "total_tokens");
-  const rawInput = readNumber(raw, "inputTokens") ?? readNumber(raw, "input_tokens");
-  const rawOutput = readNumber(raw, "outputTokens") ?? readNumber(raw, "output_tokens");
-  const totalTokens =
-    rawTotal !== null && Number.isSafeInteger(rawTotal) && rawTotal >= 0 ? rawTotal : null;
-  const inputTokens =
-    rawInput !== null && Number.isSafeInteger(rawInput) && rawInput >= 0 ? rawInput : null;
-  const outputTokens =
-    rawOutput !== null && Number.isSafeInteger(rawOutput) && rawOutput >= 0 ? rawOutput : null;
+  const totalTokens = readTokenCount(raw, "totalTokens", "total_tokens");
+  const inputTokens = readTokenCount(raw, "inputTokens", "input_tokens");
+  const outputTokens = readTokenCount(raw, "outputTokens", "output_tokens");
+  const cachedReadTokens = readTokenCount(raw, "cachedReadTokens", "cached_read_tokens");
+  const cachedWriteTokens = readTokenCount(raw, "cachedWriteTokens", "cached_write_tokens");
+  const thoughtTokens = readTokenCount(raw, "thoughtTokens", "thought_tokens");
 
-  if (totalTokens === null && inputTokens === null && outputTokens === null) {
+  if (
+    totalTokens === null &&
+    inputTokens === null &&
+    outputTokens === null &&
+    cachedReadTokens === null &&
+    cachedWriteTokens === null
+  ) {
     return null;
   }
 
   return {
+    ...(cachedReadTokens === null ? {} : { cachedReadTokens }),
+    ...(cachedWriteTokens === null ? {} : { cachedWriteTokens }),
     ...(inputTokens === null ? {} : { inputTokens }),
     ...(outputTokens === null ? {} : { outputTokens }),
     raw,
     source: "prompt_response",
+    ...(thoughtTokens === null ? {} : { thoughtTokens }),
     ...(totalTokens === null ? {} : { totalTokens }),
     usageContract: ACP_USAGE_CONTRACT,
   };
+}
+
+function readTokenCount(raw: JsonObject, key: string, snakeCaseKey: string): number | null {
+  const value = readNumber(raw, key) ?? readNumber(raw, snakeCaseKey);
+
+  return value !== null && Number.isSafeInteger(value) && value >= 0 ? value : null;
 }

--- a/src/runtimes/acp/acp-session-update-events.ts
+++ b/src/runtimes/acp/acp-session-update-events.ts
@@ -10,7 +10,8 @@ import {
 } from "./acp-types";
 import type { JsonObject } from "./acp-types";
 
-const ACP_USAGE_CONTRACT = "openai_total_with_cached_breakdown";
+// Keep in sync with acp-lifecycle-events.ts: ACP usage is Anthropic-bucketed.
+const ACP_USAGE_CONTRACT = "anthropic_bucketed";
 
 export function summarizeContentBlock(content: unknown): string | null {
   if (!isRecord(content)) {

--- a/tests/acp-event-translator-session-update.test.ts
+++ b/tests/acp-event-translator-session-update.test.ts
@@ -554,9 +554,12 @@ describe("ACP runtime event translation", () => {
       },
     });
     const completionUsage = state.completePrompt("end_turn", {
+      cachedReadTokens: 90,
+      cachedWriteTokens: 7,
       inputTokens: 10,
       outputTokens: 2,
-      totalTokens: 12,
+      thoughtTokens: 3,
+      totalTokens: 112,
     });
 
     expect(sessionUsage).toEqual([
@@ -567,7 +570,7 @@ describe("ACP runtime event translation", () => {
           costCurrency: "USD",
           size: 1_000,
           source: "session_update",
-          usageContract: "openai_total_with_cached_breakdown",
+          usageContract: "anthropic_bucketed",
           used: 12,
         },
       },
@@ -575,16 +578,22 @@ describe("ACP runtime event translation", () => {
     expect(completionUsage).toContainEqual({
       kind: "usage.updated",
       payload: {
+        cachedReadTokens: 90,
+        cachedWriteTokens: 7,
         inputTokens: 10,
         outputTokens: 2,
         raw: {
+          cachedReadTokens: 90,
+          cachedWriteTokens: 7,
           inputTokens: 10,
           outputTokens: 2,
-          totalTokens: 12,
+          thoughtTokens: 3,
+          totalTokens: 112,
         },
         source: "prompt_response",
-        totalTokens: 12,
-        usageContract: "openai_total_with_cached_breakdown",
+        thoughtTokens: 3,
+        totalTokens: 112,
+        usageContract: "anthropic_bucketed",
       },
       runId: RUN_ID,
     });

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -50,6 +50,10 @@
   "completePrompt": {
     "stopReason": "end_turn",
     "usage": {
+      "cachedReadTokens": 5,
+      "cachedWriteTokens": 1,
+      "inputTokens": 4,
+      "outputTokens": 2,
       "totalTokens": 12
     }
   },
@@ -136,12 +140,20 @@
     {
       "kind": "usage.updated",
       "payload": {
+        "cachedReadTokens": 5,
+        "cachedWriteTokens": 1,
+        "inputTokens": 4,
+        "outputTokens": 2,
         "raw": {
+          "cachedReadTokens": 5,
+          "cachedWriteTokens": 1,
+          "inputTokens": 4,
+          "outputTokens": 2,
           "totalTokens": 12
         },
         "source": "prompt_response",
         "totalTokens": 12,
-        "usageContract": "openai_total_with_cached_breakdown"
+        "usageContract": "anthropic_bucketed"
       },
       "runId": "run-1"
     },


### PR DESCRIPTION
Fill what changed. Use N/A for irrelevant or maintainer-only items.

## Summary

- Forward `cachedReadTokens`, `cachedWriteTokens`, and `thoughtTokens` from the ACP prompt-response usage payload in `normalizePromptUsage` (previously only input/output/total were kept, so cache buckets were silently dropped).
- Declare ACP usage as `anthropic_bucketed` instead of `openai_total_with_cached_breakdown`, matching OpenCode's actual token semantics (fresh input excludes cache read/write buckets).

## Why

- The mosoo Cost dashboard for OpenCode (`acp-fallback`) agents only showed avg tokens: **Cache Hit was always 0% and cache read/write spend was never billed**, because the driver dropped the cache buckets OpenCode reports over ACP (`opencode/src/acp/usage.ts` `buildUsage` sends `cachedReadTokens`/`cachedWriteTokens`/`thoughtTokens`).
- The contract label was also wrong: `openai_total_with_cached_breakdown` makes the API compute `billableInput = inputTokens - cacheReadTokens`, but OpenCode normalizes `tokens.input` to *exclude* cache tokens ("AI SDK v6 … Always subtract cache tokens", `opencode/src/session/session.ts`). With cache fields forwarded under the old contract, fresh input would be under-billed; without them, cached tokens vanish from billing entirely. `anthropic_bucketed` is the contract that matches this payload shape (same as the Claude harness).

## Verification

- Commands: `bun test` (1074 pass; 1 pre-existing failure in `tests/acp-file-system.test.ts` also fails on clean `origin/main`), `bun run tc`, `bun run lint`.
- Manual steps: verified OpenCode's ACP usage shape against `sst/opencode` source (`acp/usage.ts`, `session/session.ts:getUsage`) and the ACP schema (`Usage` with `cachedReadTokens`/`cachedWriteTokens`); traced the mosoo API pipeline (`normalizeUsageTokens` + `calculateUsageCost`) to confirm `anthropic_bucketed` prices fresh input, cache reads, and cache writes at their own rates and fixes the Cache Hit ratio (`cache_read / (fresh + cache_read)`).
- Not run: live OpenCode end-to-end run (`test:live:opencode`).

## Impact

- User/API/contract changes: new `usage_event`/`session_model_call` rows for ACP runs now carry cache token buckets and the `anthropic_bucketed` contract; Cost dashboards start showing non-zero Cache Hit and cache-adjusted spend for OpenCode agents. Historical rows are unaffected (they recorded zero cache tokens under the old label).
- Generated files / GraphQL / DB / lockfile: N/A
- Env or config changes: N/A
- Risk and rollback: low; ACP-only payload change, API already accepts both contract values. Revert the commit to roll back.

## Review

- Closest review areas: `src/runtimes/acp/acp-lifecycle-events.ts` (`normalizePromptUsage`), usage-contract handling in mosoo `apps/api/src/modules/cost/domain/usage-contract.ts`.
- Known trade-offs: the contract is chosen for OpenCode's semantics; if another ACP agent that reports cache-inclusive input tokens is onboarded later, contract selection may need to become per-agent. The runtime-reported cumulative session cost from `usage_update` is still superseded by the API's own token-based pricing at turn end (tracked separately).
