### PR TITLE
fix(runtime): isolate event delivery timeout per lane

### DIFF
--- a/src/runtimes/driver-event-publisher.ts
+++ b/src/runtimes/driver-event-publisher.ts
@@ -218,7 +218,6 @@ export class DriverEventPublisher {
     const queuedEvents = [...this.#pendingEvents, ...entries.flatMap((entry) => entry.events)];
     const remainingLossless = queuedEvents.filter(({ event }) => isLosslessDriverEvent(event));
     const ownerErrors = new Map<symbol, unknown>();
-    const deadline = AbortSignal.timeout(DRIVER_EVENT_DELIVERY_TIMEOUT_MS);
     const reason =
       entries.length === 0
         ? `driver.events.pending.${wakeReason ?? "retry"}`
@@ -255,6 +254,7 @@ export class DriverEventPublisher {
         const sameDelivery = queuedEvents.slice(index, end);
 
         if (lossless) {
+          const deadline = AbortSignal.timeout(DRIVER_EVENT_DELIVERY_TIMEOUT_MS);
           let remaining = sameDelivery;
 
           while (remaining.length > 0) {
@@ -303,6 +303,7 @@ export class DriverEventPublisher {
             }
           }
         } else {
+          const deadline = AbortSignal.timeout(DRIVER_EVENT_DELIVERY_TIMEOUT_MS);
           try {
             const events = sameDelivery.map(({ event }) => event);
             const result = await context.ports.eventSink.pushEvents({

--- a/tests/driver-event-publisher-admission.test.ts
+++ b/tests/driver-event-publisher-admission.test.ts
@@ -372,17 +372,25 @@ describe("DriverEventPublisher", () => {
     await context.logger.destroy();
   });
 
-  test("shares one overall deadline across a mixed-delivery push", async () => {
+  test("does not let a timed-out best-effort lane poison later lossless delivery", async () => {
     const nativeTimeout = AbortSignal.timeout;
     const signals: (AbortSignal | undefined)[] = [];
-    let timeouts = 0;
+    const controllers: AbortController[] = [];
     AbortSignal.timeout = () => {
-      timeouts += 1;
-      return new AbortController().signal;
+      const controller = new AbortController();
+      controllers.push(controller);
+      return controller.signal;
     };
     const context = createContext({
       pushEvents: async (events, signal) => {
         signals.push(signal);
+        signal?.throwIfAborted();
+
+        if (signals.length === 1) {
+          controllers[0]!.abort(new DOMException("The operation timed out.", "TimeoutError"));
+          signal?.throwIfAborted();
+        }
+
         return {
           accepted: events.map((event, index) => ({
             eventId: event.sourceEventId,
@@ -407,8 +415,8 @@ describe("DriverEventPublisher", () => {
 
     expect(signals).toHaveLength(3);
     expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
-    expect(new Set(signals).size).toBe(1);
-    expect(timeouts).toBe(1);
+    expect(new Set(signals).size).toBe(3);
+    expect(controllers).toHaveLength(3);
   });
 
   test("freezes the active run before a queued partial delivery", async () => {


### PR DESCRIPTION
### What's changed?

- Create a fresh `AbortSignal.timeout` for each same-delivery batch (lossless and best-effort) instead of one overall deadline for the whole `#deliver` wake.
- Update the mixed-delivery test so a timed-out best-effort lane cannot abort later lossless delivery in the same push.

### Why

- A shared deadline meant a best-effort timeout aborted the signal still used by later lossless lanes, so lossless events could fail even when their own delivery was still within budget.

## Considered and deferred

- src/runtimes/driver-event-publisher.ts:257 [BOT-NIT]: Multi-lane wall time can grow as N * DRIVER_EVENT_DELIVERY_TIMEOUT_MS after isolation; intentional vs shared-deadline poisoning. Not changing.
- tests/driver-event-publisher-admission.test.ts:416 [BOT-NIT]: Asserts distinct per-lane signals rather than explicit later-lane receipts; three completed pushes already prove post-timeout progress. Not changing.