### PR TITLE
perf(container): slim bundled runtime packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,14 +2,13 @@ FROM cloudflare/sandbox:0.12.3
 
 # Keep the default base image version in sync with apps/api/package.json -> @cloudflare/sandbox.
 ARG CLAUDE_AGENT_SDK_VERSION=0.3.211
-ARG ANTHROPIC_SDK_VERSION=0.111.0
 ARG OPENAI_RUNTIME_VERSION=0.144.5
 ARG OPENCODE_VERSION=1.18.4
 
 # Environment package setup invokes `pip`, so the runtime image must provide it.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-pip python-is-python3 \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/cache/apt/* /var/lib/apt/lists/* \
     && python --version \
     && pip --version
 
@@ -22,22 +21,29 @@ RUN apt-get update \
 #   opencode-ai                           -> opencode         -> acp-fallback
 #   bun (base image)                      -> bun              -> driver launcher
 #
-# Pick the architecture-specific `claude` binary that npm just installed under
-# `@anthropic-ai/claude-agent-sdk-<linux-x64|linux-arm64>` so the image works
-# on CF Containers (linux/amd64) and local arm64 hosts (e.g. Apple Silicon)
-# without forcing platform emulation.
-RUN OPENAI_RUNTIME_PACKAGE="@openai/codex@${OPENAI_RUNTIME_VERSION}" \
+# Install only the native Claude and OpenCode packages needed at runtime. The
+# Driver bundle already contains the Claude SDK, while the x64 OpenCode baseline
+# binary stays compatible with container hosts that do not expose AVX2.
+RUN CLAUDE_ARCH_PACKAGE="$(node -p "'@anthropic-ai/claude-agent-sdk-linux-' + process.arch")" \
+    && OPENCODE_ARCH_PACKAGE="$(node -p "'opencode-linux-' + process.arch + (process.arch === 'x64' ? '-baseline' : '')")" \
+    && OPENAI_RUNTIME_PACKAGE="@openai/codex@${OPENAI_RUNTIME_VERSION}" \
     && npm install -g \
-      @anthropic-ai/claude-agent-sdk@${CLAUDE_AGENT_SDK_VERSION} \
-      @anthropic-ai/sdk@${ANTHROPIC_SDK_VERSION} \
-      opencode-ai@${OPENCODE_VERSION} \
+      "${CLAUDE_ARCH_PACKAGE}@${CLAUDE_AGENT_SDK_VERSION}" \
       "$OPENAI_RUNTIME_PACKAGE" \
+    && npm install -g --ignore-scripts --omit=optional \
+      opencode-ai@${OPENCODE_VERSION} \
+      "${OPENCODE_ARCH_PACKAGE}@${OPENCODE_VERSION}" \
+    && OPENCODE_PACKAGE_ROOT=/usr/local/lib/node_modules/opencode-ai \
+    && OPENCODE_BIN="/usr/local/lib/node_modules/${OPENCODE_ARCH_PACKAGE}/bin/opencode" \
+    && test -x "$OPENCODE_BIN" \
+    && mkdir -p "$OPENCODE_PACKAGE_ROOT/bin" \
+    && ln -f "$OPENCODE_BIN" "$OPENCODE_PACKAGE_ROOT/bin/opencode.exe" \
+    && rm -rf "$OPENCODE_PACKAGE_ROOT/node_modules" \
     && codex --version \
     && codex app-server --help >/dev/null \
     && opencode --version \
     && opencode acp --help >/dev/null \
-    && CLAUDE_ARCH_PACKAGE="$(node -p "'@anthropic-ai/claude-agent-sdk-' + (process.arch === 'arm64' ? 'linux-arm64' : 'linux-x64')")" \
-    && CLAUDE_BIN="/usr/local/lib/node_modules/@anthropic-ai/claude-agent-sdk/node_modules/${CLAUDE_ARCH_PACKAGE}/claude" \
+    && CLAUDE_BIN="/usr/local/lib/node_modules/${CLAUDE_ARCH_PACKAGE}/claude" \
     && test -x "$CLAUDE_BIN" \
     && ln -sf "$CLAUDE_BIN" /usr/local/bin/mosoo-claude-code \
     && npm cache clean --force


### PR DESCRIPTION
## Summary

- install only the architecture-specific Claude native package; the Driver bundle remains the single Claude SDK copy
- install the OpenCode wrapper without optional native packages and retain one compatible platform binary
- clean apt/npm caches while keeping Codex, Claude Code, and OpenCode fully preinstalled
- keep warm-pool work out of scope

## Why

The universal sandbox image included duplicate SDK and optional native packages. Fresh cattle containers pay that weight during image distribution and pool refill. This removes the duplicates without moving installation into the user-visible first-run path.

Refs langgenius/mosoo#387.

## Measured evidence

- Docker image size: 1,791,427,776 B -> 1,451,690,537 B (-339.7 MB, -18.96%)
- network-disabled container smoke passed for `codex app-server`, `opencode acp`, and `mosoo-claude-code`
- local cached fresh-container smoke, 5 paired runs, median container start through all three CLI checks: 3.69 s -> 3.44 s (-0.25 s, -6.8%)

The local timing is a regression check, not a Cloudflare TTFT claim. Registry pull time and Cloudflare cattle first-request latency require a staging A/B with the published image.

## Validation

- `vp run tc` — passed
- `vp run build` — passed (312 modules, 2.91 MB bundle)
- `docker build -f Containerfile -t mosoo-p0-9-pr:local .` — passed
- network-disabled three-runtime smoke — passed
- `vp run test` — 1,080 passed, 42 live tests skipped, 1 unrelated macOS `/var` vs `/private/var` path assertion failed
- `vp run check` — reports 84 pre-existing formatting failures in integration-branch TypeScript/test files; `Containerfile` is not among them

## Risk / not verified

- production Cloudflare pull, cattle startup, and first usable request were not measured locally
- the exact image was built with Docker because Buildah is unavailable on this host
- the production image is linux/amd64 and was exercised through OrbStack on an arm64 host
