### PR TITLE
feat(acp): expose materialized skills to native skill discovery

### DIFF
--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -28,6 +28,7 @@ import {
   computeRuntimeBootstrapDigest,
   writeSkillBootstrapArtifacts,
 } from "../skill-bootstrap";
+import { exposeNativeSkillAliases } from "../skill-materialization";
 import { startAcpAgentProcess, stopAcpAgentProcess } from "./acp-agent-process";
 import type { AcpAgentProcess } from "./acp-agent-process";
 import { AcpClientRequestHandler } from "./acp-client-request-handler";
@@ -119,6 +120,10 @@ export class AcpDriverBackend implements AgentDriverBackend {
       context.ports.skill.materialize(this.#payload.execution),
       signal,
     );
+    const nativeSkillAliases = await raceWithAbort(
+      exposeNativeSkillAliases(this.#payload.execution, context.logger, materializedSkills),
+      signal,
+    );
     const bootstrapArtifacts = await raceWithAbort(
       writeSkillBootstrapArtifacts(this.#payload.execution),
       signal,
@@ -162,6 +167,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
           sharedRootPath: summarizePath(this.#payload.execution.session.sharedRootPath),
         },
         nativeResumeRefPresent: this.#nativeSessionId !== null,
+        nativeSkillAliasCount: nativeSkillAliases.length,
         skillCount: materializedSkills.length,
       });
     } catch (error) {

--- a/src/runtimes/skill-materialization.ts
+++ b/src/runtimes/skill-materialization.ts
@@ -1,5 +1,16 @@
 import { createHash } from "node:crypto";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 
 import type { AgentDriverMaterializedSkill } from "../host-ports";
@@ -13,6 +24,7 @@ export type MaterializedSkill = AgentDriverMaterializedSkill;
 
 const MAX_SKILL_ENTRY_BYTES = 2 * 1024 * 1024;
 const MAX_SKILL_UNCOMPRESSED_BYTES = 25 * 1024 * 1024;
+const NATIVE_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const SKILL_ARCHIVE_EXTRACT_OPTIONS: SkillArchiveExtractOptions = {
   maxEntryCount: 256,
   maxFileBytes: MAX_SKILL_ENTRY_BYTES,
@@ -55,6 +67,120 @@ function enforceSkillMountPath(sessionOrganizationPath: string, mountPath: strin
   ) {
     throw new Error(`Resolved skill mount path is outside the allowed root: ${mountPath}.`);
   }
+}
+
+async function ensureNativeSkillDirectory(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+
+    if (!stats.isDirectory()) {
+      throw new Error(`Native skill alias root is not a directory: ${path}.`);
+    }
+  } catch (error) {
+    if (isRecord(error) && error["code"] === "ENOENT") {
+      await mkdir(path);
+      return;
+    }
+
+    throw error;
+  }
+}
+
+function isManagedNativeSkillAliasTarget(sharedRootPath: string, target: string): boolean {
+  try {
+    enforceSkillMountPath(sharedRootPath, target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function exposeNativeSkillAliases(
+  execution: DriverExecutionInput,
+  logger: Logger,
+  materializedSkills: readonly MaterializedSkill[],
+): Promise<string[]> {
+  const desired = new Map<string, MaterializedSkill>();
+
+  for (const skill of materializedSkills) {
+    if (skill.skillName.length > 64 || !NATIVE_SKILL_NAME_PATTERN.test(skill.skillName)) {
+      logger.warn("driver.skill.native_alias.skipped", {
+        reason: "invalid_name",
+        skillId: skill.skillId,
+        skillName: skill.skillName,
+      });
+      continue;
+    }
+    if (desired.has(skill.skillName)) {
+      logger.warn("driver.skill.native_alias.skipped", {
+        reason: "duplicate_name",
+        skillId: skill.skillId,
+        skillName: skill.skillName,
+      });
+      continue;
+    }
+
+    enforceSkillMountPath(execution.session.sharedRootPath, skill.mountPath);
+    if (resolve(skill.skillMarkdownPath) !== resolve(skill.mountPath, "SKILL.md")) {
+      throw new Error(`Native skill path mismatch for "${skill.skillName}".`);
+    }
+    desired.set(skill.skillName, skill);
+  }
+
+  for (const skill of desired.values()) {
+    const stats = await lstat(skill.skillMarkdownPath);
+
+    if (!stats.isFile()) {
+      throw new Error(`Native skill "${skill.skillName}" does not contain SKILL.md.`);
+    }
+  }
+
+  const agentsRoot = join(execution.session.sharedRootPath, ".agents");
+  const aliasRoot = join(agentsRoot, "skills");
+  await ensureNativeSkillDirectory(agentsRoot);
+  await ensureNativeSkillDirectory(aliasRoot);
+
+  const staleAliases: string[] = [];
+  const retainedAliases = new Set<string>();
+  const entries = (await readdir(aliasRoot, { withFileTypes: true })).toSorted((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  for (const entry of entries) {
+    const aliasPath = join(aliasRoot, entry.name);
+    const skill = desired.get(entry.name);
+
+    if (entry.isSymbolicLink()) {
+      const target = resolve(aliasRoot, await readlink(aliasPath));
+
+      if (skill !== undefined && target === resolve(skill.mountPath)) {
+        retainedAliases.add(entry.name);
+        continue;
+      }
+      if (isManagedNativeSkillAliasTarget(execution.session.sharedRootPath, target)) {
+        staleAliases.push(aliasPath);
+        continue;
+      }
+    }
+
+    if (skill !== undefined) {
+      throw new Error(`Native skill alias "${entry.name}" collides with an existing path.`);
+    }
+  }
+
+  await Promise.all(staleAliases.map((aliasPath) => unlink(aliasPath)));
+
+  const aliasPaths: string[] = [];
+  for (const [skillName, skill] of desired) {
+    const aliasPath = join(aliasRoot, skillName);
+    aliasPaths.push(aliasPath);
+
+    if (!retainedAliases.has(skillName)) {
+      await symlink(relative(aliasRoot, resolve(skill.mountPath)), aliasPath, "dir");
+    }
+  }
+
+  return aliasPaths;
 }
 
 export async function materializeResolvedSkills(

--- a/tests/opencode-acp-contract.test.ts
+++ b/tests/opencode-acp-contract.test.ts
@@ -6,10 +6,10 @@ import {
   ndJsonStream,
 } from "@agentclientprotocol/sdk";
 import type { ClientConnection } from "@agentclientprotocol/sdk";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
@@ -21,12 +21,42 @@ import {
 } from "../src/runtimes/acp/acp-configuration";
 import { limitAcpInput } from "../src/runtimes/acp/acp-input-limit";
 import { setupAcpSession } from "../src/runtimes/acp/acp-session-setup";
+import { createBufferedSinkLogger } from "../src/observability";
+import { exposeNativeSkillAliases } from "../src/runtimes/skill-materialization";
 import type { DriverStartInput } from "../src/protocol/start";
 import { settlePromiseWithTimeout } from "../src/utils/async";
 import { driverBootPayload, driverStartInput } from "./driver-boot-payload-fixture";
 
 const OPENCODE_COMMAND = resolve(process.cwd(), "node_modules", ".bin", "opencode");
 const REQUEST_TIMEOUT_MS = 10_000;
+
+function discoverOpenCodeSkills(
+  cwd: string,
+  homePath: string,
+): {
+  location: string;
+  name: string;
+}[] {
+  const result = spawnSync(OPENCODE_COMMAND, ["debug", "skill", "--pure"], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      HOME: homePath,
+      OPENCODE_TEST_HOME: homePath,
+      PATH: process.env["PATH"] ?? "",
+      XDG_CACHE_HOME: join(homePath, ".cache"),
+      XDG_CONFIG_HOME: join(homePath, ".config"),
+      XDG_DATA_HOME: join(homePath, ".local", "share"),
+      XDG_STATE_HOME: join(homePath, ".local", "state"),
+    },
+    timeout: REQUEST_TIMEOUT_MS,
+  });
+
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout) as { location: string; name: string }[];
+}
 
 async function requestWithTimeout<T>(
   connection: ClientConnection,
@@ -170,6 +200,69 @@ test("OpenCode creates a session after unadvertised additional directories are d
     expect(setup.droppedAdditionalDirectories).toEqual([additionalDirectory]);
   } finally {
     await stopOpenCode(connection, child, closed);
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("OpenCode discovers a materialized native skill before its first process starts", async () => {
+  expect(existsSync(OPENCODE_COMMAND)).toBe(true);
+
+  const root = await mkdtemp(join(tmpdir(), "agent-driver-opencode-skill-contract-"));
+  const homePath = join(root, "home");
+  const mountPath = join(root, ".mosoo", "skill", "skill-1");
+  const skillMarkdownPath = join(mountPath, "SKILL.md");
+  await Promise.all([homePath, mountPath].map((path) => mkdir(path, { recursive: true })));
+  await writeFile(
+    skillMarkdownPath,
+    `---
+name: review
+description: Review code changes.
+---
+
+Check the diff.`,
+    "utf8",
+  );
+  const execution = {
+    ...driverStartInput.execution,
+    session: {
+      ...driverStartInput.execution.session,
+      cwd: root,
+      homePath,
+      sharedRootPath: root,
+    },
+  };
+  const logger = createBufferedSinkLogger({
+    level: "debug",
+    service: "opencode-acp-contract-test",
+    sink: async () => {},
+  });
+
+  try {
+    await exposeNativeSkillAliases(execution, logger, [
+      {
+        mountPath,
+        skillId: "skill-1",
+        skillMarkdownPath,
+        skillName: "review",
+        snapshotId: "snapshot-1",
+      },
+    ]);
+
+    const expectedSkillPath = join(await realpath(root), ".agents", "skills", "review", "SKILL.md");
+    expect(discoverOpenCodeSkills(root, homePath)).toContainEqual(
+      expect.objectContaining({
+        location: expectedSkillPath,
+        name: "review",
+      }),
+    );
+
+    await exposeNativeSkillAliases(execution, logger, []);
+
+    expect(discoverOpenCodeSkills(root, homePath).some((skill) => skill.name === "review")).toBe(
+      false,
+    );
+  } finally {
+    await logger.destroy();
     await rm(root, { force: true, recursive: true });
   }
 });

--- a/tests/skill-materialization.test.ts
+++ b/tests/skill-materialization.test.ts
@@ -1,14 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { AgentDriverMaterializedSkill } from "../src/host-ports";
 import { createBufferedSinkLogger } from "../src/observability";
 import type { DriverResolvedSkill } from "../src/protocol/boot";
 import type { DriverExecutionInput } from "../src/protocol/execution";
-import { materializeResolvedSkills } from "../src/runtimes/skill-materialization";
+import {
+  exposeNativeSkillAliases,
+  materializeResolvedSkills,
+} from "../src/runtimes/skill-materialization";
 import { createZipArchive } from "../src/skill-package";
 import type { SkillPackageEntry } from "../src/skill-package";
 import { bootPayload } from "./driver-runtime-boundary-fixtures";
@@ -52,6 +65,14 @@ function createSkill(root: string, archive: Uint8Array): DriverResolvedSkill {
   };
 }
 
+function createTestLogger() {
+  return createBufferedSinkLogger({
+    level: "debug",
+    service: "skill-materialization-test",
+    sink: async () => {},
+  });
+}
+
 function createMarkdownSkillEntries(markdown: string): SkillPackageEntry[] {
   return [
     {
@@ -66,11 +87,7 @@ function createMarkdownSkillEntries(markdown: string): SkillPackageEntry[] {
 describe("skill materialization", () => {
   test("extracts a resolved skill under the session skill root", async () => {
     const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
-    const logger = createBufferedSinkLogger({
-      level: "debug",
-      service: "skill-materialization-test",
-      sink: async () => {},
-    });
+    const logger = createTestLogger();
     const archive = createZipArchive(
       createMarkdownSkillEntries(`---
 name: review
@@ -102,11 +119,7 @@ Check the diff.`),
 
   test("rejects skill mounts outside the session skill root", async () => {
     const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
-    const logger = createBufferedSinkLogger({
-      level: "debug",
-      service: "skill-materialization-test",
-      sink: async () => {},
-    });
+    const logger = createTestLogger();
     const archive = createZipArchive(
       createMarkdownSkillEntries(`---
 name: review
@@ -132,11 +145,7 @@ Check the diff.`),
 
   test("fails malformed packages before reporting materialization success", async () => {
     const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
-    const logger = createBufferedSinkLogger({
-      level: "debug",
-      service: "skill-materialization-test",
-      sink: async () => {},
-    });
+    const logger = createTestLogger();
     const archive = createZipArchive([
       {
         body: textEncoder.encode("missing skill markdown"),
@@ -151,6 +160,169 @@ Check the diff.`),
       await expect(materializeResolvedSkills(createExecution(root, skill), logger)).rejects.toThrow(
         "does not contain SKILL.md",
       );
+    } finally {
+      await logger.destroy();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("exposes a relative native alias and removes it when the skill becomes unavailable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
+    const logger = createTestLogger();
+    const archive = createZipArchive(
+      createMarkdownSkillEntries(`---
+name: review
+description: Review code changes.
+---
+
+Check the diff.`),
+    );
+    const execution = createExecution(root, createSkill(root, archive));
+    const aliasPath = join(root, ".agents", "skills", "review");
+
+    try {
+      const materialized = await materializeResolvedSkills(execution, logger);
+
+      await exposeNativeSkillAliases(execution, logger, materialized);
+
+      await expect(readlink(aliasPath)).resolves.toBe("../../.mosoo/skill/review");
+      await expect(readFile(join(aliasPath, "SKILL.md"), "utf8")).resolves.toContain(
+        "Check the diff.",
+      );
+
+      await exposeNativeSkillAliases(execution, logger, []);
+
+      await expect(readFile(join(aliasPath, "SKILL.md"), "utf8")).rejects.toThrow();
+    } finally {
+      await logger.destroy();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("skips a native alias for an invalid skill name without failing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
+    const logger = createTestLogger();
+    const execution = createExecution(
+      root,
+      createSkill(root, createZipArchive(createMarkdownSkillEntries("unused"))),
+    );
+    const skill = {
+      mountPath: join(root, ".mosoo", "skill", "skill-1"),
+      skillId: "skill-1",
+      skillMarkdownPath: join(root, ".mosoo", "skill", "skill-1", "SKILL.md"),
+      skillName: "My Skill",
+      snapshotId: "snapshot-1",
+    } satisfies AgentDriverMaterializedSkill;
+
+    try {
+      await expect(exposeNativeSkillAliases(execution, logger, [skill])).resolves.toEqual([]);
+      await expect(readdir(join(root, ".agents", "skills"))).resolves.toEqual([]);
+    } finally {
+      await logger.destroy();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("keeps the first skill when native skill names collide", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
+    const logger = createTestLogger();
+    const execution = createExecution(
+      root,
+      createSkill(root, createZipArchive(createMarkdownSkillEntries("unused"))),
+    );
+    const firstMountPath = join(root, ".mosoo", "skill", "skill-1");
+    await mkdir(firstMountPath, { recursive: true });
+    await writeFile(join(firstMountPath, "SKILL.md"), "canonical", "utf8");
+    const first = {
+      mountPath: firstMountPath,
+      skillId: "skill-1",
+      skillMarkdownPath: join(firstMountPath, "SKILL.md"),
+      skillName: "review",
+      snapshotId: "snapshot-1",
+    } satisfies AgentDriverMaterializedSkill;
+    const duplicate = {
+      ...first,
+      mountPath: join(root, ".mosoo", "skill", "skill-2"),
+      skillId: "skill-2",
+      skillMarkdownPath: join(root, ".mosoo", "skill", "skill-2", "SKILL.md"),
+    } satisfies AgentDriverMaterializedSkill;
+
+    try {
+      await expect(
+        exposeNativeSkillAliases(execution, logger, [first, duplicate]),
+      ).resolves.toEqual([join(root, ".agents", "skills", "review")]);
+      await expect(readlink(join(root, ".agents", "skills", "review"))).resolves.toBe(
+        "../../.mosoo/skill/skill-1",
+      );
+    } finally {
+      await logger.destroy();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("recreates a dangling managed alias and cleans it once the skill is gone", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
+    const logger = createTestLogger();
+    const execution = createExecution(
+      root,
+      createSkill(root, createZipArchive(createMarkdownSkillEntries("unused"))),
+    );
+    const aliasRoot = join(root, ".agents", "skills");
+    const aliasPath = join(aliasRoot, "review");
+    const mountPath = join(root, ".mosoo", "skill", "skill-2");
+    await mkdir(aliasRoot, { recursive: true });
+    await mkdir(mountPath, { recursive: true });
+    await writeFile(join(mountPath, "SKILL.md"), "canonical", "utf8");
+    await symlink("../../.mosoo/skill/gone", aliasPath, "dir");
+
+    try {
+      await exposeNativeSkillAliases(execution, logger, [
+        {
+          mountPath,
+          skillId: "skill-2",
+          skillMarkdownPath: join(mountPath, "SKILL.md"),
+          skillName: "review",
+          snapshotId: "snapshot-1",
+        },
+      ]);
+      await expect(readlink(aliasPath)).resolves.toBe("../../.mosoo/skill/skill-2");
+
+      await exposeNativeSkillAliases(execution, logger, []);
+
+      await expect(readlink(aliasPath)).rejects.toThrow();
+    } finally {
+      await logger.destroy();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  test("preserves an existing native skill directory on collision", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mosoo-skill-materialization-"));
+    const logger = createTestLogger();
+    const execution = createExecution(
+      root,
+      createSkill(root, createZipArchive(createMarkdownSkillEntries("unused"))),
+    );
+    const mountPath = join(root, ".mosoo", "skill", "skill-1");
+    const aliasPath = join(root, ".agents", "skills", "review");
+    await mkdir(mountPath, { recursive: true });
+    await writeFile(join(mountPath, "SKILL.md"), "canonical", "utf8");
+    await mkdir(aliasPath, { recursive: true });
+    await writeFile(join(aliasPath, "KEEP"), "user-owned", "utf8");
+
+    try {
+      await expect(
+        exposeNativeSkillAliases(execution, logger, [
+          {
+            mountPath,
+            skillId: "skill-1",
+            skillMarkdownPath: join(mountPath, "SKILL.md"),
+            skillName: "review",
+            snapshotId: "snapshot-1",
+          },
+        ]),
+      ).rejects.toThrow('Native skill alias "review" collides');
+      await expect(readFile(join(aliasPath, "KEEP"), "utf8")).resolves.toBe("user-owned");
     } finally {
       await logger.destroy();
       await rm(root, { force: true, recursive: true });


### PR DESCRIPTION
### What's changed?

- Expose each materialized skill as a relative symlink under `<sharedRootPath>/.agents/skills/<name>` before the ACP agent process starts, so runtimes with native skill discovery pick them up instead of relying only on the bootstrap prompt text and the `.mosoo/skills` manifest.
- Recreate an alias when its mount is remapped and remove it once the skill becomes unavailable. Any symlink resolving inside the managed skill cache is treated as driver-owned and reclaimable, so a dangling alias can never wedge session startup.
- Skip native aliasing for invalid or duplicate skill names with a `driver.skill.native_alias.skipped` warning instead of failing startup — the host contract only guarantees non-empty names, and such skills remain available through the bootstrap catalog.
- Fail closed when a desired alias name collides with an existing non-symlink path, preserving user-owned files.
- Log `nativeSkillAliasCount` in `driver.acp.runtime.started`.

### Why

- ACP agents previously learned about skills only through injected prompt text. Runtimes with native skill support (verified against the pinned opencode-ai 1.18.4, which discovers `.agents/skills/<name>/SKILL.md`) never surfaced them as first-class skills.

### Verification

- Unit tests cover alias creation, remap recreation, removal, invalid/duplicate-name skipping, and collision preservation.
- A contract test drives the real opencode binary (`opencode debug skill --pure`) to prove the skill is discovered before the first agent process starts and disappears after removal.
- `bun test`, `tsc`, and lint are clean on the touched suites.

## Considered and deferred

- src/runtimes/skill-materialization.ts:93 [BOT-WRONG]: the empty catch converts enforceSkillMountPath's throw into a managed/unmanaged predicate; no diagnostic value is lost.
- src/runtimes/skill-materialization.ts:106 [BOT-NIT]: inline 64 sits next to NATIVE_SKILL_NAME_PATTERN and mirrors the agent-skills name-length spec; single use, not extracting.
- src/runtimes/skill-materialization.ts:145 [BOT-WRONG]: no readdir/readlink race — aliases are written before the agent process starts and backend start() runs once per session.
- src/runtimes/skill-materialization.ts:81 [BOT-NIT]: mkdir is intentionally non-recursive; the host owns creation of the session organization root and a missing root should fail loud.
- src/runtimes/skill-materialization.ts:140 [BOT-NIT]: the alias root is ensured even with zero skills to keep one code path for stale-alias cleanup; cost is an empty directory.
- tests/skill-materialization.test.ts [BOT-NIT]: defensive internal-contract throws (path mismatch, non-file SKILL.md) have no dedicated tests; product invariants are covered by unit plus real-binary contract tests.
- src/runtimes/skill-materialization.ts:174 [BOT-TASTE]: serial awaits are acceptable on a startup-once path with a handful of skills.