### PR TITLE
fix(openai): route app server through proxy base URL

### DIFF
--- a/src/runtimes/openai/auth-state.ts
+++ b/src/runtimes/openai/auth-state.ts
@@ -32,6 +32,7 @@ interface OpenAiModelProviderConfigResult {
 const OPENAI_COMPATIBLE_PROVIDER_ID = "openai-compatible";
 const OPENAI_COMPATIBLE_API_KEY_ENV_NAME = "OPENAI_COMPATIBLE_API_KEY";
 const OPENAI_COMPATIBLE_BASE_URL_ENV_NAME = "OPENAI_COMPATIBLE_BASE_URL";
+const OPENAI_BASE_URL_ENV_NAME = "OPENAI_BASE_URL";
 const DISABLED_RUNTIME_FEATURES = ["plugins", "remote_plugin", "tool_suggest"] as const;
 
 function readOpenAiApiKey(env: NodeJS.ProcessEnv): string | null {
@@ -209,6 +210,12 @@ export async function materializeOpenAiModelProviderConfig(
         wire_api: "responses",
       },
     };
+  } else if (input.provider === "openai") {
+    const baseUrl = readEnvVar(input.env, OPENAI_BASE_URL_ENV_NAME);
+
+    if (baseUrl !== null) {
+      generatedConfig["openai_base_url"] = baseUrl;
+    }
   }
 
   if (input.mcpServers !== undefined && Object.keys(input.mcpServers).length > 0) {

--- a/tests/openai-app-server-auth-state.test.ts
+++ b/tests/openai-app-server-auth-state.test.ts
@@ -111,6 +111,7 @@ describe("OpenAI app-server auth state", () => {
     const result = await materializeOpenAiModelProviderConfig({
       env: {
         OPENAI_API_KEY: "openai-key",
+        OPENAI_BASE_URL: "https://proxy.example/v1",
       },
       provider: "openai",
       runtimeHome,
@@ -121,6 +122,7 @@ describe("OpenAI app-server auth state", () => {
 
     expect(config["model_provider"]).toBeUndefined();
     expect(config["model_providers"]).toBeUndefined();
+    expect(config["openai_base_url"]).toBe("https://proxy.example/v1");
     expectDisabledRuntimeFeatures(config);
   });
 


### PR DESCRIPTION
## Summary

- materialize OPENAI_BASE_URL as Codex openai_base_url
- keep direct OpenAI runs without a custom base URL unchanged
- cover the proxy routing setting in the existing auth-state test

## Verification

- vp exec bun test tests/openai-app-server-auth-state.test.ts (8 pass)
- vp check src/runtimes/openai/auth-state.ts
- vp check --no-lint tests/openai-app-server-auth-state.test.ts
- vp run tc
- vp run build
- full Driver suite on macOS: 1202 pass, 11 unrelated process-watchdog failures already present on current main; focused watchdog file reproduces independently

No generated files, migrations, or lockfile changes.