### PR TITLE
feat(perf): add runtime performance evidence

### DIFF
--- a/bench/ttft-bench.ts
+++ b/bench/ttft-bench.ts
@@ -23,9 +23,11 @@
  *   TTFT_UPDATE_BASELINE=1   write baseline.json from this run
  *   TTFT_OPENCODE_PROVIDER=openai|anthropic   backing provider for opencode
  */
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
@@ -37,6 +39,7 @@ import { AGENT_DRIVER_PROVIDER_REGISTRY } from "../src/runtimes/provider-registr
 import { driverBootPayload } from "../tests/driver-boot-payload-fixture";
 import { DRIVER_TEST_IDS, bootPayload } from "../tests/driver-runtime-boundary-fixtures";
 import { textDeltaFrom } from "../tests/live-driver-events";
+import { percentile, readOutputTokens, summarizeStreaming } from "./ttft-metrics";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR = join(HERE, "outputs");
@@ -58,7 +61,7 @@ async function withTimeout<T>(label: string, ms: number, task: Promise<T>): Prom
 }
 
 type RuntimeId = "claude" | "openai" | "opencode";
-type ScenarioId = "no_tool" | "long_output" | "tool_write_allow" | "tool_write_reject";
+type ScenarioId = "custom" | "no_tool" | "long_output" | "tool_write_allow" | "tool_write_reject";
 
 interface Scenario {
   readonly id: ScenarioId;
@@ -68,6 +71,7 @@ interface Scenario {
   readonly permission: PermissionDecision;
   /** substring the final output must contain for ok=true */
   readonly expect: string;
+  readonly exact?: boolean;
   /** when set, ok additionally requires cwd/<marker> to contain the value */
   readonly marker?: { file: string; content: string };
 }
@@ -79,34 +83,36 @@ interface TrialMetrics {
   readonly totalMs: number | null;
   readonly deltaCount: number;
   readonly outputChars: number;
+  readonly outputTokens: number | null;
+  readonly outputTokensPerSecond: number | null;
   readonly interChunkP50: number | null;
   readonly interChunkP95: number | null;
   readonly interChunkMax: number | null;
+  readonly pauseOver250MsCount: number;
+  readonly pauseOver500MsCount: number;
+  readonly timePerOutputTokenMs: number | null;
   readonly fileCreated: boolean | null;
   readonly ok: boolean;
   readonly error: string | null;
 }
 
 interface CellResult {
-  readonly runtime: RuntimeId;
-  readonly scenario: ScenarioId;
-  readonly model: string;
-  readonly trials: TrialMetrics[];
   readonly agg: ReturnType<typeof aggregate>;
+  readonly expectedOutputSha256: string;
+  readonly model: string;
+  readonly outputValidation: "contains" | "exact";
+  readonly promptSha256: string;
+  readonly providerId: string;
+  readonly runtime: RuntimeId;
+  readonly runtimeId: string;
+  readonly scenario: ScenarioId;
+  readonly systemPromptSha256: string;
+  readonly trials: TrialMetrics[];
 }
 
 function readEnv(name: string): string | null {
   const value = process.env[name]?.trim();
   return value && value.length > 0 ? value : null;
-}
-
-function percentile(values: number[], p: number): number | null {
-  const clean = values.filter((v) => Number.isFinite(v)).toSorted((a, b) => a - b);
-  if (clean.length === 0) {
-    return null;
-  }
-  const idx = Math.min(clean.length - 1, Math.max(0, Math.ceil((p / 100) * clean.length) - 1));
-  return clean[idx] ?? null;
 }
 
 function aggregate(trials: TrialMetrics[]) {
@@ -130,6 +136,12 @@ function aggregate(trials: TrialMetrics[]) {
     totalP95: percentile(pick("totalMs"), 95),
     interChunkP50: percentile(pick("interChunkP50"), 50),
     interChunkP95: percentile(pick("interChunkP95"), 95),
+    outputTokensP50: percentile(pick("outputTokens"), 50),
+    outputTokensPerSecondP50: percentile(pick("outputTokensPerSecond"), 50),
+    outputTokensPerSecondP95: percentile(pick("outputTokensPerSecond"), 95),
+    pauseOver250MsP50: percentile(pick("pauseOver250MsCount"), 50),
+    pauseOver500MsP50: percentile(pick("pauseOver500MsCount"), 50),
+    timePerOutputTokenP50: percentile(pick("timePerOutputTokenMs"), 50),
     deltaCountP50: percentile(pick("deltaCount"), 50),
   };
 }
@@ -321,18 +333,19 @@ async function runTrial(input: {
   let totalMs: number | null = null;
   let deltaCount = 0;
   let outputChars = 0;
+  let outputTokens: number | null = null;
   let fileCreated: boolean | null = input.scenario.marker ? false : null;
   let ok = false;
   let error: string | null = null;
-  const deltaTimestamps: number[] = [];
+  const textDeltaTimestamps: number[] = [];
   let outputText = "";
 
   try {
-    const bootStart = Date.now();
+    const bootStart = performance.now();
     await withTimeout("boot", BOOT_TIMEOUT_MS, kernel.start(input.startInput(args)));
-    bootMs = Date.now() - bootStart;
+    bootMs = performance.now() - bootStart;
 
-    const dispatchStart = Date.now();
+    const dispatchStart = performance.now();
     const dispatch = kernel.dispatch({
       commandId: `ttft-${input.runtime}-cmd`,
       input: { text: input.scenario.prompt },
@@ -357,14 +370,14 @@ async function runTrial(input: {
         break;
       }
       const event: DriverEventInput = next.value;
-      const now = Date.now();
+      const now = performance.now();
       if (event.kind === "message.delta") {
         if (ttftMs === null) {
           ttftMs = now - dispatchStart;
         }
-        deltaTimestamps.push(now);
         const text = textDeltaFrom(event);
         if (text.length > 0) {
+          textDeltaTimestamps.push(now);
           if (firstTextMs === null) {
             firstTextMs = now - dispatchStart;
           }
@@ -372,6 +385,8 @@ async function runTrial(input: {
           outputText += text;
           deltaCount += 1;
         }
+      } else if (event.kind === "usage.updated") {
+        outputTokens = readOutputTokens(event) ?? outputTokens;
       } else if (event.kind === "run.failed") {
         error = "run_failed";
         done = true;
@@ -392,21 +407,30 @@ async function runTrial(input: {
         fileCreated = false;
       }
     }
+    const normalizedOutput = outputText.trim();
+    const expectedOutput = input.scenario.expect.trim();
     const textOk =
       totalMs !== null &&
-      outputText.trim().toLowerCase().includes(input.scenario.expect.toLowerCase());
+      (input.scenario.exact === true
+        ? normalizedOutput === expectedOutput
+        : normalizedOutput.toLowerCase().includes(expectedOutput.toLowerCase()));
     ok = input.scenario.marker ? textOk && fileCreated === true : textOk;
   } catch (caught) {
-    error = caught instanceof Error ? caught.message : String(caught);
+    error = (caught instanceof Error ? caught.message : String(caught)).replaceAll(
+      input.apiKey,
+      "[REDACTED]",
+    );
   } finally {
     await kernel.stop("bench.stop").catch(() => {});
     await paths.cleanup().catch(() => {});
   }
 
-  const gaps: number[] = [];
-  for (let i = 1; i < deltaTimestamps.length; i += 1) {
-    gaps.push(deltaTimestamps[i]! - deltaTimestamps[i - 1]!);
-  }
+  const streaming = summarizeStreaming({
+    firstTextMs,
+    outputTokens,
+    textDeltaTimestamps,
+    totalMs,
+  });
 
   return {
     bootMs,
@@ -415,9 +439,8 @@ async function runTrial(input: {
     totalMs,
     deltaCount,
     outputChars,
-    interChunkP50: percentile(gaps, 50),
-    interChunkP95: percentile(gaps, 95),
-    interChunkMax: gaps.length > 0 ? Math.max(...gaps) : null,
+    outputTokens,
+    ...streaming,
     fileCreated,
     ok,
     error,
@@ -477,15 +500,46 @@ async function main(): Promise<void> {
   const openaiKey = readEnv("OPENAI_API_KEY") ?? readEnv("AGENT_DRIVER_LIVE_OPENAI_API_KEY");
   const claudeModel = readEnv("AGENT_DRIVER_LIVE_ANTHROPIC_MODEL") ?? "claude-sonnet-4-5";
   const openaiModel = readEnv("AGENT_DRIVER_LIVE_OPENAI_MODEL") ?? "gpt-5.4";
-  const opencodeProvider = (readEnv("TTFT_OPENCODE_PROVIDER") ?? "openai") as
-    | "openai"
-    | "anthropic";
+  const opencodeProvider = readEnv("TTFT_OPENCODE_PROVIDER") ?? "openai";
+  const opencodeApiKeyEnv =
+    readEnv("TTFT_OPENCODE_API_KEY_ENV") ??
+    (opencodeProvider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY");
+  const opencodeKey =
+    readEnv(opencodeApiKeyEnv) ?? (opencodeProvider === "anthropic" ? anthropicKey : openaiKey);
+  const opencodeModel =
+    readEnv("TTFT_OPENCODE_MODEL") ??
+    (opencodeProvider === "anthropic" ? claudeModel : openaiModel);
+  const customPrompt = readEnv("TTFT_CUSTOM_PROMPT");
+  const customExpectedOutput = readEnv("TTFT_CUSTOM_EXPECT");
+  const customSystemPrompt = readEnv("TTFT_CUSTOM_SYSTEM_PROMPT");
+  const scenarios: Scenario[] =
+    customPrompt === null || customExpectedOutput === null || customSystemPrompt === null
+      ? SCENARIOS
+      : [
+          ...SCENARIOS,
+          {
+            exact: true,
+            expect: customExpectedOutput,
+            id: "custom",
+            permission: "allow_once",
+            prompt: customPrompt,
+            systemPrompt: customSystemPrompt,
+          },
+        ];
   const scenarioFilter = new Set<ScenarioId>(
     (readEnv("TTFT_SCENARIOS") ?? "no_tool,long_output,tool_write_allow,tool_write_reject")
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean) as ScenarioId[],
   );
+  if (
+    scenarioFilter.has("custom") &&
+    (customPrompt === null || customExpectedOutput === null || customSystemPrompt === null)
+  ) {
+    throw new Error(
+      "TTFT_SCENARIOS=custom requires TTFT_CUSTOM_PROMPT, TTFT_CUSTOM_EXPECT, and TTFT_CUSTOM_SYSTEM_PROMPT.",
+    );
+  }
 
   const cells: CellResult[] = [];
 
@@ -496,6 +550,8 @@ async function main(): Promise<void> {
     build: (paths: StartInputArgs) => DriverStartInput,
     apiKey: string,
     isOpenCode: boolean,
+    providerId: string,
+    runtimeId: string,
   ): Promise<void> => {
     process.stdout.write(`\n[${runtime}/${scenario.id}] model=${model} warmup...`);
     await runTrial({ runtime, scenario, startInput: build, apiKey, model, isOpenCode }).catch(
@@ -509,10 +565,22 @@ async function main(): Promise<void> {
         ` t${i + 1}=${m.ok ? "ok" : "FAIL"}(ttft=${m.ttftMs ?? "-"},total=${m.totalMs ?? "-"})`,
       );
     }
-    cells.push({ runtime, scenario: scenario.id, model, trials: results, agg: aggregate(results) });
+    cells.push({
+      agg: aggregate(results),
+      expectedOutputSha256: createHash("sha256").update(scenario.expect.trim()).digest("hex"),
+      model,
+      outputValidation: scenario.exact === true ? "exact" : "contains",
+      promptSha256: createHash("sha256").update(scenario.prompt).digest("hex"),
+      providerId,
+      runtime,
+      runtimeId,
+      scenario: scenario.id,
+      systemPromptSha256: createHash("sha256").update(scenario.systemPrompt).digest("hex"),
+      trials: results,
+    });
   };
 
-  for (const scenario of SCENARIOS.filter((s) => scenarioFilter.has(s.id))) {
+  for (const scenario of scenarios.filter((s) => scenarioFilter.has(s.id))) {
     if (requested.includes("claude") && anthropicKey) {
       await runCell(
         "claude",
@@ -521,50 +589,69 @@ async function main(): Promise<void> {
         (p) => claudeStartInput(p),
         anthropicKey,
         false,
+        "anthropic",
+        "claude-agent-sdk",
       );
     }
     if (requested.includes("openai") && openaiKey) {
-      await runCell("openai", scenario, openaiModel, (p) => openaiStartInput(p), openaiKey, false);
+      await runCell(
+        "openai",
+        scenario,
+        openaiModel,
+        (p) => openaiStartInput(p),
+        openaiKey,
+        false,
+        "openai",
+        "openai-runtime",
+      );
     }
-    if (requested.includes("opencode")) {
-      const key = opencodeProvider === "anthropic" ? anthropicKey : openaiKey;
-      const model = opencodeProvider === "anthropic" ? claudeModel : openaiModel;
-      const apiKeyEnv = opencodeProvider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY";
-      if (key) {
-        process.env["MOSOO_ACP_FALLBACK_COMMAND"] =
-          readEnv("MOSOO_ACP_FALLBACK_COMMAND") ?? "opencode";
-        process.env["MOSOO_ACP_FALLBACK_ARGS"] =
-          readEnv("MOSOO_ACP_FALLBACK_ARGS") ?? JSON.stringify(["acp", "--pure"]);
-        await runCell(
-          "opencode",
-          scenario,
-          model,
-          (p) => opencodeStartInput(p, opencodeProvider, apiKeyEnv),
-          key,
-          true,
-        );
-      }
+    if (requested.includes("opencode") && opencodeKey) {
+      process.env["MOSOO_ACP_FALLBACK_COMMAND"] =
+        readEnv("MOSOO_ACP_FALLBACK_COMMAND") ?? "opencode";
+      process.env["MOSOO_ACP_FALLBACK_ARGS"] =
+        readEnv("MOSOO_ACP_FALLBACK_ARGS") ?? JSON.stringify(["acp", "--pure"]);
+      await runCell(
+        "opencode",
+        scenario,
+        opencodeModel,
+        (p) => opencodeStartInput(p, opencodeProvider, opencodeApiKeyEnv),
+        opencodeKey,
+        true,
+        opencodeProvider,
+        "acp-fallback",
+      );
     }
   }
 
   await mkdir(OUTPUT_DIR, { recursive: true });
   const stamp = readEnv("TTFT_STAMP") ?? "latest";
-  const results = { generatedStamp: stamp, trials, cells };
-  await writeFile(join(OUTPUT_DIR, `results-${stamp}.json`), JSON.stringify(results, null, 2));
+  const results = {
+    cells,
+    failurePolicy: "all recorded trials are retained; any failure invalidates qualification",
+    generatedAt: new Date().toISOString(),
+    generatedStamp: stamp,
+    schemaVersion: "mosoo.driver-ttft.v2",
+    trials,
+    warmupTrialsPerCell: 1,
+  };
+  const resultsPath = readEnv("TTFT_OUTPUT") ?? join(OUTPUT_DIR, `results-${stamp}.json`);
+  await mkdir(dirname(resultsPath), { recursive: true });
+  await writeFile(resultsPath, `${JSON.stringify(results, null, 2)}\n`, { mode: 0o600 });
+  await chmod(resultsPath, 0o600);
 
   const lines: string[] = [
     `# Driver TTFT / streaming benchmark (${stamp})`,
     "",
     `trials per cell: ${trials} (+1 warmup discarded)`,
     "",
-    "| runtime | scenario | model | ok% | file% | boot p50 | ttft p50 | ttft p95 | firstText p50 | total p50 | interChunk p50/p95 | deltas |",
-    "|---|---|---|---|---|---|---|---|---|---|---|---|",
+    "| runtime | scenario | model | ok% | file% | boot p50 | ttft p50 | ttft p95 | firstText p50 | total p50 | interChunk p50/p95 | tok/s p50 | TPOT p50 | pauses >250/>500 | deltas |",
+    "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
   ];
   const fmt = (v: number | null): string => (v === null ? "-" : `${Math.round(v)}`);
   const pct = (v: number | null): string => (v === null ? "-" : `${Math.round(v * 100)}%`);
   for (const c of cells) {
     lines.push(
-      `| ${c.runtime} | ${c.scenario} | ${c.model} | ${pct(c.agg.okRate)} | ${pct(c.agg.fileCreatedRate)} | ${fmt(c.agg.bootP50)} | ${fmt(c.agg.ttftP50)} | ${fmt(c.agg.ttftP95)} | ${fmt(c.agg.firstTextP50)} | ${fmt(c.agg.totalP50)} | ${fmt(c.agg.interChunkP50)}/${fmt(c.agg.interChunkP95)} | ${fmt(c.agg.deltaCountP50)} |`,
+      `| ${c.runtime} | ${c.scenario} | ${c.model} | ${pct(c.agg.okRate)} | ${pct(c.agg.fileCreatedRate)} | ${fmt(c.agg.bootP50)} | ${fmt(c.agg.ttftP50)} | ${fmt(c.agg.ttftP95)} | ${fmt(c.agg.firstTextP50)} | ${fmt(c.agg.totalP50)} | ${fmt(c.agg.interChunkP50)}/${fmt(c.agg.interChunkP95)} | ${fmt(c.agg.outputTokensPerSecondP50)} | ${fmt(c.agg.timePerOutputTokenP50)} | ${fmt(c.agg.pauseOver250MsP50)}/${fmt(c.agg.pauseOver500MsP50)} | ${fmt(c.agg.deltaCountP50)} |`,
     );
   }
   const summary = lines.join("\n");
@@ -572,9 +659,7 @@ async function main(): Promise<void> {
   if (readEnv("TTFT_UPDATE_BASELINE") === "1") {
     await writeFile(join(OUTPUT_DIR, "baseline.json"), JSON.stringify(results, null, 2));
   }
-  process.stdout.write(
-    `\n\n${summary}\n\nWrote outputs/results-${stamp}.json + summary-${stamp}.md\n`,
-  );
+  process.stdout.write(`\n\n${summary}\n\nWrote ${resultsPath} + summary-${stamp}.md\n`);
 }
 
 await main();

--- a/bench/ttft-metrics.ts
+++ b/bench/ttft-metrics.ts
@@ -1,0 +1,72 @@
+import type { DriverEventInput } from "../src/protocol/events";
+
+export interface StreamingMetrics {
+  interChunkMax: number | null;
+  interChunkP50: number | null;
+  interChunkP95: number | null;
+  outputTokensPerSecond: number | null;
+  pauseOver250MsCount: number;
+  pauseOver500MsCount: number;
+  timePerOutputTokenMs: number | null;
+}
+
+export function percentile(values: number[], percentage: number): number | null {
+  const clean = values.filter((value) => Number.isFinite(value)).toSorted((a, b) => a - b);
+
+  if (clean.length === 0) {
+    return null;
+  }
+
+  const index = Math.min(
+    clean.length - 1,
+    Math.max(0, Math.ceil((percentage / 100) * clean.length) - 1),
+  );
+  return clean[index] ?? null;
+}
+
+export function readOutputTokens(event: DriverEventInput): number | null {
+  if (
+    event.kind !== "usage.updated" ||
+    typeof event.payload !== "object" ||
+    event.payload === null ||
+    Array.isArray(event.payload)
+  ) {
+    return null;
+  }
+
+  const outputTokens = (event.payload as Record<string, unknown>)["outputTokens"];
+  return typeof outputTokens === "number" && Number.isFinite(outputTokens) && outputTokens >= 0
+    ? outputTokens
+    : null;
+}
+
+export function summarizeStreaming(input: {
+  firstTextMs: number | null;
+  outputTokens: number | null;
+  textDeltaTimestamps: number[];
+  totalMs: number | null;
+}): StreamingMetrics {
+  const gaps = input.textDeltaTimestamps
+    .slice(1)
+    .map((timestamp, index) => timestamp - (input.textDeltaTimestamps[index] ?? timestamp));
+  const streamedMs =
+    input.firstTextMs === null || input.totalMs === null
+      ? null
+      : Math.max(0, input.totalMs - input.firstTextMs);
+  const generatedIntervals =
+    input.outputTokens === null || input.outputTokens <= 1 ? null : input.outputTokens - 1;
+  const timePerOutputTokenMs =
+    streamedMs === null || streamedMs <= 0 || generatedIntervals === null
+      ? null
+      : streamedMs / generatedIntervals;
+
+  return {
+    interChunkMax: gaps.length === 0 ? null : Math.max(...gaps),
+    interChunkP50: percentile(gaps, 50),
+    interChunkP95: percentile(gaps, 95),
+    outputTokensPerSecond: timePerOutputTokenMs === null ? null : 1000 / timePerOutputTokenMs,
+    pauseOver250MsCount: gaps.filter((gap) => gap > 250).length,
+    pauseOver500MsCount: gaps.filter((gap) => gap > 500).length,
+    timePerOutputTokenMs,
+  };
+}

--- a/src/bin/driver-process.ts
+++ b/src/bin/driver-process.ts
@@ -12,6 +12,7 @@ import { createDriverHostIntegrationSnapshotFromBootExecution } from "../protoco
 import type { DriverHostIntegrationSnapshot } from "../protocol/host-integration";
 import { parseDriverId } from "../protocol/id";
 import type { RunId } from "../protocol/id";
+import type { DriverRuntimeIdentity } from "../protocol/orpc";
 import { createDriverStartInputFromBootPayload } from "../protocol/start";
 import type { DriverStartInput } from "../protocol/start";
 import type { AgentDriverBackendFactory, AgentDriverContext } from "../core/agent-driver-backend";
@@ -54,6 +55,7 @@ export class DriverProcess {
   readonly #shutdownController = new AbortController();
   readonly #hostSnapshot: DriverHostIntegrationSnapshot;
   readonly #runtimeState = new DriverRuntimeStateMachine("created");
+  readonly #runtimeIdentity: Promise<DriverRuntimeIdentity | undefined>;
   readonly #startInput: DriverStartInput;
   #shutdownReason: string | null = null;
   #shutdownTask: Promise<void> | null = null;
@@ -64,10 +66,12 @@ export class DriverProcess {
     payload: DriverBootPayload,
     backendFactory: AgentDriverBackendFactory = (input) =>
       AGENT_DRIVER_PROVIDER_REGISTRY.createBackend(input),
+    runtimeIdentity?: DriverRuntimeIdentity | PromiseLike<DriverRuntimeIdentity | undefined>,
   ) {
     this.#backendFactory = backendFactory;
     this.payload = payload;
     this.#hostSnapshot = createDriverHostIntegrationSnapshotFromBootExecution(payload.execution);
+    this.#runtimeIdentity = Promise.resolve(runtimeIdentity);
     this.#startInput = createDriverStartInputFromBootPayload(payload);
     this.#permissionBroker = new DriverPermissionBroker(() => this.#logger);
     this.#heartbeatLoop = new DriverHeartbeatLoop({
@@ -99,6 +103,7 @@ export class DriverProcess {
     try {
       await socket.connect();
       this.#shutdownController.signal.throwIfAborted();
+      const runtimeIdentity = await this.#runtimeIdentity;
 
       const { logger, uplink } = createDriverLogger(this.payload, socket);
       this.#logger = logger;
@@ -124,6 +129,7 @@ export class DriverProcess {
             capabilities: [...capabilities],
             driverVersion: AGENT_DRIVER_VERSION,
             protocolVersion: DRIVER_PROTOCOL_VERSION,
+            ...(runtimeIdentity === undefined ? {} : { runtimeIdentity }),
             startedAt: this.#startedAt,
           }),
         );

--- a/src/bin/driver.ts
+++ b/src/bin/driver.ts
@@ -3,6 +3,7 @@
 import { readDriverBootPayload } from "../boot/read-driver-boot-payload";
 import { DriverProcess } from "./driver-process";
 import { logDriverFatal } from "../infrastructure/logging/driver-logger";
+import { captureDriverRuntimeIdentity } from "../infrastructure/runtime/driver-runtime-identity";
 import { isSupportedDriverRuntime, isSupportedDriverRuntimeTransport } from "../protocol/runtime";
 
 async function main(): Promise<void> {
@@ -16,7 +17,13 @@ async function main(): Promise<void> {
     throw new Error(`Unsupported runtime transport: ${String(payload.runtimeTransport)}.`);
   }
 
-  const driver = new DriverProcess(payload);
+  const driver = new DriverProcess(
+    payload,
+    undefined,
+    captureDriverRuntimeIdentity({
+      bundlePath: process.argv[1] ?? "",
+    }),
+  );
   await driver.run();
 }
 

--- a/src/infrastructure/runtime/driver-instance-socket.ts
+++ b/src/infrastructure/runtime/driver-instance-socket.ts
@@ -195,6 +195,7 @@ export class DriverInstanceSocket {
         pid: process.pid,
         protocolVersion: input.protocolVersion,
         runtime: this.payload.runtime,
+        ...(input.runtimeIdentity === undefined ? {} : { runtimeIdentity: input.runtimeIdentity }),
         startedAt: input.startedAt,
       },
       this.#rpcOptions(),

--- a/src/infrastructure/runtime/driver-runtime-identity.ts
+++ b/src/infrastructure/runtime/driver-runtime-identity.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type { DriverRuntimeIdentity } from "../../protocol/orpc";
+
+const CLOUDFLARE_IDENTITY_FIELDS = {
+  containerApplicationId: "CLOUDFLARE_APPLICATION_ID",
+  containerDeploymentId: "CLOUDFLARE_DEPLOYMENT_ID",
+  containerDurableObjectId: "CLOUDFLARE_DURABLE_OBJECT_ID",
+  containerPlacementId: "CLOUDFLARE_PLACEMENT_ID",
+} as const;
+
+type DriverRuntimeEnvironment = Readonly<Record<string, string | undefined>>;
+
+function readCloudflareRuntimeIdentity(
+  environment: DriverRuntimeEnvironment,
+): Omit<DriverRuntimeIdentity, "driverBundleSha256" | "observedAt"> | undefined {
+  const values = Object.entries(CLOUDFLARE_IDENTITY_FIELDS).map(([field, name]) => ({
+    field,
+    value: environment[name]?.trim() ?? "",
+  }));
+
+  if (values.every(({ value }) => value.length === 0)) {
+    return undefined;
+  }
+
+  if (values.some(({ value }) => value.length === 0)) {
+    return undefined;
+  }
+
+  return Object.fromEntries(values.map(({ field, value }) => [field, value])) as Omit<
+    DriverRuntimeIdentity,
+    "driverBundleSha256" | "observedAt"
+  >;
+}
+
+export async function captureDriverRuntimeIdentity(input: {
+  readonly bundlePath: string;
+  readonly environment?: DriverRuntimeEnvironment;
+  readonly now?: () => Date;
+}): Promise<DriverRuntimeIdentity | undefined> {
+  const cloudflare = readCloudflareRuntimeIdentity(input.environment ?? process.env);
+  if (cloudflare === undefined) {
+    return undefined;
+  }
+
+  const bundlePath = input.bundlePath.trim();
+  if (bundlePath.length === 0) {
+    return undefined;
+  }
+
+  let bundle: Uint8Array;
+  try {
+    bundle = await readFile(bundlePath);
+  } catch {
+    // Runtime identity is benchmark evidence, not a Driver availability
+    // dependency. The performance gate fails closed when hello omits it.
+    return undefined;
+  }
+
+  const driverBundleSha256 = createHash("sha256").update(bundle).digest("hex");
+
+  return {
+    ...cloudflare,
+    driverBundleSha256,
+    observedAt: (input.now ?? (() => new Date()))().toISOString(),
+  };
+}

--- a/src/protocol/orpc/index.ts
+++ b/src/protocol/orpc/index.ts
@@ -16,7 +16,17 @@ export interface DriverHelloInput {
   readonly pid: number;
   readonly protocolVersion: DriverBootPayload["protocolVersion"];
   readonly runtime: DriverRuntime;
+  readonly runtimeIdentity?: DriverRuntimeIdentity | undefined;
   readonly startedAt: string;
+}
+
+export interface DriverRuntimeIdentity {
+  readonly containerApplicationId: string;
+  readonly containerDeploymentId: string;
+  readonly containerDurableObjectId: string;
+  readonly containerPlacementId: string;
+  readonly driverBundleSha256: string;
+  readonly observedAt: string;
 }
 
 export interface DriverHelloOutput {
@@ -241,6 +251,22 @@ function readDriverRuntime(record: Record<string, unknown>): DriverRuntime {
   return runtime;
 }
 
+function readDriverRuntimeIdentity(value: unknown): DriverRuntimeIdentity | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const record = readRecord(value, "driver runtime identity");
+  return {
+    containerApplicationId: readNonEmptyString(record, "containerApplicationId"),
+    containerDeploymentId: readNonEmptyString(record, "containerDeploymentId"),
+    containerDurableObjectId: readNonEmptyString(record, "containerDurableObjectId"),
+    containerPlacementId: readNonEmptyString(record, "containerPlacementId"),
+    driverBundleSha256: readNonEmptyString(record, "driverBundleSha256"),
+    observedAt: readNonEmptyString(record, "observedAt"),
+  };
+}
+
 function readHeartbeatReason(value: unknown): DriverHeartbeatInput["reason"] {
   if (value === "interval" || value === "ping") {
     return value;
@@ -313,6 +339,7 @@ function readDriverCapabilities(record: Record<string, unknown>): DriverCapabili
 
 export function parseDriverHelloInput(value: unknown): DriverHelloInput {
   const record = readRecord(value, "driver hello input");
+  const runtimeIdentity = readDriverRuntimeIdentity(record["runtimeIdentity"]);
 
   return {
     capabilities: readDriverCapabilities(record),
@@ -320,6 +347,7 @@ export function parseDriverHelloInput(value: unknown): DriverHelloInput {
     pid: readNumber(record, "pid"),
     protocolVersion: readProtocolVersion(record),
     runtime: readDriverRuntime(record),
+    ...(runtimeIdentity === undefined ? {} : { runtimeIdentity }),
     startedAt: readString(record, "startedAt"),
   };
 }

--- a/tests/driver-instance-socket-process.test.ts
+++ b/tests/driver-instance-socket-process.test.ts
@@ -260,6 +260,34 @@ describe("DriverInstanceSocket lifecycle", () => {
       }),
     ).rejects.toThrow(message);
   });
+
+  test("forwards runtime identity in the hello handshake", async () => {
+    globalThis.WebSocket = RpcWebSocket as unknown as typeof WebSocket;
+    const socket = new DriverInstanceSocket(driverBootPayload, {
+      onClose: () => {},
+    });
+    const runtimeIdentity = {
+      containerApplicationId: "application-1",
+      containerDeploymentId: "deployment-1",
+      containerDurableObjectId: "do-1",
+      containerPlacementId: "placement-1",
+      driverBundleSha256: "a".repeat(64),
+      observedAt: "2026-07-19T00:00:00.000Z",
+    };
+    await socket.connect();
+    await socket.hello({
+      capabilities: [],
+      driverVersion: "test",
+      protocolVersion: driverBootPayload.protocolVersion,
+      runtimeIdentity,
+      startedAt: new Date(0).toISOString(),
+    });
+
+    expect((PendingWebSocket.instances[0] as RpcWebSocket).requests[0]).toEqual({
+      input: expect.objectContaining({ runtimeIdentity }),
+      path: "/driver/hello",
+    });
+  });
 });
 
 describe("DriverProcess lifecycle", () => {

--- a/tests/driver-runtime-identity.test.ts
+++ b/tests/driver-runtime-identity.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { captureDriverRuntimeIdentity } from "../src/infrastructure/runtime/driver-runtime-identity";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("Driver runtime identity", () => {
+  test("attests the running bundle and Cloudflare container identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-driver-identity-"));
+    temporaryRoots.push(root);
+    const bundlePath = join(root, "agent-driver");
+    await writeFile(bundlePath, "driver bundle");
+
+    await expect(
+      captureDriverRuntimeIdentity({
+        bundlePath,
+        environment: {
+          CLOUDFLARE_APPLICATION_ID: "application-1",
+          CLOUDFLARE_DEPLOYMENT_ID: "deployment-1",
+          CLOUDFLARE_DURABLE_OBJECT_ID: "do-1",
+          CLOUDFLARE_PLACEMENT_ID: "placement-1",
+        },
+        now: () => new Date("2026-07-19T00:00:00.000Z"),
+      }),
+    ).resolves.toEqual({
+      containerApplicationId: "application-1",
+      containerDeploymentId: "deployment-1",
+      containerDurableObjectId: "do-1",
+      containerPlacementId: "placement-1",
+      driverBundleSha256: "3a16fdd3a4b15ea20f534e87f6915425f00a84564a04b85237efa8abf00474af",
+      observedAt: "2026-07-19T00:00:00.000Z",
+    });
+  });
+
+  test("does no bundle I/O outside Cloudflare or with partial platform identity", async () => {
+    await expect(
+      captureDriverRuntimeIdentity({
+        bundlePath: "/does/not/exist",
+        environment: {},
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      captureDriverRuntimeIdentity({
+        bundlePath: "/does/not/exist",
+        environment: { CLOUDFLARE_APPLICATION_ID: "application-1" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not make Driver availability depend on identity attestation I/O", async () => {
+    await expect(
+      captureDriverRuntimeIdentity({
+        bundlePath: "/does/not/exist",
+        environment: {
+          CLOUDFLARE_APPLICATION_ID: "application-1",
+          CLOUDFLARE_DEPLOYMENT_ID: "deployment-1",
+          CLOUDFLARE_DURABLE_OBJECT_ID: "do-1",
+          CLOUDFLARE_PLACEMENT_ID: "placement-1",
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/public-api-exports.snapshot.json
+++ b/tests/public-api-exports.snapshot.json
@@ -498,7 +498,8 @@
       "DriverNextCommandOutput",
       "DriverReadyInput",
       "DriverRpcOptions",
-      "DriverRuntimeClient"
+      "DriverRuntimeClient",
+      "DriverRuntimeIdentity"
     ],
     "values": ["parseDriverHeartbeatInput", "parseDriverHelloInput", "parseDriverReadyInput"]
   },

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -83,11 +83,20 @@ describe("public API", () => {
         pid: 1,
         protocolVersion: 1,
         runtime: "openai-runtime",
+        runtimeIdentity: {
+          containerApplicationId: "application-1",
+          containerDeploymentId: "deployment-1",
+          containerDurableObjectId: "do-1",
+          containerPlacementId: "placement-1",
+          driverBundleSha256: "a".repeat(64),
+          observedAt: "2026-07-19T00:00:00.000Z",
+        },
         startedAt: "now",
       }),
     ).toMatchObject({
       driverVersion: "0.1.0",
       runtime: "openai-runtime",
+      runtimeIdentity: { containerDeploymentId: "deployment-1" },
     });
     expect(
       parseDriverReadyInputFromOrpcSubpath({

--- a/tests/ttft-metrics.test.ts
+++ b/tests/ttft-metrics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { readOutputTokens, summarizeStreaming } from "../bench/ttft-metrics";
+
+describe("TTFT streaming metrics", () => {
+  test("measures only visible-text cadence and provider output throughput", () => {
+    expect(
+      summarizeStreaming({
+        firstTextMs: 100,
+        outputTokens: 5,
+        textDeltaTimestamps: [100, 120, 400, 920],
+        totalMs: 1100,
+      }),
+    ).toEqual({
+      interChunkMax: 520,
+      interChunkP50: 280,
+      interChunkP95: 520,
+      outputTokensPerSecond: 4,
+      pauseOver250MsCount: 2,
+      pauseOver500MsCount: 1,
+      timePerOutputTokenMs: 250,
+    });
+  });
+
+  test("reads output tokens only from valid usage events", () => {
+    expect(
+      readOutputTokens({
+        kind: "usage.updated",
+        payload: { outputTokens: 42 },
+      }),
+    ).toBe(42);
+    expect(readOutputTokens({ kind: "message.delta", payload: { outputTokens: 42 } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- attest the running Driver bundle and Cloudflare Container identity in the hello handshake
- extend the existing TTFT benchmark exporter with provider-direct first text, cadence, throughput, and exact-output provenance
- keep identity attestation best-effort so Driver availability is unchanged

This is the Driver dependency for the Mosoo Runtime E2E Scoreboard infrastructure PR. It is intentionally based on `fix/openai-app-server-init-stop-race`, the Driver revision already pinned by Mosoo, so ACP lifecycle fixes are not counted as Scoreboard changes.

## Validation

- `bun run tc`
- `bun run build`
- `bun test tests/driver-runtime-identity.test.ts tests/ttft-metrics.test.ts tests/driver-instance-socket-process.test.ts tests/public-api.test.ts` (28 passed)
- `bun test tests/public-api-exports.test.ts` (1 passed)

The unchanged ACP filesystem test still fails locally on macOS because `mkdtemp` reports `/var/...` while `realpath` emits `/private/var/...`; this branch does not modify that code or test. No live provider benchmark was run for this infrastructure-only change.
