### PR TITLE
fix(runtime): allow slow terminal status responses

### DIFF
--- a/src/core/driver-command-delivery.ts
+++ b/src/core/driver-command-delivery.ts
@@ -11,7 +11,7 @@ import type { DriverRuntimeIo } from "./driver-runtime-io";
 
 const MAX_TRACKED_COMMANDS = 1_024;
 const COMMAND_UPDATE_TIMEOUT_MS = 1_000;
-const TERMINAL_UPDATE_ATTEMPT_TIMEOUT_MS = 250;
+const RUN_TERMINAL_UPDATE_ATTEMPT_TIMEOUT_MS = 250;
 const TERMINAL_UPDATE_MAX_ATTEMPTS = 3;
 
 export interface TerminalCommandUpdate {
@@ -266,13 +266,12 @@ export class DriverCommandDelivery {
         break;
       }
 
-      const timeoutMs = Math.min(remainingMs, TERMINAL_UPDATE_ATTEMPT_TIMEOUT_MS);
       const controller = new AbortController();
       const delivery = await settlePromiseWithTimeout(
         sendCommandUpdate(runtimeContext, command, terminal, controller.signal),
         {
           label: `Driver command ${command.commandId} terminal status delivery`,
-          timeoutMs,
+          timeoutMs: remainingMs,
         },
       );
 
@@ -317,7 +316,7 @@ export async function deliverRunTerminal(
       ),
       {
         label: `Driver run ${terminal.status} terminal delivery`,
-        timeoutMs: Math.min(remainingMs, TERMINAL_UPDATE_ATTEMPT_TIMEOUT_MS),
+        timeoutMs: Math.min(remainingMs, RUN_TERMINAL_UPDATE_ATTEMPT_TIMEOUT_MS),
       },
     );
 

--- a/tests/driver-runtime-boundary-dispatcher.test.ts
+++ b/tests/driver-runtime-boundary-dispatcher.test.ts
@@ -647,14 +647,14 @@ describe("driver runtime boundary", () => {
     );
     await logger.destroy();
 
-    expect(terminalAttempts).toBe(3);
+    expect(terminalAttempts).toBe(1);
     expect(socket.completedRunReasons).toHaveLength(1);
     expect(socket.failedRuns).toEqual([]);
     expect(runtimeState.status()).toBe("failed");
   });
 
   test.each(["input", "mcp"] as const)(
-    "aborts a hung %s terminal attempt before retrying and settling later work",
+    "accepts a slow %s terminal response before settling later work",
     async (kind) => {
       const backend = createBackend();
       let sideEffects = 0;
@@ -694,18 +694,20 @@ describe("driver runtime boundary", () => {
             };
       const socket = new FakeDriverRuntimeIo([first, next]);
       const recordUpdate = socket.commandUpdate.bind(socket);
-      const ackEntered = Promise.withResolvers<void>();
-      let firstSignal: AbortSignal | undefined;
       let terminalAttempts = 0;
       socket.commandUpdate = async (update, signal) => {
         if (update.commandId === first.commandId && update.status !== "accepted") {
           terminalAttempts += 1;
-        }
-        if (update.commandId === first.commandId && terminalAttempts === 1) {
-          firstSignal = signal;
-          ackEntered.resolve();
-          await new Promise<never>((_resolve, reject) => {
-            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(resolve, 300);
+            signal?.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                reject(signal.reason);
+              },
+              { once: true },
+            );
           });
         }
 
@@ -733,16 +735,14 @@ describe("driver runtime boundary", () => {
       });
       const run = dispatcher.run(socket, logger);
 
-      await ackEntered.promise;
       const outcome = await settlePromiseWithTimeout(run, {
-        label: `${kind} terminal acknowledgement retry`,
+        label: `${kind} slow terminal acknowledgement`,
         timeoutMs: 1_500,
       });
       await logger.destroy();
 
       expect(outcome.status).toBe("completed");
-      expect(firstSignal?.aborted).toBe(true);
-      expect(terminalAttempts).toBe(2);
+      expect(terminalAttempts).toBe(1);
       expect(sideEffects).toBe(kind === "input" ? 2 : 1);
     },
   );


### PR DESCRIPTION
## Summary

- let command terminal RPCs use the existing one-second delivery deadline
- retain immediate retries for explicit transport failures
- keep run terminal retry timing unchanged

## Root cause

Each command terminal attempt was aborted after 250ms even though the API could commit the update shortly afterward, causing a false driver failure after a successful run.

## Verification

- bun test tests/driver-runtime-boundary-dispatcher.test.ts
- bun run tc
- bun run check reached 1201 passing tests; macOS process watchdog and /var path-alias tests failed outside this change

No deployment. Companion mosoo submodule pin PR follows.