### PR TITLE
fix(acp): degrade gracefully when the agent lacks additional directory support

### DIFF
--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -229,6 +229,13 @@ export class AcpDriverBackend implements AgentDriverBackend {
         signal,
       );
 
+      if (setup.droppedAdditionalDirectories.length > 0) {
+        context.logger.warn("driver.acp.session.additional_directories_dropped", {
+          count: setup.droppedAdditionalDirectories.length,
+          reason: "agent_capability_missing",
+        });
+      }
+
       await withAcpStartupStage(
         "ACP session ready event push",
         () =>

--- a/src/runtimes/acp/acp-session-setup.ts
+++ b/src/runtimes/acp/acp-session-setup.ts
@@ -23,6 +23,7 @@ import type { JsonObject } from "./acp-types";
 export type AcpSessionSetupMode = "created" | "loaded" | "resumed";
 
 export interface AcpSessionSetup {
+  readonly droppedAdditionalDirectories: readonly string[];
   readonly mode: AcpSessionSetupMode;
   readonly raw: JsonObject;
   readonly sessionId: string;
@@ -41,11 +42,16 @@ export async function setupAcpSession(input: AcpSessionSetupInput): Promise<AcpS
   const mcpServers = buildMcpServers(input.payload);
   assertMcpSupport(input.agentCapabilities, mcpServers);
   const existingSessionId = input.currentSessionId;
-  const additionalDirectories = input.payload.execution.session.additionalDirectories;
+  const requestedAdditionalDirectories = input.payload.execution.session.additionalDirectories;
 
-  if (additionalDirectories.length > 0 && !supportsAdditionalDirs(input.agentCapabilities)) {
-    throw new Error("ACP agent does not advertise additional directory support.");
-  }
+  // Agents that do not advertise sessionCapabilities.additionalDirectories
+  // (OpenCode never has) used to receive the field anyway and silently ignore
+  // it. Failing the whole session here turns that long-standing silent
+  // degradation into an outage, so drop the directories instead and let the
+  // caller surface the degradation.
+  const supportsDirs = supportsAdditionalDirs(input.agentCapabilities);
+  const additionalDirectories = supportsDirs ? requestedAdditionalDirectories : [];
+  const droppedAdditionalDirectories = supportsDirs ? [] : requestedAdditionalDirectories;
 
   const baseParams = {
     _meta: toRequestMeta({
@@ -60,6 +66,7 @@ export async function setupAcpSession(input: AcpSessionSetupInput): Promise<AcpS
     const params = { ...baseParams, sessionId: existingSessionId } satisfies ResumeSessionRequest;
     const result = await input.connection.request(acpMethods.agent.session.resume, params);
     return {
+      droppedAdditionalDirectories,
       mode: "resumed",
       raw: isRecord(result) ? result : {},
       sessionId: existingSessionId,
@@ -71,6 +78,7 @@ export async function setupAcpSession(input: AcpSessionSetupInput): Promise<AcpS
       const params = { ...baseParams, sessionId: existingSessionId } satisfies LoadSessionRequest;
       const result = await input.connection.request(acpMethods.agent.session.load, params);
       return {
+        droppedAdditionalDirectories,
         mode: "loaded",
         raw: isRecord(result) ? result : {},
         sessionId: existingSessionId,
@@ -85,6 +93,7 @@ export async function setupAcpSession(input: AcpSessionSetupInput): Promise<AcpS
   }
 
   return {
+    droppedAdditionalDirectories,
     mode: "created",
     raw: isRecord(result) ? result : {},
     sessionId: result.sessionId,

--- a/tests/acp-session-setup.test.ts
+++ b/tests/acp-session-setup.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import { methods as acpMethods } from "@agentclientprotocol/sdk";
+import type { ClientContext } from "@agentclientprotocol/sdk";
+
+import type { DriverExecutionSessionContext } from "../src/protocol/boot";
+import { setupAcpSession } from "../src/runtimes/acp/acp-session-setup";
+import { driverBootPayload, driverStartInput } from "./driver-boot-payload-fixture";
+
+const SESSION_CONTEXT = driverBootPayload.execution.session
+  .context as DriverExecutionSessionContext;
+
+function withAdditionalDirectories(directories: readonly string[]): typeof driverStartInput {
+  return {
+    ...driverStartInput,
+    execution: {
+      ...driverStartInput.execution,
+      session: {
+        ...driverStartInput.execution.session,
+        additionalDirectories: [...directories],
+      },
+    },
+  };
+}
+
+function createRecordingConnection(): {
+  connection: ClientContext;
+  requests: Array<{ method: unknown; params: Record<string, unknown> }>;
+} {
+  const requests: Array<{ method: unknown; params: Record<string, unknown> }> = [];
+  const connection = {
+    request: async (method: unknown, params: Record<string, unknown>) => {
+      requests.push({ method, params });
+      return { sessionId: "acp-session-1" };
+    },
+  } as unknown as ClientContext;
+
+  return { connection, requests };
+}
+
+describe("ACP session setup", () => {
+  test("drops additional directories when the agent does not advertise support", async () => {
+    const { connection, requests } = createRecordingConnection();
+
+    const setup = await setupAcpSession({
+      agentCapabilities: {
+        loadSession: true,
+        sessionCapabilities: { close: {}, resume: {} },
+      },
+      connection,
+      currentSessionId: null,
+      payload: withAdditionalDirectories(["/workspace/extra"]),
+      sessionContext: SESSION_CONTEXT,
+      replaySession: async (operation) => operation(),
+    });
+
+    expect(setup.mode).toBe("created");
+    expect(setup.sessionId).toBe("acp-session-1");
+    expect(setup.droppedAdditionalDirectories).toEqual(["/workspace/extra"]);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe(acpMethods.agent.session.new);
+    expect("additionalDirectories" in (requests[0]?.params ?? {})).toBe(false);
+  });
+
+  test("passes additional directories through when the agent advertises support", async () => {
+    const { connection, requests } = createRecordingConnection();
+
+    const setup = await setupAcpSession({
+      agentCapabilities: {
+        loadSession: true,
+        sessionCapabilities: { additionalDirectories: {}, close: {} },
+      },
+      connection,
+      currentSessionId: null,
+      payload: withAdditionalDirectories(["/workspace/extra"]),
+      sessionContext: SESSION_CONTEXT,
+      replaySession: async (operation) => operation(),
+    });
+
+    expect(setup.droppedAdditionalDirectories).toEqual([]);
+    expect(requests[0]?.params["additionalDirectories"]).toEqual(["/workspace/extra"]);
+  });
+});


### PR DESCRIPTION
## Production incident (try.mosoo.ai, 2026-07-25)

Every run on the acp-fallback runtime fails after `run.dispatched` with:

> ACP session setup failed: ACP agent does not advertise additional directory support.

Started when the mosoo pin moved to driver `9d4415d` (langgenius/mosoo#399, deployed 07-24 ~14:45Z). Reproduces for all published agents, all models, with/without MCP, restartDriver ineffective — the failure is in capability negotiation, upstream of all of those.

## Root cause

Contract v2 (#54) added a hard gate in `acp-session-setup.ts`: session requests `additionalDirectories` + agent does not advertise `sessionCapabilities.additionalDirectories` → throw. The previous driver passed the field through unconditionally.

OpenCode — the acp-fallback agent — **has never advertised that capability**. Verified against sst/opencode v1.18.4 `packages/opencode/src/acp/service.ts`: initialize returns `sessionCapabilities: { close, fork, list, resume }` only, and `session/new` does not read `additionalDirectories` at all. The old passthrough was a silent no-op; the new gate converts that long-standing silent degradation into a full outage, because mosoo populates `additionalDirectories` for published agents.

## Fix

Drop the directories when the capability is missing instead of failing the session, and return `droppedAdditionalDirectories` so the backend logs the degradation (`driver.acp.session.additional_directories_dropped`, warn). Behavior with capability-advertising agents is unchanged — covered by a new regression test in both directions (dropped when unsupported, passed through when supported).

Tests: 1078 pass locally (1 known macOS-only `/var` symlink case in acp-file-system, green on Linux CI).