### PR TITLE
fix(acp): decouple update admission from delivery

### DIFF
--- a/src/runtimes/acp/acp-session-update-inbox.ts
+++ b/src/runtimes/acp/acp-session-update-inbox.ts
@@ -22,6 +22,7 @@ export interface AcpSessionUpdateInboxOptions {
 export class AcpSessionUpdateInbox {
   readonly #apply: AcpSessionUpdateInboxOptions["apply"];
   #closed = false;
+  readonly #deliveries = new Set<Promise<void>>();
   #failure: Error | null = null;
   readonly #onFailure: AcpSessionUpdateInboxOptions["onFailure"];
   #pendingBytes = 0;
@@ -88,7 +89,8 @@ export class AcpSessionUpdateInbox {
     this.#pendingCount += 1;
     const gate = this.#updateGate;
     const scope = { replaying: this.#replaying, suppressed: this.#suppressed };
-    const update = this.#tail
+    let delivery = Promise.resolve();
+    const admission = this.#tail
       .then(async () => {
         if (this.#failure !== null) {
           throw this.#failure;
@@ -97,23 +99,28 @@ export class AcpSessionUpdateInbox {
           return;
         }
 
-        await this.#apply(context, notification, scope);
+        delivery = this.#apply(context, notification, scope);
+        this.#deliveries.add(delivery);
+        void delivery
+          .catch((error: unknown) => this.#fail(error))
+          .finally(() => this.#deliveries.delete(delivery));
       })
       .finally(() => {
         this.#pendingBytes -= bytes;
         this.#pendingCount -= 1;
       });
-    this.#tail = update.catch((error: unknown) => this.#fail(error));
-    return update;
+    this.#tail = admission.catch((error: unknown) => this.#fail(error));
+    return admission.then(() => delivery);
   }
 
   async drain(): Promise<void> {
     for (;;) {
       const tail = this.#tail;
       await tail;
+      await Promise.allSettled(this.#deliveries);
       await Promise.resolve();
 
-      if (tail !== this.#tail) {
+      if (tail !== this.#tail || this.#deliveries.size > 0) {
         continue;
       }
 

--- a/tests/acp-client-request-handler.test.ts
+++ b/tests/acp-client-request-handler.test.ts
@@ -259,6 +259,62 @@ describe("ACP client request handler", () => {
     expect(pushedReasons).toEqual(["driver.acp.session.update"]);
   });
 
+  test("does not hold session update admission behind delivery acknowledgement", async () => {
+    const firstDelivery = Promise.withResolvers<void>();
+    const firstAdmitted = Promise.withResolvers<void>();
+    const failures: Error[] = [];
+    const pending: Promise<void>[] = [];
+    const turnEvents = new AcpTurnEventState();
+    let pushes = 0;
+    turnEvents.begin({
+      messageId: "message-1" as never,
+      runId: "run-1" as never,
+      sessionId: "native-session-1",
+    });
+    const handler = new AcpClientRequestHandler({
+      allowedRoots: [],
+      cwd: "/workspace",
+      env: {},
+      isCancelling: () => false,
+      nativeSessionId: () => "native-session-1",
+      onUpdateFailure: (error) => failures.push(error),
+      push: async () => {
+        pushes += 1;
+        if (pushes === 1) {
+          firstAdmitted.resolve();
+          await firstDelivery.promise;
+        }
+      },
+      turnEvents,
+    });
+    const update = (text: string) =>
+      handler.enqueueUpdate({} as never, {
+        sessionId: "native-session-1",
+        update: {
+          content: { text, type: "text" },
+          messageId: text,
+          sessionUpdate: "agent_message_chunk",
+        },
+      });
+    const track = (promise: Promise<void>) => {
+      pending.push(promise);
+      void promise.catch(() => {});
+    };
+
+    track(update("first"));
+    await firstAdmitted.promise;
+    for (let index = 0; index < 1_024; index += 1) {
+      track(update(`queued-${index}`));
+      await Promise.resolve();
+    }
+    firstDelivery.resolve();
+
+    const settled = await Promise.allSettled(pending);
+    expect(settled.every((result) => result.status === "fulfilled")).toBe(true);
+    expect(failures).toEqual([]);
+    expect(pushes).toBe(1_025);
+  });
+
   test("fails every queued update after the first commit failure", async () => {
     const failures: Error[] = [];
     let pushes = 0;


### PR DESCRIPTION
### What changed?

- Decouple ordered ACP session update admission from delivery acknowledgement.
- Keep drain and close waiting for all admitted deliveries.
- Add a regression test covering more than 1,024 updates behind a blocked first delivery.

### Why

A slow lossless delivery acknowledgement currently blocks later ACP notifications until the raw update inbox reaches its hard limit. The event publisher already owns bounded delivery, so the inbox only needs to serialize validation, translation, and admission.

Closes #97.

### Validation

- `bun run tc`
- `bun test tests/acp-client-request-handler.test.ts tests/acp-driver-backend.test.ts` — 44 passed, 1 skipped
- `bun run build`
- `git diff HEAD~1..HEAD --check`

### Known baseline failures

The full `bun test` run still has 11 macOS process-watchdog failures unrelated to the changed inbox and handler paths.