### PR TITLE
feat(runtime): propagate custom tool call identity

### DIFF
--- a/src/core/driver-command-dispatcher.ts
+++ b/src/core/driver-command-dispatcher.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../observability";
 import { summarizeRuntimeCommand } from "../observability/driver-debug";
 import { parseDriverId } from "../protocol/id";
 import type { RunId } from "../protocol/id";
-import type { RunError, RuntimeCommand } from "../runtime-command";
+import type { McpExecuteCommandResult, RunError, RuntimeCommand } from "../runtime-command";
 import { promiseWithTimeout, raceWithAbort, sleepPromise } from "../utils/async";
 import type { AgentDriverBackend, AgentDriverContext } from "./agent-driver-backend";
 import { DriverCommandDelivery, TerminalCommandDeliveryError } from "./driver-command-delivery";
@@ -12,6 +12,7 @@ import {
   PermissionEventDeliveryError,
   type DriverPermissionBroker,
 } from "./driver-permission-broker";
+import { pushLosslessEvents } from "./driver-runtime-io";
 import type { DriverRuntimeIo } from "./driver-runtime-io";
 import type { DriverRuntimeStateMachine } from "./driver-runtime-state";
 import {
@@ -580,41 +581,69 @@ export class DriverCommandDispatcher {
     }
 
     try {
+      await pushLosslessEvents(socket, [
+        {
+          kind: "tool.call.updated",
+          payload: {
+            kind: "mcp",
+            rawInput: command.argumentsJson,
+            status: "running",
+            title: command.toolName,
+            toolCallId: command.toolCallId,
+          },
+        },
+      ]);
       const effect = await effectLedger.claimExternalToolEffect(
         { commandId: command.commandId },
         controller.signal,
       );
-
-      if (effect.kind === "completed") {
-        await this.#commandDelivery.finish(runtimeContext, command, {
-          result: effect.result,
-          status: "completed",
-        });
-        return;
-      }
-
       if (effect.kind === "unknown") {
         throw new ExternalToolEffectResolutionRequiredError(command, effect.effectId);
       }
 
-      effectClaimed = true;
-      runtimeContext.logger.info("driver.runtime.mcp.execute.started", {
-        effectAttempt: effect.attempt,
-        serverId: command.serverId,
-        toolName: command.toolName,
-      });
-      const execution = await runtimeContext.ports.mcp.execute(command, controller.signal, effect);
-      const { providerReceiptJson, ...result } = execution;
-      controller.signal.throwIfAborted();
-      await effectLedger.completeExternalToolEffect(
+      let result: McpExecuteCommandResult;
+
+      if (effect.kind === "completed") {
+        result = effect.result;
+      } else {
+        effectClaimed = true;
+        runtimeContext.logger.info("driver.runtime.mcp.execute.started", {
+          effectAttempt: effect.attempt,
+          serverId: command.serverId,
+          toolName: command.toolName,
+        });
+        const execution = await runtimeContext.ports.mcp.execute(
+          command,
+          controller.signal,
+          effect,
+        );
+        const { providerReceiptJson, ...executionResult } = execution;
+        result = executionResult;
+        controller.signal.throwIfAborted();
+        await effectLedger.completeExternalToolEffect(
+          {
+            commandId: command.commandId,
+            ...(providerReceiptJson === undefined ? {} : { providerReceiptJson }),
+            result,
+          },
+          controller.signal,
+        );
+        effectCompleted = true;
+      }
+
+      await pushLosslessEvents(socket, [
         {
-          commandId: command.commandId,
-          ...(providerReceiptJson === undefined ? {} : { providerReceiptJson }),
-          result,
+          kind: "tool.call.updated",
+          payload: {
+            kind: "mcp",
+            rawInput: command.argumentsJson,
+            rawOutput: result.outputText,
+            status: "completed",
+            title: command.toolName,
+            toolCallId: command.toolCallId,
+          },
         },
-        controller.signal,
-      );
-      effectCompleted = true;
+      ]);
       await this.#commandDelivery.finish(runtimeContext, command, {
         result,
         status: "completed",
@@ -639,6 +668,25 @@ export class DriverCommandDispatcher {
         });
         return;
       }
+
+      await pushLosslessEvents(socket, [
+        {
+          kind: "tool.call.updated",
+          payload: {
+            kind: "mcp",
+            rawInput: command.argumentsJson,
+            rawOutput: toErrorMessage(error, "MCP tool execution failed."),
+            status: "failed",
+            title: command.toolName,
+            toolCallId: command.toolCallId,
+          },
+        },
+      ]).catch((deliveryError: unknown) => {
+        runtimeContext.logger.error("driver.runtime.mcp.failed-event.failed", deliveryError, {
+          commandId: command.commandId,
+          toolCallId: command.toolCallId,
+        });
+      });
 
       await this.#failCommand(runtimeContext, socket, command, error);
     }

--- a/src/projections/cma/inbound.ts
+++ b/src/projections/cma/inbound.ts
@@ -49,6 +49,7 @@ export interface CmaUserCustomToolResultEvent {
   readonly commandId: string;
   readonly requestId: string;
   readonly serverId: string;
+  readonly toolCallId: string;
   readonly toolName: string;
   readonly type: "user.custom_tool_result";
 }
@@ -65,6 +66,7 @@ const supportedFieldsByInboundType = {
     "commandId",
     "requestId",
     "serverId",
+    "toolCallId",
     "toolName",
     "type",
   ]),
@@ -174,6 +176,7 @@ export function parseCmaInboundEvent(input: unknown): CmaInboundEvent {
         commandId: readString(record, "commandId"),
         requestId: readString(record, "requestId"),
         serverId: readString(record, "serverId"),
+        toolCallId: readString(record, "toolCallId"),
         toolName: readString(record, "toolName"),
         type,
       };
@@ -215,6 +218,7 @@ export function projectCmaInboundToDriverCommand(input: unknown): RuntimeCommand
         kind: "mcp.execute",
         requestId: event.requestId,
         serverId: event.serverId,
+        toolCallId: event.toolCallId,
         toolName: event.toolName,
       };
   }

--- a/src/runtime-command/index.ts
+++ b/src/runtime-command/index.ts
@@ -47,6 +47,7 @@ export interface McpExecuteCommand {
   readonly kind: "mcp.execute";
   readonly requestId: string;
   readonly serverId: string;
+  readonly toolCallId: string;
   readonly toolName: string;
 }
 
@@ -222,6 +223,7 @@ export function parseRuntimeCommand(value: unknown): RuntimeCommand {
         kind,
         requestId: readNonEmptyString(record, "requestId"),
         serverId: readNonEmptyString(record, "serverId"),
+        toolCallId: readNonEmptyString(record, "toolCallId"),
         toolName: readNonEmptyString(record, "toolName"),
       };
     case "permission.resolve":

--- a/src/runtimes/mcp/remote-http-mcp-executor.ts
+++ b/src/runtimes/mcp/remote-http-mcp-executor.ts
@@ -22,6 +22,7 @@ type ActiveMcpServer = Extract<SessionMcpServer, { authorizationState: "active" 
 
 const MCP_REQUEST_TIMEOUT_MS = 60_000;
 const MCP_CLEANUP_TIMEOUT_MS = 2_000;
+const MOSOO_TOOL_CALL_ID_HEADER = "X-Mosoo-Tool-Call-Id";
 
 function parseToolArguments(command: McpExecuteCommand): Record<string, unknown> {
   try {
@@ -203,6 +204,9 @@ export async function executeRemoteHttpMcpCommand(
   });
   const transport = new StreamableHTTPClientTransport(new URL(server.proxyUrl), {
     authProvider,
+    requestInit: {
+      headers: { [MOSOO_TOOL_CALL_ID_HEADER]: command.toolCallId },
+    },
   });
   const requestSignal = AbortSignal.any([signal, AbortSignal.timeout(MCP_REQUEST_TIMEOUT_MS)]);
 

--- a/tests/agent-driver-kernel-async-queue.test.ts
+++ b/tests/agent-driver-kernel-async-queue.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
 import { AsyncValueQueue } from "../src/core/async-value-queue";
 import type { DriverEventInput } from "../src/protocol/events";
 import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
 import type { RuntimeCommand } from "../src/runtime-command";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { driverBootPayload } from "./driver-boot-payload-fixture";
 import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
@@ -379,6 +379,7 @@ describe("AgentDriverKernelCore", () => {
       kind: "mcp.execute",
       requestId: "owned-result-request",
       serverId: "mcp-server",
+      toolCallId: "owned-result-tool",
       toolName: "tool",
     };
     const externalResult = {

--- a/tests/agent-driver-kernel-commands.test.ts
+++ b/tests/agent-driver-kernel-commands.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
-import type { DriverEventInput } from "../src/protocol/events";
-import type { RuntimeCommand } from "../src/runtime-command";
 import type {
   AgentDriverContext,
   AgentDriverContextPortOverrides,
 } from "../src/core/agent-driver-backend";
+import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
+import type { DriverEventInput } from "../src/protocol/events";
+import type { RuntimeCommand } from "../src/runtime-command";
 import { settlePromiseWithTimeout } from "../src/utils/async";
 import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
@@ -801,6 +801,7 @@ describe("AgentDriverKernelCore", () => {
           kind: "mcp.execute",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "complete",
         },
         new AbortController().signal,

--- a/tests/agent-driver-kernel-lifecycle.test.ts
+++ b/tests/agent-driver-kernel-lifecycle.test.ts
@@ -77,6 +77,7 @@ describe("AgentDriverKernelCore", () => {
               kind: "mcp.execute",
               requestId: "request-replay",
               serverId: "mcp-linear",
+              toolCallId: "tool-replay",
               toolName: "createIssue",
             };
 

--- a/tests/cma-http-request.test.ts
+++ b/tests/cma-http-request.test.ts
@@ -222,6 +222,7 @@ describe("CMA HTTP surface", () => {
         commandId: "command-1",
         requestId: "request-1",
         serverId: "server-1",
+        toolCallId: "tool-call-1",
         toolName: "tool-1",
         type: "user.custom_tool_result",
       }),

--- a/tests/cma-projection.test.ts
+++ b/tests/cma-projection.test.ts
@@ -58,6 +58,7 @@ describe("CMA projection", () => {
         commandId: "mcp-1",
         requestId: "request-1",
         serverId: "server-1",
+        toolCallId: "tool-1",
         toolName: "complete",
         type: "user.custom_tool_result",
       }),
@@ -67,6 +68,7 @@ describe("CMA projection", () => {
       kind: "mcp.execute",
       requestId: "request-1",
       serverId: "server-1",
+      toolCallId: "tool-1",
       toolName: "complete",
     });
   });

--- a/tests/cma-store-events.test.ts
+++ b/tests/cma-store-events.test.ts
@@ -191,6 +191,7 @@ describe("CMA memory store lifecycle", () => {
           kind: "mcp.execute",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "tool-1",
         },
         event: {
@@ -198,6 +199,7 @@ describe("CMA memory store lifecycle", () => {
           commandId: "command-1",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "tool-1",
           type: "user.custom_tool_result",
         },

--- a/tests/driver-runtime-boundary-dispatcher.test.ts
+++ b/tests/driver-runtime-boundary-dispatcher.test.ts
@@ -562,6 +562,7 @@ describe("driver runtime boundary", () => {
                 kind: "mcp.execute",
                 requestId: "request-terminal-failure",
                 serverId: "mcp-linear",
+                toolCallId: "tool-terminal-failure",
                 toolName: "createIssue",
               }
             : {
@@ -676,6 +677,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "ack-blocked-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-ack-blocked",
               toolName: "createIssue",
             };
       const next: RuntimeCommand =

--- a/tests/driver-runtime-boundary-event-envelope.test.ts
+++ b/tests/driver-runtime-boundary-event-envelope.test.ts
@@ -39,6 +39,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "serialized-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-serialized",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -117,6 +118,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "joined-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-joined",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -207,6 +209,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "failed-joined-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-failed-joined",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -297,6 +300,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "sink-mutation-request",
         serverId: "mcp-linear",
+        toolCallId: "tool-sink-mutation",
         toolName: "createIssue",
       };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -406,6 +410,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "request-report-failure",
               serverId: "mcp-linear",
+              toolCallId: "tool-report-failure",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command]);

--- a/tests/driver-runtime-boundary-state.test.ts
+++ b/tests/driver-runtime-boundary-state.test.ts
@@ -321,6 +321,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "request-replay",
               serverId: "mcp-linear",
+              toolCallId: "tool-replay",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -376,6 +377,7 @@ describe("driver runtime boundary", () => {
       kind: "mcp.execute",
       requestId: "request-persistent-effect",
       serverId: "mcp-linear",
+      toolCallId: "tool-persistent-effect",
       toolName: "createIssue",
     };
     let providerCalls = 0;
@@ -463,6 +465,14 @@ describe("driver runtime boundary", () => {
       { commandId: command.commandId, status: "accepted" },
       { commandId: command.commandId, result: effectResult, status: "completed" },
     ]);
+    expect(secondSocket.pushedEvents).toMatchObject([
+      {
+        events: [{ kind: "tool.call.updated", payload: { toolCallId: command.toolCallId } }],
+      },
+      {
+        events: [{ kind: "tool.call.updated", payload: { toolCallId: command.toolCallId } }],
+      },
+    ]);
   });
 
   test("blocks an unknown MCP effect without another provider call", async () => {
@@ -472,6 +482,7 @@ describe("driver runtime boundary", () => {
       kind: "mcp.execute",
       requestId: "unknown-effect-request",
       serverId: "mcp-linear",
+      toolCallId: "tool-unknown-effect",
       toolName: "createIssue",
     };
     const socket = new FakeDriverRuntimeIo([command]);
@@ -515,6 +526,7 @@ describe("driver runtime boundary", () => {
       kind: "mcp.execute",
       requestId: "cancelled-effect-request",
       serverId: "mcp-linear",
+      toolCallId: "tool-cancelled-effect",
       toolName: "createIssue",
     };
     const cancelCommand: RuntimeCommand = {

--- a/tests/driver-runtime-boundary-timing.test.ts
+++ b/tests/driver-runtime-boundary-timing.test.ts
@@ -189,6 +189,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-1",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-1",
         toolName: "createIssue",
       },
     ]);
@@ -222,6 +223,33 @@ describe("driver runtime boundary", () => {
         status: "completed",
       },
     ]);
+    expect(socket.pushedEvents).toMatchObject([
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawInput: '{"issue":"A-1"}',
+              status: "running",
+              title: "createIssue",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawOutput: "ran createIssue",
+              status: "completed",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+    ]);
   });
 
   test("reports remote MCP execute failures as diagnostics", async () => {
@@ -234,6 +262,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-1",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-1",
         toolName: "createIssue",
       },
     ]);
@@ -268,6 +297,29 @@ describe("driver runtime boundary", () => {
       {
         events: [
           {
+            kind: "tool.call.updated",
+            payload: {
+              status: "running",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawOutput: "MCP upstream failed",
+              status: "failed",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
             kind: "diagnostic.reported",
             payload: {
               code: "driver.mcp_execute_failed",
@@ -299,6 +351,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-stuck",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-stuck",
         toolName: "waitForever",
       },
       {
@@ -396,6 +449,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute" as const,
         requestId: `mcp-request-${index}`,
         serverId: "mcp-linear",
+        toolCallId: `tool-mcp-${index}`,
         toolName: "waitForever",
       })),
       {

--- a/tests/fixtures/driver/commands/mcp-execute.json
+++ b/tests/fixtures/driver/commands/mcp-execute.json
@@ -4,5 +4,6 @@
   "kind": "mcp.execute",
   "requestId": "request-1",
   "serverId": "server-1",
+  "toolCallId": "tool-1",
   "toolName": "complete"
 }


### PR DESCRIPTION
## Summary
- require a distinct logical `toolCallId` on custom MCP commands
- emit start/completed/failed tool lifecycle events with the same ID
- forward the ID to the Mosoo MCP proxy while preserving the durable external-effect ledger
- replay a persisted terminal result without repeating the provider side effect

## Verification
- `bun run tc`
- `bun run build`
- focused Driver runtime/CMA suites: 180 passing
- replay regression: provider called once and both replay lifecycle events retain the same ID

Related: https://github.com/langgenius/mosoo/issues/488