### PR TITLE
fix(openai): YEF-1053 isolate subagent lifecycle events

### DIFF
--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -121,6 +121,10 @@ const APP_SERVER_REQUEST_TIMEOUT_MS = 60_000;
 const MAX_APP_SERVER_MESSAGE_BYTES = 8 * 1_024 * 1_024;
 const MAX_PENDING_SERVER_MESSAGES = 1_024;
 const MAX_PENDING_SERVER_MESSAGE_BYTES = 32 * 1_024 * 1_024;
+const PAUSE_PENDING_SERVER_MESSAGES = Math.floor(MAX_PENDING_SERVER_MESSAGES * 0.75);
+const RESUME_PENDING_SERVER_MESSAGES = Math.floor(MAX_PENDING_SERVER_MESSAGES * 0.5);
+const PAUSE_PENDING_SERVER_MESSAGE_BYTES = Math.floor(MAX_PENDING_SERVER_MESSAGE_BYTES * 0.75);
+const RESUME_PENDING_SERVER_MESSAGE_BYTES = Math.floor(MAX_PENDING_SERVER_MESSAGE_BYTES * 0.5);
 
 export function limitNdjsonLines(maxMessageBytes = MAX_APP_SERVER_MESSAGE_BYTES): Transform {
   if (!Number.isSafeInteger(maxMessageBytes) || maxMessageBytes < 1) {
@@ -201,6 +205,7 @@ export class OpenAiAppServerClient {
   #processTreeMarker: string | null = null;
   #readline: ReadlineInterface | null = null;
   #serverMessageQueue: Promise<void> = Promise.resolve();
+  #serverMessagesPaused = false;
   #startRequested = false;
   #stopRequested = false;
   #stopTask: Promise<void> | null = null;
@@ -558,7 +563,12 @@ export class OpenAiAppServerClient {
     for (;;) {
       const tail = this.#serverMessageQueue;
       await tail;
-      await Promise.resolve();
+      // Resuming stdout schedules the next buffered chunk on a later event-loop
+      // turn. A microtask-only check can mistake that backpressure handoff for
+      // an empty queue and return before the resumed notifications are admitted.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       if (tail === this.#serverMessageQueue) {
         return;
@@ -732,16 +742,14 @@ export class OpenAiAppServerClient {
     if (method !== null) {
       const bytes = Buffer.byteLength(trimmed, "utf8");
 
-      if (
-        this.#pendingServerMessages >= MAX_PENDING_SERVER_MESSAGES ||
-        bytes > MAX_PENDING_SERVER_MESSAGE_BYTES - this.#pendingServerMessageBytes
-      ) {
+      if (bytes > MAX_PENDING_SERVER_MESSAGE_BYTES - this.#pendingServerMessageBytes) {
         this.#failProtocol(new Error("App-server message queue limit exceeded."));
         return;
       }
 
       this.#pendingServerMessages += 1;
       this.#pendingServerMessageBytes += bytes;
+      this.#pauseServerMessagesIfNeeded();
       this.#serverMessageQueue = this.#processMessage(
         this.#serverMessageQueue,
         method,
@@ -750,6 +758,7 @@ export class OpenAiAppServerClient {
       ).finally(() => {
         this.#pendingServerMessages -= 1;
         this.#pendingServerMessageBytes -= bytes;
+        this.#resumeServerMessagesIfReady();
       });
       return;
     }
@@ -757,6 +766,41 @@ export class OpenAiAppServerClient {
     if (id !== null) {
       this.#onResponse(id, parsed);
     }
+  }
+
+  #pauseServerMessagesIfNeeded(): void {
+    if (
+      this.#serverMessagesPaused ||
+      (this.#pendingServerMessages < PAUSE_PENDING_SERVER_MESSAGES &&
+        this.#pendingServerMessageBytes < PAUSE_PENDING_SERVER_MESSAGE_BYTES)
+    ) {
+      return;
+    }
+
+    this.#serverMessagesPaused = true;
+    this.#context.logger.debug("driver.openai.server_message_queue.paused", {
+      pendingBytes: this.#pendingServerMessageBytes,
+      pendingMessages: this.#pendingServerMessages,
+    });
+    this.#process?.stdout.pause();
+  }
+
+  #resumeServerMessagesIfReady(): void {
+    if (
+      !this.#serverMessagesPaused ||
+      this.#stopRequested ||
+      this.#pendingServerMessages > RESUME_PENDING_SERVER_MESSAGES ||
+      this.#pendingServerMessageBytes > RESUME_PENDING_SERVER_MESSAGE_BYTES
+    ) {
+      return;
+    }
+
+    this.#serverMessagesPaused = false;
+    this.#context.logger.debug("driver.openai.server_message_queue.resumed", {
+      pendingBytes: this.#pendingServerMessageBytes,
+      pendingMessages: this.#pendingServerMessages,
+    });
+    this.#process?.stdout.resume();
   }
 
   #failProtocol(error: Error): void {

--- a/src/runtimes/openai/app-server-event-bridge.ts
+++ b/src/runtimes/openai/app-server-event-bridge.ts
@@ -169,7 +169,21 @@ export class OpenAiAppServerEventBridge {
     params: ServerNotificationParams[M],
   ): Promise<void> {
     const payload = isRecord(params) ? params : {};
-    const turnId = readNonEmptyString(payload, "turnId");
+    const turnId =
+      readNonEmptyString(payload, "turnId") ??
+      readNonEmptyString(readRecord(payload, "turn"), "id");
+
+    // Native Codex subagents own child threads and turns. Their direct message
+    // and lifecycle frames are provider-internal activity, not authoritative
+    // mutations of the Mosoo Run attached to the root app-server thread. Root
+    // collabAgentToolCall/subAgentActivity items still arrive on the root thread
+    // and continue through the normal item projection below.
+    if (
+      turnId !== null &&
+      readNonEmptyString(payload, "threadId") !== this.#options.requireThreadId()
+    ) {
+      return;
+    }
 
     if (turnId !== null && this.#turns.hasTerminal(turnId)) {
       return;

--- a/src/runtimes/openai/event-translator.ts
+++ b/src/runtimes/openai/event-translator.ts
@@ -39,6 +39,14 @@ export function toOpenAiToolName(item: JsonObject): string | null {
     return "Web search";
   }
 
+  if (itemType === "collabAgentToolCall") {
+    return readNonEmptyString(item, "tool") ?? "Agent collaboration";
+  }
+
+  if (itemType === "subAgentActivity") {
+    return "Sub-agent activity";
+  }
+
   return null;
 }
 
@@ -86,6 +94,18 @@ export function toOpenAiToolResultText(item: JsonObject): string | null {
 
   if (itemType === "webSearch") {
     return readString(item, "query");
+  }
+
+  if (itemType === "collabAgentToolCall") {
+    return stringifyForDisplay(item["agentsStates"]);
+  }
+
+  if (itemType === "subAgentActivity") {
+    return stringifyForDisplay({
+      agentPath: item["agentPath"] ?? null,
+      agentThreadId: item["agentThreadId"] ?? null,
+      kind: item["kind"] ?? null,
+    });
   }
 
   return null;

--- a/tests/fixtures/providers/openai-app-server/cases/root-with-parallel-child-turns.json
+++ b/tests/fixtures/providers/openai-app-server/cases/root-with-parallel-child-turns.json
@@ -1,0 +1,259 @@
+{
+  "trackTurnBeforeNotifications": {
+    "expectation": "resolve",
+    "turnId": "turn-root"
+  },
+  "notifications": [
+    {
+      "method": "turn/started",
+      "params": {
+        "threadId": "thread-1",
+        "turn": { "id": "turn-root", "status": "inProgress" }
+      }
+    },
+    {
+      "method": "item/started",
+      "params": {
+        "item": {
+          "agentsStates": {},
+          "id": "agent-call-1",
+          "model": "gpt-5.5",
+          "prompt": "Run A and B in parallel",
+          "reasoningEffort": "high",
+          "receiverThreadIds": ["thread-child-a", "thread-child-b"],
+          "senderThreadId": "thread-1",
+          "status": "inProgress",
+          "tool": "spawnAgent",
+          "type": "collabAgentToolCall"
+        },
+        "threadId": "thread-1",
+        "turnId": "turn-root"
+      }
+    },
+    {
+      "method": "turn/started",
+      "params": {
+        "threadId": "thread-child-a",
+        "turn": { "id": "turn-child-a", "status": "inProgress" }
+      }
+    },
+    {
+      "method": "item/completed",
+      "params": {
+        "item": { "id": "message-child-a", "text": "CHILD_A", "type": "agentMessage" },
+        "threadId": "thread-child-a",
+        "turnId": "turn-child-a"
+      }
+    },
+    {
+      "method": "turn/completed",
+      "params": {
+        "threadId": "thread-child-a",
+        "turn": {
+          "id": "turn-child-a",
+          "items": [],
+          "itemsView": "notLoaded",
+          "status": "completed"
+        }
+      }
+    },
+    {
+      "method": "turn/started",
+      "params": {
+        "threadId": "thread-child-b",
+        "turn": { "id": "turn-child-b", "status": "inProgress" }
+      }
+    },
+    {
+      "method": "item/completed",
+      "params": {
+        "item": { "id": "message-child-b", "text": "CHILD_B", "type": "agentMessage" },
+        "threadId": "thread-child-b",
+        "turnId": "turn-child-b"
+      }
+    },
+    {
+      "method": "turn/completed",
+      "params": {
+        "threadId": "thread-child-b",
+        "turn": {
+          "id": "turn-child-b",
+          "items": [],
+          "itemsView": "notLoaded",
+          "status": "completed"
+        }
+      }
+    },
+    {
+      "method": "item/completed",
+      "params": {
+        "item": {
+          "agentsStates": {
+            "thread-child-a": { "message": "CHILD_A", "status": "completed" },
+            "thread-child-b": { "message": "CHILD_B", "status": "completed" }
+          },
+          "id": "agent-call-1",
+          "model": "gpt-5.5",
+          "prompt": "Run A and B in parallel",
+          "reasoningEffort": "high",
+          "receiverThreadIds": ["thread-child-a", "thread-child-b"],
+          "senderThreadId": "thread-1",
+          "status": "completed",
+          "tool": "spawnAgent",
+          "type": "collabAgentToolCall"
+        },
+        "threadId": "thread-1",
+        "turnId": "turn-root"
+      }
+    },
+    {
+      "method": "item/completed",
+      "params": {
+        "item": {
+          "id": "message-parent",
+          "text": "PARENT_OK: CHILD_A + CHILD_B",
+          "type": "agentMessage"
+        },
+        "threadId": "thread-1",
+        "turnId": "turn-root"
+      }
+    },
+    {
+      "method": "turn/completed",
+      "params": {
+        "threadId": "thread-1",
+        "turn": {
+          "id": "turn-root",
+          "items": [
+            {
+              "agentsStates": {
+                "thread-child-a": { "message": "CHILD_A", "status": "completed" },
+                "thread-child-b": { "message": "CHILD_B", "status": "completed" }
+              },
+              "id": "agent-call-1",
+              "model": "gpt-5.5",
+              "prompt": "Run A and B in parallel",
+              "reasoningEffort": "high",
+              "receiverThreadIds": ["thread-child-a", "thread-child-b"],
+              "senderThreadId": "thread-1",
+              "status": "completed",
+              "tool": "spawnAgent",
+              "type": "collabAgentToolCall"
+            },
+            {
+              "id": "message-parent",
+              "text": "PARENT_OK: CHILD_A + CHILD_B",
+              "type": "agentMessage"
+            }
+          ],
+          "itemsView": "full",
+          "status": "completed"
+        }
+      }
+    },
+    {
+      "method": "item/completed",
+      "params": {
+        "item": { "id": "message-child-late", "text": "LATE_CHILD", "type": "agentMessage" },
+        "threadId": "thread-child-b",
+        "turnId": "turn-child-b"
+      }
+    }
+  ],
+  "expectedEvents": [
+    {
+      "kind": "run.started",
+      "native": {
+        "eventName": "turn.started",
+        "provider": "openai",
+        "turnId": "turn-root"
+      },
+      "payload": { "startedAt": "<iso-timestamp>" },
+      "runId": "<driver-id>",
+      "sourceEventId": "openai.turn.started:turn-root"
+    },
+    {
+      "kind": "message.started",
+      "payload": { "messageId": "<driver-id>", "role": "agent" }
+    },
+    {
+      "kind": "item.started",
+      "payload": {
+        "itemId": "agent-call-1",
+        "itemType": "tool_call",
+        "parentMessageId": "<driver-id>",
+        "title": "spawnAgent"
+      }
+    },
+    {
+      "kind": "tool.call.updated",
+      "payload": {
+        "kind": "tool",
+        "parentMessageId": "<driver-id>",
+        "status": "running",
+        "title": "spawnAgent",
+        "toolCallId": "agent-call-1"
+      }
+    },
+    {
+      "kind": "tool.call.updated",
+      "payload": {
+        "content": "{\"thread-child-a\":{\"message\":\"CHILD_A\",\"status\":\"completed\"},\"thread-child-b\":{\"message\":\"CHILD_B\",\"status\":\"completed\"}}",
+        "messageId": "<driver-id>",
+        "rawOutput": "{\"thread-child-a\":{\"message\":\"CHILD_A\",\"status\":\"completed\"},\"thread-child-b\":{\"message\":\"CHILD_B\",\"status\":\"completed\"}}",
+        "status": "completed",
+        "toolCallId": "agent-call-1"
+      }
+    },
+    {
+      "kind": "item.completed",
+      "payload": {
+        "itemId": "agent-call-1",
+        "itemType": "tool_call",
+        "status": "completed"
+      }
+    },
+    {
+      "delivery": "best_effort",
+      "kind": "message.delta",
+      "payload": {
+        "contentDelta": "PARENT_OK: CHILD_A + CHILD_B",
+        "messageId": "<driver-id>",
+        "role": "agent"
+      }
+    },
+    {
+      "delivery": "lossless",
+      "kind": "message.added",
+      "payload": {
+        "content": "PARENT_OK: CHILD_A + CHILD_B",
+        "messageId": "<driver-id>",
+        "role": "agent"
+      }
+    },
+    {
+      "kind": "message.completed",
+      "payload": { "messageId": "<driver-id>", "role": "agent" }
+    },
+    {
+      "kind": "runtime.resume.updated",
+      "payload": { "resumePointer": "thread-1", "threadId": "thread-1" },
+      "visibility": "owner_debug"
+    },
+    {
+      "kind": "run.completed",
+      "native": {
+        "eventName": "turn.completed",
+        "provider": "openai",
+        "turnId": "turn-root"
+      },
+      "payload": {
+        "finalMessageId": "<driver-id>",
+        "finalMessageText": "PARENT_OK: CHILD_A + CHILD_B",
+        "stopReason": "end_turn"
+      },
+      "runId": "<driver-id>",
+      "sourceEventId": "openai.turn.completed:turn-root"
+    }
+  ]
+}

--- a/tests/openai-app-server-client.test.ts
+++ b/tests/openai-app-server-client.test.ts
@@ -1262,11 +1262,10 @@ setInterval(() => {}, 1000);
     }
   });
 
-  test("fails and stops when queued server messages exceed the hard limit", async () => {
-    let releaseNotification: (() => void) | null = null;
-    const notificationGate = new Promise<void>((resolve) => {
-      releaseNotification = resolve;
-    });
+  test("applies backpressure to a bounded multi-agent notification burst", async () => {
+    const firstNotification = Promise.withResolvers<void>();
+    const notificationGate = Promise.withResolvers<void>();
+    let handled = 0;
     const harness = await createClientHarness(
       () => `
 let buffer = "";
@@ -1276,27 +1275,44 @@ process.stdin.on("data", (chunk) => {
   const newline = buffer.indexOf("\\n");
   if (newline < 0) return;
   const request = JSON.parse(buffer.slice(0, newline));
+  buffer = buffer.slice(newline + 1);
+  if (request.id === undefined) return;
   process.stdout.write(JSON.stringify({ id: request.id, result: {} }) + "\\n");
-  for (let index = 0; index < 1025; index += 1) {
-    process.stdout.write(JSON.stringify({ method: "warning", params: { message: String(index), threadId: null } }) + "\\n");
+  for (let index = 0; index < 2048; index += 1) {
+    process.stdout.write(JSON.stringify({
+      method: "item/agentMessage/delta",
+      params: {
+        delta: "x",
+        itemId: "message-" + index,
+        threadId: "thread-child-" + (index % 2),
+        turnId: "turn-child-" + (index % 2)
+      }
+    }) + "\\n");
   }
 });
 setInterval(() => {}, 1000);
 `,
-      async () => notificationGate,
+      async () => {
+        handled += 1;
+        if (handled === 1) {
+          firstNotification.resolve();
+          await notificationGate.promise;
+        }
+      },
     );
 
     try {
       await harness.client.start();
+      await firstNotification.promise;
+      await Bun.sleep(25);
+      expect(harness.protocolErrors).toEqual([]);
 
-      for (let attempt = 0; attempt < 50 && harness.protocolErrors.length === 0; attempt += 1) {
-        await Bun.sleep(10);
-      }
-
-      expect(harness.protocolErrors).toHaveLength(1);
-      expect(harness.protocolErrors[0]?.message).toBe("App-server message queue limit exceeded.");
+      notificationGate.resolve();
+      await harness.client.drainServerMessages();
+      expect(handled).toBe(2048);
+      expect(harness.protocolErrors).toEqual([]);
     } finally {
-      (releaseNotification as (() => void) | null)?.();
+      notificationGate.resolve();
       await harness.client.stop();
       await harness.logger.destroy();
     }

--- a/tests/openai-app-server-provider-fixtures.test.ts
+++ b/tests/openai-app-server-provider-fixtures.test.ts
@@ -36,6 +36,7 @@ interface TrackTurnFixture {
 interface ProviderFixtureCase {
   readonly expectedEvents: readonly unknown[];
   readonly notifications: readonly ProviderNotificationFixture[];
+  readonly trackTurnBeforeNotifications?: TrackTurnFixture | undefined;
   readonly trackTurnAfterNotifications?: TrackTurnFixture | undefined;
 }
 
@@ -44,6 +45,7 @@ const providerFixtureNames = [
   "command-output-stream",
   "error-before-tracked-turn",
   "reasoning-empty-summary",
+  "root-with-parallel-child-turns",
   "turn-completed-with-final-agent-message",
   "turn-plan-updated",
   "unknown-notification-ignored",
@@ -113,6 +115,7 @@ function readProviderFixtureCase(path: string): ProviderFixtureCase {
   return {
     expectedEvents,
     notifications: notifications.map(readProviderNotificationFixture),
+    trackTurnBeforeNotifications: readTrackTurnFixture(fixture["trackTurnBeforeNotifications"]),
     trackTurnAfterNotifications: readTrackTurnFixture(fixture["trackTurnAfterNotifications"]),
   };
 }
@@ -364,10 +367,23 @@ describe("OpenAI app-server provider fixtures", () => {
     );
     const { bridge, context, events, logger } = createHarness();
 
+    const trackedTurn = fixture.trackTurnBeforeNotifications;
+    const trackedCompletion =
+      trackedTurn === undefined
+        ? null
+        : bridge.trackTurn(trackedTurn.turnId, DRIVER_TEST_IDS.runId);
+
     for (const notification of fixture.notifications) {
       await dispatchProviderNotification(notification, bridge, context);
     }
 
+    if (trackedCompletion !== null) {
+      if (trackedTurn?.expectation === "reject") {
+        await expect(trackedCompletion).rejects.toThrow();
+      } else {
+        await expect(trackedCompletion).resolves.toBeUndefined();
+      }
+    }
     await assertTrackTurnFixture(bridge, fixture.trackTurnAfterNotifications);
     await logger.destroy();
 


### PR DESCRIPTION
## Summary

- scope authoritative OpenAI Run lifecycle and assistant transcript events to the root app-server thread, excluding native Codex child threads
- preserve root `collabAgentToolCall` and `subAgentActivity` items as provider-native Agent tool activity
- apply stdout high/low-water backpressure so bounded multi-agent bursts drain without tripping the former 1,024-message queue failure
- add a deterministic root-plus-two-parallel-children fixture covering one start, one terminal, parent final output, and ignored late child mutation

## Testing

- `vp check`
- `vp exec tsc`
- `vp exec bun test tests/openai-app-server-provider-fixtures.test.ts tests/openai-app-server-event-bridge-items.test.ts tests/openai-app-server-event-bridge-run-lifecycle.test.ts tests/openai-app-server-event-bridge-terminal.test.ts tests/openai-app-server-event-bridge-transcript.test.ts` (61 passed)
- `vp exec bun test tests/openai-app-server-client.test.ts --test-name-pattern 'applies backpressure'`
- `vp run build`
- `vp run check` reaches the full test suite but this macOS workspace has three unrelated ACP process-watchdog tests timing out while waiting for fixture PID files; all changed OpenAI scopes above pass

Fixes langgenius/mosoo#553

Closes YEF-1053
