### PR TITLE
fix(acp): parent tool calls to an assistant message for projection

### DIFF
--- a/src/runtimes/acp/acp-assistant-transcript-state.ts
+++ b/src/runtimes/acp/acp-assistant-transcript-state.ts
@@ -299,6 +299,7 @@ export class AcpAssistantTranscriptState {
     return {
       ...translation,
       events: [
+        ...this.#ensureToolParentMessage(translation.targetItemId),
         ...this.#tools.ensureStarted({
           parentMessageId: this.#toolParentMessageId(),
           runId,
@@ -415,26 +416,31 @@ export class AcpAssistantTranscriptState {
     }
 
     const runId = this.#requireRunId();
+    const parentStart = this.#ensureToolParentMessage(toolCallId);
     const nativeStatus = readString(update, "status");
     const projected = this.#tools.patch({
+      parentMessageId: this.#toolParentMessageId(),
       status: nativeStatus === null ? null : toRuntimeToolStatus(nativeStatus),
       toolCallId,
       update,
     });
 
     if (!projected.changed) {
-      return [];
+      return parentStart;
     }
 
     const title =
       (typeof projected.payload["title"] === "string" ? projected.payload["title"] : null) ??
       (typeof projected.payload["kind"] === "string" ? projected.payload["kind"] : "tool");
-    const events = this.#tools.ensureStarted({
-      parentMessageId: this.#toolParentMessageId(),
-      runId,
-      title,
-      toolCallId,
-    });
+    const events = [
+      ...parentStart,
+      ...this.#tools.ensureStarted({
+        parentMessageId: this.#toolParentMessageId(),
+        runId,
+        title,
+        toolCallId,
+      }),
+    ];
 
     events.push({
       ...(type === "tool_call_update"
@@ -638,5 +644,18 @@ export class AcpAssistantTranscriptState {
 
   #toolParentMessageId(): string | undefined {
     return this.#activeAssistantMessage?.id ?? this.#promptMessageId ?? undefined;
+  }
+
+  // Tool calls must be parented to an assistant message: the session event
+  // projection drops tool starts without a parent, and the prompt message id
+  // would attach them to the user's bubble. ACP agents may open a tool call
+  // before any assistant chunk, so start an anonymous assistant message first,
+  // matching the Claude runtime's ensureMessageStarted behavior.
+  #ensureToolParentMessage(toolCallId: string): DriverEventInput[] {
+    if (this.#tools.hasStarted(toolCallId) || this.#activeAssistantMessage !== null) {
+      return [];
+    }
+
+    return this.#startAnonymousMessage().events;
   }
 }

--- a/src/runtimes/acp/acp-tool-events.ts
+++ b/src/runtimes/acp/acp-tool-events.ts
@@ -40,6 +40,10 @@ export class AcpToolEventState {
     return this.#started.size > 0;
   }
 
+  hasStarted(toolCallId: string): boolean {
+    return this.#started.has(toolCallId);
+  }
+
   clear(): void {
     this.#completed.clear();
     this.#snapshots.clear();
@@ -47,6 +51,7 @@ export class AcpToolEventState {
   }
 
   patch(input: {
+    parentMessageId?: string | undefined;
     status: RuntimeToolStatus | null;
     toolCallId: string;
     update: JsonObject | null;
@@ -57,10 +62,17 @@ export class AcpToolEventState {
       previousStatus === "completed" || previousStatus === "failed"
         ? previousStatus
         : (input.status ?? "running");
+    // The projection layer links tool calls to their assistant message via
+    // parentMessageId; keep the first observed parent for the call's lifetime.
+    const parentMessageId =
+      (typeof previous?.["parentMessageId"] === "string"
+        ? previous["parentMessageId"]
+        : undefined) ?? input.parentMessageId;
     const payload = {
       ...previous,
       ...toToolCallPayload(input.toolCallId, status, input.update),
       kind: readNonEmptyString(input.update, "kind") ?? previous?.["kind"] ?? "tool",
+      ...(parentMessageId === undefined ? {} : { parentMessageId }),
       status,
       title: readNullableString(input.update, "title") ?? previous?.["title"] ?? null,
       toolCallId: input.toolCallId,

--- a/tests/acp-event-translator-session-update.test.ts
+++ b/tests/acp-event-translator-session-update.test.ts
@@ -61,9 +61,11 @@ describe("ACP runtime event translation", () => {
     const events = [...translation.events, ...state.completePrompt("end_turn", null)];
 
     expect(eventKinds(events)).toEqual([
+      "message.started",
       "item.started",
       "tool.call.updated",
       "permission.requested",
+      "message.completed",
       "item.completed",
       "run.completed",
     ]);
@@ -91,12 +93,14 @@ describe("ACP runtime event translation", () => {
     ];
 
     expect(eventKinds(events)).toEqual([
+      "message.started",
       "item.started",
       "tool.call.updated",
+      "message.completed",
       "item.completed",
       "run.completed",
     ]);
-    expect(eventPayload(events[2]!)).toMatchObject({
+    expect(eventPayload(events[4]!)).toMatchObject({
       itemId: "tool-1",
       status: "completed",
     });
@@ -124,16 +128,18 @@ describe("ACP runtime event translation", () => {
     ];
 
     expect(eventKinds(events)).toEqual([
+      "message.started",
       "item.started",
       "tool.call.updated",
+      "message.completed",
       "item.completed",
       "run.completed",
     ]);
-    expect(eventPayload(events[2]!)).toMatchObject({
+    expect(eventPayload(events[4]!)).toMatchObject({
       itemId: "tool-1",
       status: "completed",
     });
-    expect(eventPayload(events[3]!)).toMatchObject({
+    expect(eventPayload(events[5]!)).toMatchObject({
       stopReason: "max_turn_requests",
     });
   });

--- a/tests/fixtures/providers/acp/cases/max-turn-failure.json
+++ b/tests/fixtures/providers/acp/cases/max-turn-failure.json
@@ -20,11 +20,19 @@
   },
   "expectedEvents": [
     {
+      "kind": "message.started",
+      "payload": {
+        "messageId": "assistant-message-1",
+        "role": "agent"
+      },
+      "runId": "run-1"
+    },
+    {
       "kind": "item.started",
       "payload": {
         "itemId": "tool-1",
         "itemType": "tool_call",
-        "parentMessageId": "message-1",
+        "parentMessageId": "assistant-message-1",
         "title": "Run command"
       },
       "runId": "run-1"
@@ -32,13 +40,22 @@
     {
       "kind": "tool.call.updated",
       "payload": {
-        "kind": "tool",
         "status": "running",
         "title": "Run command",
-        "toolCallId": "tool-1"
+        "toolCallId": "tool-1",
+        "kind": "tool",
+        "parentMessageId": "assistant-message-1"
       },
       "runId": "run-1",
       "sourceEventId": "acp:session-1:run-1:tool-call:1"
+    },
+    {
+      "kind": "message.completed",
+      "payload": {
+        "messageId": "assistant-message-1",
+        "role": "agent"
+      },
+      "runId": "run-1"
     },
     {
       "kind": "item.completed",

--- a/tests/fixtures/providers/acp/cases/permission-request.json
+++ b/tests/fixtures/providers/acp/cases/permission-request.json
@@ -35,11 +35,19 @@
   },
   "expectedEvents": [
     {
+      "kind": "message.started",
+      "payload": {
+        "messageId": "assistant-message-1",
+        "role": "agent"
+      },
+      "runId": "run-1"
+    },
+    {
       "kind": "item.started",
       "payload": {
         "itemId": "tool-1",
         "itemType": "tool_call",
-        "parentMessageId": "message-1",
+        "parentMessageId": "assistant-message-1",
         "title": "Run command"
       },
       "runId": "run-1"
@@ -82,6 +90,14 @@
           "title": "Run command",
           "toolCallId": "tool-1"
         }
+      },
+      "runId": "run-1"
+    },
+    {
+      "kind": "message.completed",
+      "payload": {
+        "messageId": "assistant-message-1",
+        "role": "agent"
       },
       "runId": "run-1"
     },

--- a/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
+++ b/tests/fixtures/providers/acp/cases/turn-text-tool-usage.json
@@ -94,7 +94,8 @@
         "rawInput": "{\"command\":\"pwd\"}",
         "status": "running",
         "title": "Run command",
-        "toolCallId": "tool-1"
+        "toolCallId": "tool-1",
+        "parentMessageId": "assistant-message-1"
       },
       "runId": "run-1",
       "sourceEventId": "acp:session-1:run-1:tool-call:2"
@@ -105,10 +106,11 @@
       "payload": {
         "kind": "shell",
         "rawInput": "{\"command\":\"pwd\"}",
-        "rawOutput": "{\"text\":\"/workspace\"}",
         "status": "completed",
         "title": "Run command",
-        "toolCallId": "tool-1"
+        "toolCallId": "tool-1",
+        "parentMessageId": "assistant-message-1",
+        "rawOutput": "{\"text\":\"/workspace\"}"
       },
       "runId": "run-1",
       "sourceEventId": "acp:session-1:run-1:tool-call-update:3"


### PR DESCRIPTION
## Summary

Fixes the OpenCode (ACP) runtime rendering every tool call as a generic `tool` card in the platform chat UI (reported in YEF-891 with OpenCode + DeepSeek V4 Pro + an MCP server).

**Root cause.** ACP `tool.call.updated` payloads carried no `parentMessageId`/`messageId`, unlike the Claude runtime (`agent-sdk-event-writer.ts` sets `parentMessageId`) and the OpenAI runtime (`app-server-item-events.ts` sets `messageId`). The platform projection (`mosoo/pkgs/runtime-events/src/session-event-projection.ts` `toolCallStartEvent`) drops `TOOL_CALL_START` — the only AG-UI event carrying `toolCallName` — when both ids are missing. The tool result still lands, so `ag-ui-session`'s `appendToolResult` creates an orphaned segment with the hardcoded fallback name `"tool"`. Every OpenCode tool call (MCP and built-in, any model) therefore rendered as `tool`, losing its real name. The `item.started` event does carry the title, but it is not projected to AG-UI at all.

## Changes

- `AcpAssistantTranscriptState`: when a tool call opens without an active assistant message, start an anonymous assistant message first (mirroring the Claude runtime's `ensureMessageStarted`), so tools are parented to an assistant message rather than the user's prompt message. Applied to both the `tool_call`/`tool_call_update` path and the permission-request path.
- `AcpToolEventState.patch`: stamp a sticky `parentMessageId` (first observed parent wins for the call's lifetime) on every `tool.call.updated` payload. The field is already part of the wire contract (`runtime-events.ts` validates `parentMessageId` as an optional string on `tool.call.updated`).
- Updated the three ACP fixture cases and translator test expectations for the new `message.started`/`message.completed` envelope.

## Verification

Fed identical tool events through the real platform pipeline (`appRuntimeEventToAgUiSessionEvents` → `applyAgUiEventsToSessionLiveState` from the mosoo repo):

```
=== OLD (broken) ACP payloads
AG-UI events: TOOL_CALL_ARGS, TOOL_CALL_ARGS, TOOL_CALL_RESULT, TOOL_CALL_END
tool segments: ["assistant:tool_result:tool"]

=== NEW (fixed) ACP payloads
AG-UI events: TEXT_MESSAGE_START, TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_RESULT, TOOL_CALL_END, TEXT_MESSAGE_END
tool segments: ["assistant:tool_use:deepwiki_read_wiki_structure","assistant:tool_result:deepwiki_read_wiki_structure"]
```

Also reproduced the full platform path locally (opencode-ai 1.18.4 `opencode acp --pure`, `OPENCODE_CONFIG_CONTENT` with `deepseek/deepseek-v4-pro`, MCP servers passed via ACP `session/new`, including through a faithful replica of the platform MCP proxy): OpenCode emits `title`/`kind` on every tool update, tool calls execute, turns end with `end_turn` — confirming the name loss happened in the event pipeline, not in OpenCode/DeepSeek/MCP transport.

- `bun test`: 1074 pass / 1 pre-existing failure (`acp-file-system.test.ts` `/tmp` vs `/private/tmp` realpath on macOS, fails on a clean checkout too)
- `tsc --noEmit`: clean
- `vp lint`: clean
