### PR TITLE
fix(openai): persist complete assistant snapshots

### DIFF
--- a/src/runtimes/openai/app-server-item-events.ts
+++ b/src/runtimes/openai/app-server-item-events.ts
@@ -1,5 +1,5 @@
-import type { DriverEventInput } from "../../protocol/events";
 import type { AgentDriverContext } from "../../core/agent-driver-backend";
+import type { DriverEventInput } from "../../protocol/events";
 import { toOpenAiPlanStatus } from "./app-server-event-mapping";
 import type {
   OpenAiEventPush,
@@ -466,6 +466,15 @@ export class OpenAiAppServerItemEventBridge {
         messageId,
         text: filteredFinalText.text,
         turnId,
+      });
+      events.push({
+        delivery: "lossless",
+        kind: "message.added",
+        payload: {
+          content: filteredFinalText.text,
+          messageId,
+          role: "agent",
+        },
       });
     }
 

--- a/tests/fixtures/providers/openai-app-server/cases/agent-message-completed.json
+++ b/tests/fixtures/providers/openai-app-server/cases/agent-message-completed.json
@@ -31,6 +31,15 @@
       }
     },
     {
+      "delivery": "lossless",
+      "kind": "message.added",
+      "payload": {
+        "content": "pong",
+        "messageId": "<driver-id>",
+        "role": "agent"
+      }
+    },
+    {
       "kind": "message.completed",
       "payload": {
         "messageId": "<driver-id>",

--- a/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
+++ b/tests/fixtures/providers/openai-app-server/cases/turn-completed-with-final-agent-message.json
@@ -52,6 +52,15 @@
       }
     },
     {
+      "delivery": "lossless",
+      "kind": "message.added",
+      "payload": {
+        "content": "pong",
+        "messageId": "<driver-id>",
+        "role": "agent"
+      }
+    },
+    {
       "kind": "message.completed",
       "payload": {
         "messageId": "<driver-id>",

--- a/tests/openai-app-server-event-bridge-run-lifecycle.test.ts
+++ b/tests/openai-app-server-event-bridge-run-lifecycle.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
+import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverEventInput } from "../src/protocol/events";
 import { isDriverId } from "../src/protocol/id";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
-import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { OpenAiAppServerEventBridge } from "../src/runtimes/openai/app-server-event-bridge";
 import { DRIVER_TEST_IDS, driverStartInput as bootPayload } from "./driver-boot-payload-fixture";
 
@@ -87,6 +87,41 @@ function createHarness(options: { failNativeResumePublish?: boolean; holdReason?
 }
 
 describe("OpenAi app-server event bridge", () => {
+  test("publishes a lossless completed assistant snapshot", async () => {
+    const { bridge, context, events, logger } = createHarness();
+    const finalText = "I will inspect the files.";
+
+    await bridge.handleNotification(context, "item/agentMessage/delta", {
+      delta: "I",
+      itemId: "message-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await bridge.handleNotification(context, "item/completed", {
+      item: {
+        id: "message-1",
+        text: finalText,
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await logger.destroy();
+
+    const assistantMessageId = readAssistantMessageId(events());
+    const snapshot = events().find((event) => event.kind === "message.added");
+
+    expect(snapshot).toMatchObject({
+      kind: "message.added",
+      payload: {
+        content: finalText,
+        messageId: assistantMessageId,
+        role: "agent",
+      },
+    });
+    expect(snapshot?.delivery).toBe("lossless");
+  });
+
   test("fails an active turn exactly once when the provider exits", async () => {
     const { bridge, context, events, logger } = createHarness();
     const failure = new Error("app-server exited");
@@ -183,6 +218,15 @@ describe("OpenAi app-server event bridge", () => {
         kind: "message.delta",
         payload: {
           contentDelta: "pong",
+          messageId: assistantMessageId,
+          role: "agent",
+        },
+      },
+      {
+        delivery: "lossless",
+        kind: "message.added",
+        payload: {
+          content: "pong",
           messageId: assistantMessageId,
           role: "agent",
         },

--- a/tests/openai-app-server-event-bridge-terminal.test.ts
+++ b/tests/openai-app-server-event-bridge-terminal.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
+import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverEventInput } from "../src/protocol/events";
 import { isDriverId } from "../src/protocol/id";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
-import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { OpenAiAppServerEventBridge } from "../src/runtimes/openai/app-server-event-bridge";
 import { DRIVER_TEST_IDS } from "./driver-boot-payload-fixture";
 import { driverStartInput as bootPayload } from "./driver-boot-payload-fixture";
@@ -515,6 +515,15 @@ describe("OpenAi app-server event bridge", () => {
         kind: "message.delta",
         payload: {
           contentDelta: "pong",
+          messageId: assistantMessageId,
+          role: "agent",
+        },
+      },
+      {
+        delivery: "lossless",
+        kind: "message.added",
+        payload: {
+          content: "pong",
           messageId: assistantMessageId,
           role: "agent",
         },

--- a/tests/openai-app-server-event-bridge-transcript.test.ts
+++ b/tests/openai-app-server-event-bridge-transcript.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
+import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverEventInput } from "../src/protocol/events";
 import { isDriverId } from "../src/protocol/id";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
-import { createAgentDriverContext } from "../src/core/agent-driver-backend";
 import { OpenAiAppServerEventBridge } from "../src/runtimes/openai/app-server-event-bridge";
 import { DRIVER_TEST_IDS } from "./driver-boot-payload-fixture";
 import { driverStartInput as bootPayload } from "./driver-boot-payload-fixture";
@@ -391,6 +391,15 @@ describe("OpenAi app-server event bridge", () => {
         kind: "message.delta",
         payload: {
           contentDelta: "pong",
+          messageId: assistantMessageId,
+          role: "agent",
+        },
+      },
+      {
+        delivery: "lossless",
+        kind: "message.added",
+        payload: {
+          content: "pong",
           messageId: assistantMessageId,
           role: "agent",
         },


### PR DESCRIPTION
## What changed
- publish the authoritative `item/completed` assistant text as a lossless `message.added` snapshot
- retain best-effort token deltas for live preview
- update bridge and provider contract coverage

## Why
OpenAI token deltas are best-effort. Under uplink backpressure, production retained only the first token of intermediate assistant messages (`I`, `The`, etc.). The provider already supplies the complete text at `item/completed`; publishing that snapshot losslessly lets downstream folding replace any truncated preview with the full message.

## Impact
Every completed OpenAI assistant item now converges to a complete persisted log entry. Messages that never receive a provider completion event can still only expose the streamed prefix.

## Validation
- `bun test tests/openai-app-server-event-bridge-*.test.ts tests/openai-app-server-provider-fixtures.test.ts` (60 pass)
- `bun run tc`
- `bun run build`
- changed-file format check and source lint
- API fold regression suite in the parent repo (16 pass)
