### PR TITLE
feat(runtime): propagate custom tool call identity (v1)

### DIFF
--- a/src/core/driver-command-dispatcher.ts
+++ b/src/core/driver-command-dispatcher.ts
@@ -1,17 +1,18 @@
-import { summarizeRuntimeCommand } from "../observability/driver-debug";
 import { createScopedWideEvent, emitWideEvent } from "../observability";
 import type { Logger } from "../observability";
+import { summarizeRuntimeCommand } from "../observability/driver-debug";
 import { parseDriverId } from "../protocol/id";
 import type { RunId } from "../protocol/id";
 import type { RunError, RuntimeCommand } from "../runtime-command";
-import type { AgentDriverBackend, AgentDriverContext } from "./agent-driver-backend";
 import { promiseWithTimeout, raceWithAbort, sleepPromise } from "../utils/async";
+import type { AgentDriverBackend, AgentDriverContext } from "./agent-driver-backend";
 import { DriverCommandDelivery, TerminalCommandDeliveryError } from "./driver-command-delivery";
 import { pushDriverDiagnosticEvent } from "./driver-diagnostics";
 import {
   PermissionEventDeliveryError,
   type DriverPermissionBroker,
 } from "./driver-permission-broker";
+import { pushLosslessEvents } from "./driver-runtime-io";
 import type { DriverRuntimeIo } from "./driver-runtime-io";
 import type { DriverRuntimeStateMachine } from "./driver-runtime-state";
 import { DriverTurnCancelledError, isDriverTurnCancelledError } from "./driver-runtime-state";
@@ -499,12 +500,34 @@ export class DriverCommandDispatcher {
     controller: AbortController,
   ): Promise<void> {
     try {
+      await pushLosslessEvents(socket, [
+        {
+          kind: "tool.call.updated",
+          payload: {
+            kind: "mcp",
+            rawInput: command.argumentsJson,
+            status: "running",
+            title: command.toolName,
+            toolCallId: command.toolCallId,
+          },
+        },
+      ]);
       runtimeContext.logger.info("driver.runtime.mcp.execute.started", {
         serverId: command.serverId,
         toolName: command.toolName,
       });
       const result = await runtimeContext.ports.mcp.execute(command, controller.signal);
       controller.signal.throwIfAborted();
+      await pushLosslessEvents(socket, [
+        {
+          kind: "tool.call.updated",
+          payload: {
+            rawOutput: result.outputText,
+            status: "completed",
+            toolCallId: command.toolCallId,
+          },
+        },
+      ]);
       await this.#commandDelivery.finish(runtimeContext, command, {
         result,
         status: "completed",
@@ -525,6 +548,22 @@ export class DriverCommandDispatcher {
         });
         return;
       }
+
+      await pushLosslessEvents(socket, [
+        {
+          kind: "tool.call.updated",
+          payload: {
+            rawOutput: toErrorMessage(error, "MCP tool execution failed."),
+            status: "failed",
+            toolCallId: command.toolCallId,
+          },
+        },
+      ]).catch((deliveryError: unknown) => {
+        runtimeContext.logger.error("driver.runtime.mcp.failed-event.failed", deliveryError, {
+          commandId: command.commandId,
+          toolCallId: command.toolCallId,
+        });
+      });
 
       await this.#failCommand(runtimeContext, socket, command, error);
     }

--- a/src/projections/cma/inbound.ts
+++ b/src/projections/cma/inbound.ts
@@ -50,6 +50,7 @@ export interface CmaUserCustomToolResultEvent {
   readonly commandId: string;
   readonly requestId: string;
   readonly serverId: string;
+  readonly toolCallId: string;
   readonly toolName: string;
   readonly type: "user.custom_tool_result";
 }
@@ -66,6 +67,7 @@ const supportedFieldsByInboundType = {
     "commandId",
     "requestId",
     "serverId",
+    "toolCallId",
     "toolName",
     "type",
   ]),
@@ -195,6 +197,7 @@ export function parseCmaInboundEvent(input: unknown): CmaInboundEvent {
         commandId: readString(record, "commandId"),
         requestId: readString(record, "requestId"),
         serverId: readString(record, "serverId"),
+        toolCallId: readString(record, "toolCallId"),
         toolName: readString(record, "toolName"),
         type,
       };
@@ -237,6 +240,7 @@ export function projectCmaInboundToDriverCommand(input: unknown): RuntimeCommand
         kind: "mcp.execute",
         requestId: event.requestId,
         serverId: event.serverId,
+        toolCallId: event.toolCallId,
         toolName: event.toolName,
       };
   }

--- a/src/runtime-command/index.ts
+++ b/src/runtime-command/index.ts
@@ -48,6 +48,7 @@ export interface McpExecuteCommand {
   readonly kind: "mcp.execute";
   readonly requestId: string;
   readonly serverId: string;
+  readonly toolCallId: string;
   readonly toolName: string;
 }
 
@@ -199,6 +200,7 @@ export function parseRuntimeCommand(value: unknown): RuntimeCommand {
         kind,
         requestId: readNonEmptyString(record, "requestId"),
         serverId: readNonEmptyString(record, "serverId"),
+        toolCallId: readNonEmptyString(record, "toolCallId"),
         toolName: readNonEmptyString(record, "toolName"),
       };
     case "permission.resolve":

--- a/src/runtimes/mcp/remote-http-mcp-executor.ts
+++ b/src/runtimes/mcp/remote-http-mcp-executor.ts
@@ -8,16 +8,17 @@ import {
 } from "@modelcontextprotocol/client";
 import type { AuthProvider, CallToolResult } from "@modelcontextprotocol/client";
 
+import { AGENT_DRIVER_VERSION } from "../../core/version";
 import type { DriverStartInput } from "../../protocol/start";
 import type { McpExecuteCommand } from "../../runtime-command";
 import { settlePromiseWithTimeout } from "../../utils/async";
-import { AGENT_DRIVER_VERSION } from "../../core/version";
 
 type SessionMcpServer = DriverStartInput["execution"]["session"]["mcpServers"][number];
 type ActiveMcpServer = Extract<SessionMcpServer, { authorizationState: "active" }>;
 
 const MCP_REQUEST_TIMEOUT_MS = 60_000;
 const MCP_CLEANUP_TIMEOUT_MS = 2_000;
+const MOSOO_TOOL_CALL_ID_HEADER = "X-Mosoo-Tool-Call-Id";
 
 function parseToolArguments(command: McpExecuteCommand): Record<string, unknown> {
   try {
@@ -196,6 +197,9 @@ export async function executeRemoteHttpMcpCommand(
   });
   const transport = new StreamableHTTPClientTransport(new URL(server.proxyUrl), {
     authProvider,
+    requestInit: {
+      headers: { [MOSOO_TOOL_CALL_ID_HEADER]: command.toolCallId },
+    },
   });
   const requestSignal = AbortSignal.any([signal, AbortSignal.timeout(MCP_REQUEST_TIMEOUT_MS)]);
 

--- a/tests/agent-driver-kernel-async-queue.test.ts
+++ b/tests/agent-driver-kernel-async-queue.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
 import { AsyncValueQueue } from "../src/core/async-value-queue";
 import type { DriverEventInput } from "../src/protocol/events";
 import { createDriverStartInputFromBootPayload } from "../src/protocol/start";
 import type { RuntimeCommand } from "../src/runtime-command";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { driverBootPayload } from "./driver-boot-payload-fixture";
 import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
@@ -379,6 +379,7 @@ describe("AgentDriverKernelCore", () => {
       kind: "mcp.execute",
       requestId: "owned-result-request",
       serverId: "mcp-server",
+      toolCallId: "owned-result-tool",
       toolName: "tool",
     };
     const externalResult = {

--- a/tests/agent-driver-kernel-commands.test.ts
+++ b/tests/agent-driver-kernel-commands.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
-import type { DriverEventInput } from "../src/protocol/events";
-import type { RuntimeCommand } from "../src/runtime-command";
 import type {
   AgentDriverContext,
   AgentDriverContextPortOverrides,
 } from "../src/core/agent-driver-backend";
+import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
+import type { DriverEventInput } from "../src/protocol/events";
+import type { RuntimeCommand } from "../src/runtime-command";
 import { settlePromiseWithTimeout } from "../src/utils/async";
 import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
@@ -532,6 +532,7 @@ describe("AgentDriverKernelCore", () => {
           kind: "mcp.execute",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "complete",
         },
         new AbortController().signal,

--- a/tests/agent-driver-kernel-lifecycle.test.ts
+++ b/tests/agent-driver-kernel-lifecycle.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { AgentDriverKernelCore } from "../src/core/agent-driver-kernel";
 import type { DriverEventInput } from "../src/protocol/events";
 import type { RuntimeCommand } from "../src/runtime-command";
-import type { AgentDriverContext } from "../src/core/agent-driver-backend";
 import { DRIVER_TEST_IDS, bootPayload, createBackend } from "./driver-runtime-boundary-fixtures";
 
 describe("AgentDriverKernelCore", () => {
@@ -48,6 +48,7 @@ describe("AgentDriverKernelCore", () => {
               kind: "mcp.execute",
               requestId: "request-replay",
               serverId: "mcp-linear",
+              toolCallId: "tool-replay",
               toolName: "createIssue",
             };
 

--- a/tests/cma-http-request.test.ts
+++ b/tests/cma-http-request.test.ts
@@ -222,6 +222,7 @@ describe("CMA HTTP surface", () => {
         commandId: "command-1",
         requestId: "request-1",
         serverId: "server-1",
+        toolCallId: "tool-call-1",
         toolName: "tool-1",
         type: "user.custom_tool_result",
       }),

--- a/tests/cma-projection.test.ts
+++ b/tests/cma-projection.test.ts
@@ -60,6 +60,7 @@ describe("CMA projection", () => {
         commandId: "mcp-1",
         requestId: "request-1",
         serverId: "server-1",
+        toolCallId: "tool-1",
         toolName: "complete",
         type: "user.custom_tool_result",
       }),
@@ -69,6 +70,7 @@ describe("CMA projection", () => {
       kind: "mcp.execute",
       requestId: "request-1",
       serverId: "server-1",
+      toolCallId: "tool-1",
       toolName: "complete",
     });
   });

--- a/tests/cma-store-events.test.ts
+++ b/tests/cma-store-events.test.ts
@@ -191,6 +191,7 @@ describe("CMA memory store lifecycle", () => {
           kind: "mcp.execute",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "tool-1",
         },
         event: {
@@ -198,6 +199,7 @@ describe("CMA memory store lifecycle", () => {
           commandId: "command-1",
           requestId: "request-1",
           serverId: "server-1",
+          toolCallId: "tool-1",
           toolName: "tool-1",
           type: "user.custom_tool_result",
         },

--- a/tests/driver-runtime-boundary-dispatcher.test.ts
+++ b/tests/driver-runtime-boundary-dispatcher.test.ts
@@ -194,6 +194,7 @@ describe("driver runtime boundary", () => {
                 kind: "mcp.execute",
                 requestId: "request-terminal-failure",
                 serverId: "mcp-linear",
+                toolCallId: "tool-terminal-failure",
                 toolName: "createIssue",
               }
             : {
@@ -306,6 +307,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "ack-blocked-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-ack-blocked",
               toolName: "createIssue",
             };
       const next: RuntimeCommand =

--- a/tests/driver-runtime-boundary-event-envelope.test.ts
+++ b/tests/driver-runtime-boundary-event-envelope.test.ts
@@ -39,6 +39,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "serialized-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-serialized",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -117,6 +118,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "joined-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-joined",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -207,6 +209,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "failed-joined-request",
               serverId: "mcp-linear",
+              toolCallId: "tool-failed-joined",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -297,6 +300,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "sink-mutation-request",
         serverId: "mcp-linear",
+        toolCallId: "tool-sink-mutation",
         toolName: "createIssue",
       };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);
@@ -406,6 +410,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "request-report-failure",
               serverId: "mcp-linear",
+              toolCallId: "tool-report-failure",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command]);

--- a/tests/driver-runtime-boundary-state.test.ts
+++ b/tests/driver-runtime-boundary-state.test.ts
@@ -322,6 +322,7 @@ describe("driver runtime boundary", () => {
               kind: "mcp.execute",
               requestId: "request-replay",
               serverId: "mcp-linear",
+              toolCallId: "tool-replay",
               toolName: "createIssue",
             };
       const socket = new FakeDriverRuntimeIo([command, structuredClone(command)]);

--- a/tests/driver-runtime-boundary-timing.test.ts
+++ b/tests/driver-runtime-boundary-timing.test.ts
@@ -189,6 +189,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-1",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-1",
         toolName: "createIssue",
       },
     ]);
@@ -222,6 +223,33 @@ describe("driver runtime boundary", () => {
         status: "completed",
       },
     ]);
+    expect(socket.pushedEvents).toMatchObject([
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawInput: '{"issue":"A-1"}',
+              status: "running",
+              title: "createIssue",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawOutput: "ran createIssue",
+              status: "completed",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+    ]);
   });
 
   test("reports remote MCP execute failures as diagnostics", async () => {
@@ -234,6 +262,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-1",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-1",
         toolName: "createIssue",
       },
     ]);
@@ -268,6 +297,29 @@ describe("driver runtime boundary", () => {
       {
         events: [
           {
+            kind: "tool.call.updated",
+            payload: {
+              status: "running",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
+            kind: "tool.call.updated",
+            payload: {
+              rawOutput: "MCP upstream failed",
+              status: "failed",
+              toolCallId: "tool-mcp-1",
+            },
+          },
+        ],
+      },
+      {
+        events: [
+          {
             kind: "diagnostic.reported",
             payload: {
               code: "driver.mcp_execute_failed",
@@ -299,6 +351,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute",
         requestId: "mcp-request-stuck",
         serverId: "mcp-linear",
+        toolCallId: "tool-mcp-stuck",
         toolName: "waitForever",
       },
       {
@@ -396,6 +449,7 @@ describe("driver runtime boundary", () => {
         kind: "mcp.execute" as const,
         requestId: `mcp-request-${index}`,
         serverId: "mcp-linear",
+        toolCallId: `tool-mcp-${index}`,
         toolName: "waitForever",
       })),
       {

--- a/tests/fixtures/driver/commands/mcp-execute.json
+++ b/tests/fixtures/driver/commands/mcp-execute.json
@@ -4,5 +4,6 @@
   "kind": "mcp.execute",
   "requestId": "request-1",
   "serverId": "server-1",
+  "toolCallId": "tool-1",
   "toolName": "complete"
 }


### PR DESCRIPTION
## Summary
- backport the logical `toolCallId` contract to the Driver v1 line currently pinned by Mosoo
- emit start/completed/failed lifecycle events with the same ID
- forward the ID to the Mosoo MCP proxy

## Verification
- `bun run tc`
- focused runtime/CMA suites: 51 passing

Forward-port: #109
Related: https://github.com/langgenius/mosoo/issues/488