### PR TITLE
perf(acp): use native instructions for runtime context

### DIFF
--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -1,3 +1,5 @@
+import { basename } from "node:path";
+
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import type { AgentCapabilities, ClientCapabilities, McpServer } from "@agentclientprotocol/sdk";
 
@@ -28,6 +30,46 @@ export function readFallbackCommand(): string {
   return typeof command === "string" && command.trim().length > 0
     ? command.trim()
     : ACP_DEFAULT_COMMAND;
+}
+
+export function isOpenCodeCommand(command: string): boolean {
+  const executable = basename(command).toLowerCase();
+  return executable === "opencode" || executable === "opencode.exe";
+}
+
+export function appendOpenCodeInstruction(
+  env: Record<string, string>,
+  instructionPath: string,
+): Record<string, string> {
+  const rawConfig = env["OPENCODE_CONFIG_CONTENT"];
+  const parsed: unknown = rawConfig === undefined ? {} : JSON.parse(rawConfig);
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("OPENCODE_CONFIG_CONTENT must be a JSON object.");
+  }
+
+  const config = parsed as Record<string, unknown>;
+  const currentInstructions = config["instructions"];
+
+  if (
+    currentInstructions !== undefined &&
+    (!Array.isArray(currentInstructions) ||
+      !currentInstructions.every((entry) => typeof entry === "string"))
+  ) {
+    throw new Error("OPENCODE_CONFIG_CONTENT instructions must be a string array.");
+  }
+
+  const instructions = currentInstructions ?? [];
+
+  return {
+    ...env,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      ...config,
+      instructions: instructions.includes(instructionPath)
+        ? instructions
+        : [...instructions, instructionPath],
+    }),
+  };
 }
 
 export function readFallbackArgs(): string[] {

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -1,3 +1,5 @@
+import { Readable, Writable } from "node:stream";
+
 import {
   client as createAcpClient,
   methods as acpMethods,
@@ -10,8 +12,9 @@ import type {
   ClientContext,
   InitializeResponse,
 } from "@agentclientprotocol/sdk";
-import { Readable, Writable } from "node:stream";
 
+import type { AgentDriverBackend, AgentDriverContext } from "../../core/agent-driver-backend";
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 import { summarizePath, summarizePathCollection } from "../../observability/driver-debug";
 import type { DriverEventInput } from "../../protocol/events";
 import type { DriverHostIntegrationSnapshot } from "../../protocol/host-integration";
@@ -20,28 +23,30 @@ import type { DriverRuntime } from "../../protocol/runtime";
 import type { DriverStartInput } from "../../protocol/start";
 import type { RuntimeCommandInput } from "../../runtime-command";
 import { raceWithAbort, settlePromiseWithTimeout } from "../../utils/async";
-import { AGENT_DRIVER_VERSION } from "../../core/version";
-import type { AgentDriverBackend, AgentDriverContext } from "../../core/agent-driver-backend";
 import { DriverEventPublisher } from "../driver-event-publisher";
 import {
   buildRuntimeBootstrapText,
   computeRuntimeBootstrapDigest,
+  writeNativeRuntimeSystemPrompt,
   writeSkillBootstrapArtifacts,
 } from "../skill-bootstrap";
 import { startAcpAgentProcess, stopAcpAgentProcess } from "./acp-agent-process";
 import type { AcpAgentProcess } from "./acp-agent-process";
 import { AcpClientRequestHandler } from "./acp-client-request-handler";
-import { limitAcpInput } from "./acp-input-limit";
 import {
   ACP_PROTOCOL_VERSION,
+  appendOpenCodeInstruction,
   buildChildEnv,
   buildClientCapabilities,
   assertProtocolVersion,
+  isOpenCodeCommand,
+  readFallbackCommand,
   readResumeId,
   resolveAuthMethod,
   supportsSessionClose,
 } from "./acp-configuration";
 import { toAuthEvent, toInitializeEvents, toSessionReadyEvents } from "./acp-event-translator";
+import { limitAcpInput } from "./acp-input-limit";
 import { setupAcpSession } from "./acp-session-setup";
 import { withAcpStartupStage } from "./acp-startup";
 import { AcpTurnController } from "./acp-turn-controller";
@@ -115,13 +120,20 @@ export class AcpDriverBackend implements AgentDriverBackend {
       writeSkillBootstrapArtifacts(this.#payload.execution),
       signal,
     );
+    const command = readFallbackCommand();
+    const nativeInstructionPath = isOpenCodeCommand(command)
+      ? await raceWithAbort(writeNativeRuntimeSystemPrompt(this.#payload.execution), signal)
+      : null;
 
     if (this.#stopRequested || signal.aborted) {
       signal.throwIfAborted();
       throw new Error("ACP driver backend stopped during startup.");
     }
 
-    const env = this.#childProcessEnv;
+    const env =
+      nativeInstructionPath === null
+        ? this.#childProcessEnv
+        : appendOpenCodeInstruction(this.#childProcessEnv, nativeInstructionPath);
     const agentProcess = await startAcpAgentProcess(context, this.#payload, env, signal);
     this.#agentProcess = agentProcess;
 
@@ -251,7 +263,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
         signal,
       );
 
-      if (setup.mode === "created") {
+      if (setup.mode === "created" && nativeInstructionPath === null) {
         await withAcpStartupStage(
           "ACP runtime bootstrap",
           () => this.#applyBootstrap(context, signal),
@@ -270,6 +282,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
           homePath: summarizePath(this.#payload.execution.session.homePath),
           sharedRootPath: summarizePath(this.#payload.execution.session.sharedRootPath),
         },
+        nativeInstructions: nativeInstructionPath !== null,
         nativeResumeRefPresent: this.#nativeSessionId !== null,
         skillCount: materializedSkills.length,
       });

--- a/src/runtimes/skill-bootstrap.ts
+++ b/src/runtimes/skill-bootstrap.ts
@@ -167,6 +167,22 @@ export function buildNativeRuntimeSystemPrompt(execution: DriverExecutionInput):
   return bootstrap.length > 0 ? bootstrap : null;
 }
 
+export async function writeNativeRuntimeSystemPrompt(
+  execution: DriverExecutionInput,
+): Promise<string | null> {
+  const systemPrompt = buildNativeRuntimeSystemPrompt(execution);
+
+  if (systemPrompt === null) {
+    return null;
+  }
+
+  const path = join(execution.session.homePath, "runtime-instructions.md");
+  await mkdir(execution.session.homePath, { recursive: true });
+  await writeFile(path, `${systemPrompt}\n`, { encoding: "utf8", mode: 0o600 });
+
+  return path;
+}
+
 export function computeRuntimeBootstrapDigest(execution: DriverExecutionInput): string | null {
   const bootstrapText = buildRuntimeBootstrapText(execution);
 

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -1,18 +1,20 @@
 import { describe, expect, test } from "bun:test";
 
+import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { createBufferedSinkLogger } from "../src/observability";
 import {
   ACP_PROTOCOL_VERSION,
+  appendOpenCodeInstruction,
   buildChildEnv,
   buildClientCapabilities,
   assertProtocolVersion,
+  isOpenCodeCommand,
   resolveAuthMethod,
   supportsAdditionalDirs,
   supportsSessionClose,
   supportsSessionResume,
 } from "../src/runtimes/acp/acp-configuration";
 import { AcpDriverBackend, limitAcpInput } from "../src/runtimes/acp/acp-driver-backend";
-import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { bootPayload } from "./driver-runtime-boundary-fixtures";
 
 function createInitializeResult(protocolVersion: number | string | null) {
@@ -25,6 +27,35 @@ function createInitializeResult(protocolVersion: number | string | null) {
 }
 
 describe("ACP runtime configuration", () => {
+  test("adds a session instruction to OpenCode's inline config", () => {
+    const instructionPath = "/workspace/se/session/.state/acp/runtime-instructions.md";
+    const env = appendOpenCodeInstruction(
+      {
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          instructions: ["/managed/instructions.md"],
+          model: "deepseek/deepseek-v4-pro",
+        }),
+      },
+      instructionPath,
+    );
+
+    expect(isOpenCodeCommand("/usr/local/bin/opencode")).toBe(true);
+    expect(isOpenCodeCommand("opencode.exe")).toBe(true);
+    expect(isOpenCodeCommand("acp-agent")).toBe(false);
+    expect(JSON.parse(env["OPENCODE_CONFIG_CONTENT"] ?? "{}")).toEqual({
+      instructions: ["/managed/instructions.md", instructionPath],
+      model: "deepseek/deepseek-v4-pro",
+    });
+    expect(
+      JSON.parse(
+        appendOpenCodeInstruction(env, instructionPath)["OPENCODE_CONFIG_CONTENT"] ?? "{}",
+      ),
+    ).toEqual({
+      instructions: ["/managed/instructions.md", instructionPath],
+      model: "deepseek/deepseek-v4-pro",
+    });
+  });
+
   test("accepts the configured ACP protocol version only", () => {
     expect(() => assertProtocolVersion(createInitializeResult(ACP_PROTOCOL_VERSION))).not.toThrow();
     expect(() =>

--- a/tests/acp-driver-backend.test.ts
+++ b/tests/acp-driver-backend.test.ts
@@ -1,24 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverBootPayload } from "../src/protocol/boot";
-import { createDriverHostIntegrationSnapshotFromBootExecution } from "../src/protocol/host-integration";
 import type { DriverEventInput } from "../src/protocol/events";
+import { createDriverHostIntegrationSnapshotFromBootExecution } from "../src/protocol/host-integration";
 import type { RunId } from "../src/protocol/id";
 import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
 import { AcpDriverBackend } from "../src/runtimes/acp/acp-driver-backend";
-import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { settlePromiseWithTimeout } from "../src/utils/async";
 import { driverBootPayload, DRIVER_TEST_IDS } from "./driver-boot-payload-fixture";
 
 const FAKE_AGENT = String.raw`
 const { appendFileSync, existsSync } = require("node:fs");
 const logPath = process.env.TEST_LOG_PATH;
+const openCodeConfigPath = process.env.TEST_OPENCODE_CONFIG_PATH;
 const responsePath = process.env.TEST_RESPONSE_PATH;
 const triggerPath = process.env.TEST_TRIGGER_PATH;
+if (openCodeConfigPath) {
+  appendFileSync(openCodeConfigPath, process.env.OPENCODE_CONFIG_CONTENT || "");
+}
 let buffer = "";
 let sessionReady = false;
 let updateSent = false;
@@ -144,23 +148,35 @@ setInterval(() => {
 }, 5);
 `;
 
-async function createHarness(options: { readonly hangClose?: boolean } = {}) {
+async function createHarness(
+  options: { readonly hangClose?: boolean; readonly openCodeInstructions?: boolean } = {},
+) {
   const root = await mkdtemp(join(tmpdir(), "driver-acp-backend-"));
   const logPath = join(root, "methods.log");
+  const openCodeConfigPath = join(root, "opencode-config.json");
   const responsePath = join(root, "responses.log");
   const triggerPath = join(root, "send-update");
+  const command = options.openCodeInstructions ? join(root, "opencode") : process.execPath;
+
+  if (options.openCodeInstructions) {
+    await symlink(process.execPath, command);
+  }
+
   const boot = {
     ...driverBootPayload,
     execution: {
       ...driverBootPayload.execution,
       environment: {
         variables: {
+          ...(options.openCodeInstructions ? { OPENCODE_CONFIG_CONTENT: "{}" } : {}),
           TEST_LOG_PATH: logPath,
+          TEST_OPENCODE_CONFIG_PATH: openCodeConfigPath,
           TEST_RESPONSE_PATH: responsePath,
           TEST_TRIGGER_PATH: triggerPath,
           TEST_HANG_CLOSE: options.hangClose ? "1" : "0",
         },
       },
+      profilePrompt: options.openCodeInstructions ? "Always answer concisely." : "",
       session: {
         ...driverBootPayload.execution.session,
         context: {
@@ -224,7 +240,7 @@ async function createHarness(options: { readonly hangClose?: boolean } = {}) {
   const backend = new AcpDriverBackend(payload);
   const previousCommand = process.env["MOSOO_ACP_FALLBACK_COMMAND"];
   const previousArgs = process.env["MOSOO_ACP_FALLBACK_ARGS"];
-  process.env["MOSOO_ACP_FALLBACK_COMMAND"] = process.execPath;
+  process.env["MOSOO_ACP_FALLBACK_COMMAND"] = command;
   process.env["MOSOO_ACP_FALLBACK_ARGS"] = JSON.stringify(["-e", FAKE_AGENT]);
 
   try {
@@ -265,6 +281,11 @@ async function createHarness(options: { readonly hangClose?: boolean } = {}) {
     async methods() {
       return (await readFile(logPath, "utf8")).trim().split("\n").filter(Boolean);
     },
+    async openCodeConfig() {
+      return JSON.parse(await readFile(openCodeConfigPath, "utf8")) as {
+        instructions?: unknown;
+      };
+    },
     async responses() {
       return (await readFile(responsePath, "utf8").catch(() => ""))
         .trim()
@@ -277,6 +298,20 @@ async function createHarness(options: { readonly hangClose?: boolean } = {}) {
 }
 
 describe("ACP driver backend lifecycle", () => {
+  test("uses OpenCode native instructions without a hidden bootstrap prompt", async () => {
+    const harness = await createHarness({ openCodeInstructions: true });
+
+    try {
+      expect(await harness.methods()).not.toContain("session/prompt");
+      const config = await harness.openCodeConfig();
+      expect(config.instructions).toEqual([expect.any(String)]);
+      const [instructionPath] = config.instructions as [string];
+      expect(await readFile(instructionPath, "utf8")).toContain("Always answer concisely.");
+    } finally {
+      await harness.destroy();
+    }
+  });
+
   test("clears turn state when prompt-start publication fails", async () => {
     const harness = await createHarness();
 


### PR DESCRIPTION
## Summary
- inject Mosoo runtime context through OpenCode native instructions
- skip the hidden ACP bootstrap model turn for OpenCode only
- preserve the existing bootstrap path for other ACP agents

## Evidence
- exact-shape staging Agent: pet / acp-fallback / DeepSeek v4 pro / one bearer MCP / no tool calls
- successful Driver logs report nativeInstructions=true with no bootstrap prompt event
- removes the report-era 15.8s hidden model turn

## Verification
- bun test tests/acp-configuration.test.ts tests/acp-driver-backend.test.ts (17 passed)
- vp run tc
- vp run build
- vp check --no-lint on all five changed files
- full suite: 1080 passed, 42 skipped; one pre-existing macOS /var vs /private/var path assertion remains unrelated

Related to langgenius/mosoo#387.