### PR TITLE
fix(runtime): preserve v1 production parity on v2

### DIFF
--- a/src/runtimes/acp/acp-configuration.ts
+++ b/src/runtimes/acp/acp-configuration.ts
@@ -1,5 +1,6 @@
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 import type { AgentCapabilities, ClientCapabilities, McpServer } from "@agentclientprotocol/sdk";
+import { basename } from "node:path";
 
 import type { DriverExecutionSessionContext } from "../../protocol/boot";
 import type { DriverStartInput } from "../../protocol/start";
@@ -28,6 +29,46 @@ export function readFallbackCommand(): string {
   return typeof command === "string" && command.trim().length > 0
     ? command.trim()
     : ACP_DEFAULT_COMMAND;
+}
+
+export function isOpenCodeCommand(command: string): boolean {
+  const executable = basename(command).toLowerCase();
+  return executable === "opencode" || executable === "opencode.exe";
+}
+
+export function appendOpenCodeInstruction(
+  env: Record<string, string>,
+  instructionPath: string,
+): Record<string, string> {
+  const rawConfig = env["OPENCODE_CONFIG_CONTENT"];
+  const parsed: unknown = rawConfig === undefined ? {} : JSON.parse(rawConfig);
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("OPENCODE_CONFIG_CONTENT must be a JSON object.");
+  }
+
+  const config = parsed as Record<string, unknown>;
+  const currentInstructions = config["instructions"];
+
+  if (
+    currentInstructions !== undefined &&
+    (!Array.isArray(currentInstructions) ||
+      !currentInstructions.every((entry) => typeof entry === "string"))
+  ) {
+    throw new Error("OPENCODE_CONFIG_CONTENT instructions must be a string array.");
+  }
+
+  const instructions = currentInstructions ?? [];
+
+  return {
+    ...env,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      ...config,
+      instructions: instructions.includes(instructionPath)
+        ? instructions
+        : [...instructions, instructionPath],
+    }),
+  };
 }
 
 export function readFallbackArgs(): string[] {

--- a/src/runtimes/acp/acp-driver-backend.ts
+++ b/src/runtimes/acp/acp-driver-backend.ts
@@ -26,6 +26,7 @@ import { DriverEventPublisher } from "../driver-event-publisher";
 import {
   buildRuntimeBootstrapText,
   computeRuntimeBootstrapDigest,
+  writeNativeRuntimeSystemPrompt,
   writeSkillBootstrapArtifacts,
 } from "../skill-bootstrap";
 import { exposeNativeSkillAliases } from "../skill-materialization";
@@ -35,9 +36,11 @@ import { AcpClientRequestHandler } from "./acp-client-request-handler";
 import { limitAcpInput } from "./acp-input-limit";
 import {
   ACP_PROTOCOL_VERSION,
+  appendOpenCodeInstruction,
   buildChildEnv,
   buildClientCapabilities,
   assertProtocolVersion,
+  isOpenCodeCommand,
   readFallbackArgs,
   readFallbackCommand,
   readResumeId,
@@ -73,6 +76,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
   readonly #eventPublisher = new DriverEventPublisher(this.runtime, () => this.#nativeSessionId);
   #hostSnapshot: DriverHostIntegrationSnapshot | null = null;
   #nativeSessionId: string | null = null;
+  #nativeInstructionPath: string | null = null;
   readonly #payload: DriverStartInput;
   readonly #runtimeBootstrapDigest: string | null;
   readonly #runtimeBootstrapText: string;
@@ -128,6 +132,13 @@ export class AcpDriverBackend implements AgentDriverBackend {
       writeSkillBootstrapArtifacts(this.#payload.execution),
       signal,
     );
+    const launch = (this.#agentLaunch ??= {
+      args: readFallbackArgs(),
+      command: readFallbackCommand(),
+    });
+    this.#nativeInstructionPath = isOpenCodeCommand(launch.command)
+      ? await raceWithAbort(writeNativeRuntimeSystemPrompt(this.#payload.execution), signal)
+      : null;
 
     if (this.#stopRequested || signal.aborted) {
       signal.throwIfAborted();
@@ -142,7 +153,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
 
       const setup = await this.#connect(context, signal, true);
 
-      if (setup.mode === "created") {
+      if (setup.mode === "created" && this.#nativeInstructionPath === null) {
         await withAcpStartupStage(
           "ACP runtime bootstrap",
           () => this.#applyBootstrap(context, signal),
@@ -167,6 +178,7 @@ export class AcpDriverBackend implements AgentDriverBackend {
           sharedRootPath: summarizePath(this.#payload.execution.session.sharedRootPath),
         },
         nativeResumeRefPresent: this.#nativeSessionId !== null,
+        nativeInstructions: this.#nativeInstructionPath !== null,
         nativeSkillAliasCount: nativeSkillAliases.length,
         skillCount: materializedSkills.length,
       });
@@ -198,10 +210,14 @@ export class AcpDriverBackend implements AgentDriverBackend {
       args: readFallbackArgs(),
       command: readFallbackCommand(),
     });
+    const processEnv =
+      this.#nativeInstructionPath === null
+        ? this.#childProcessEnv
+        : appendOpenCodeInstruction(this.#childProcessEnv, this.#nativeInstructionPath);
     const agentProcess = await startAcpAgentProcess(
       context,
       this.#payload,
-      this.#childProcessEnv,
+      processEnv,
       signal,
       launch,
     );

--- a/src/runtimes/openai/app-server-client.ts
+++ b/src/runtimes/openai/app-server-client.ts
@@ -474,6 +474,10 @@ export class OpenAiAppServerClient {
         },
         signal,
       );
+      if (this.#stopRequested) {
+        return;
+      }
+
       this.notify("initialized", {});
     });
 

--- a/src/runtimes/skill-bootstrap.ts
+++ b/src/runtimes/skill-bootstrap.ts
@@ -167,6 +167,22 @@ export function buildNativeRuntimeSystemPrompt(execution: DriverExecutionInput):
   return bootstrap.length > 0 ? bootstrap : null;
 }
 
+export async function writeNativeRuntimeSystemPrompt(
+  execution: DriverExecutionInput,
+): Promise<string | null> {
+  const systemPrompt = buildNativeRuntimeSystemPrompt(execution);
+
+  if (systemPrompt === null) {
+    return null;
+  }
+
+  const path = join(execution.session.homePath, "runtime-instructions.md");
+  await mkdir(execution.session.homePath, { recursive: true });
+  await writeFile(path, `${systemPrompt}\n`, { encoding: "utf8", mode: 0o600 });
+
+  return path;
+}
+
 export function computeRuntimeBootstrapDigest(execution: DriverExecutionInput): string | null {
   const bootstrapText = buildRuntimeBootstrapText(execution);
 

--- a/tests/acp-configuration.test.ts
+++ b/tests/acp-configuration.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { createBufferedSinkLogger } from "../src/observability";
 import {
   ACP_PROTOCOL_VERSION,
+  appendOpenCodeInstruction,
   buildChildEnv,
   buildClientCapabilities,
   assertProtocolVersion,
+  isOpenCodeCommand,
   resolveAuthMethod,
   supportsAdditionalDirs,
   supportsSessionClose,
@@ -25,6 +27,35 @@ function createInitializeResult(protocolVersion: number | string | null) {
 }
 
 describe("ACP runtime configuration", () => {
+  test("adds a session instruction to OpenCode's inline config", () => {
+    const instructionPath = "/workspace/session/runtime-instructions.md";
+    const env = appendOpenCodeInstruction(
+      {
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          instructions: ["/managed/instructions.md"],
+          model: "deepseek/deepseek-v4-pro",
+        }),
+      },
+      instructionPath,
+    );
+
+    expect(isOpenCodeCommand("/usr/local/bin/opencode")).toBe(true);
+    expect(isOpenCodeCommand("opencode.exe")).toBe(true);
+    expect(isOpenCodeCommand("acp-agent")).toBe(false);
+    expect(JSON.parse(env["OPENCODE_CONFIG_CONTENT"] ?? "{}")).toEqual({
+      instructions: ["/managed/instructions.md", instructionPath],
+      model: "deepseek/deepseek-v4-pro",
+    });
+    expect(
+      JSON.parse(
+        appendOpenCodeInstruction(env, instructionPath)["OPENCODE_CONFIG_CONTENT"] ?? "{}",
+      ),
+    ).toEqual({
+      instructions: ["/managed/instructions.md", instructionPath],
+      model: "deepseek/deepseek-v4-pro",
+    });
+  });
+
   test("accepts the configured ACP protocol version only", () => {
     expect(() => assertProtocolVersion(createInitializeResult(ACP_PROTOCOL_VERSION))).not.toThrow();
     expect(() =>

--- a/tests/acp-driver-backend.test.ts
+++ b/tests/acp-driver-backend.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ClientContext } from "@agentclientprotocol/sdk";
 import { readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -29,9 +29,13 @@ const { appendFileSync, existsSync } = require("node:fs");
 const { spawn } = require("node:child_process");
 const logPath = process.env.TEST_LOG_PATH;
 const latePidPath = process.env.TEST_LATE_PID_PATH;
+const openCodeConfigPath = process.env.TEST_OPENCODE_CONFIG_PATH;
 const responsePath = process.env.TEST_RESPONSE_PATH;
 const resumeGatePath = process.env.TEST_RESUME_GATE_PATH;
 const triggerPath = process.env.TEST_TRIGGER_PATH;
+if (openCodeConfigPath) {
+  appendFileSync(openCodeConfigPath, process.env.OPENCODE_CONFIG_CONTENT || "");
+}
 let buffer = "";
 let sessionReady = false;
 let updateSent = false;
@@ -319,6 +323,7 @@ async function createHarness(
     readonly blockResume?: boolean;
     readonly failResume?: boolean;
     readonly hangClose?: boolean;
+    readonly openCodeInstructions?: boolean;
     onEvents?(events: readonly DriverEventInput[]): void;
     readonly permission?: AgentDriverPermissionPort["request"];
     readonly spawnLateChild?: boolean;
@@ -328,17 +333,25 @@ async function createHarness(
   const root = await mkdtemp(join(tmpdir(), "driver-acp-backend-"));
   const logPath = join(root, "methods.log");
   const latePidPath = join(root, "late.pid");
+  const openCodeConfigPath = join(root, "opencode-config.json");
   const responsePath = join(root, "responses.log");
   const resumeGatePath = join(root, "resume-gate");
   const triggerPath = join(root, "send-update");
+  const command = options.openCodeInstructions ? join(root, "opencode") : process.execPath;
+
+  if (options.openCodeInstructions) {
+    await symlink(process.execPath, command);
+  }
   const boot = {
     ...driverBootPayload,
     execution: {
       ...driverBootPayload.execution,
       environment: {
         variables: {
+          ...(options.openCodeInstructions ? { OPENCODE_CONFIG_CONTENT: "{}" } : {}),
           TEST_LOG_PATH: logPath,
           TEST_LATE_PID_PATH: latePidPath,
+          TEST_OPENCODE_CONFIG_PATH: openCodeConfigPath,
           TEST_RESPONSE_PATH: responsePath,
           TEST_RESUME_GATE_PATH: resumeGatePath,
           TEST_TRIGGER_PATH: triggerPath,
@@ -350,6 +363,7 @@ async function createHarness(
           ...(options.authenticate ? { MOSOO_ACP_AUTH_METHOD_ID: "test-auth" } : {}),
         },
       },
+      profilePrompt: options.openCodeInstructions ? "Always answer concisely." : "",
       session: {
         ...driverBootPayload.execution.session,
         context: {
@@ -418,7 +432,7 @@ async function createHarness(
   const backend = new AcpDriverBackend(payload);
   const previousCommand = process.env["MOSOO_ACP_FALLBACK_COMMAND"];
   const previousArgs = process.env["MOSOO_ACP_FALLBACK_ARGS"];
-  process.env["MOSOO_ACP_FALLBACK_COMMAND"] = process.execPath;
+  process.env["MOSOO_ACP_FALLBACK_COMMAND"] = command;
   process.env["MOSOO_ACP_FALLBACK_ARGS"] = JSON.stringify(["-e", FAKE_AGENT]);
 
   try {
@@ -461,6 +475,11 @@ async function createHarness(
     async methods() {
       return (await readFile(logPath, "utf8")).trim().split("\n").filter(Boolean);
     },
+    async openCodeConfig() {
+      return JSON.parse(await readFile(openCodeConfigPath, "utf8")) as {
+        instructions?: unknown;
+      };
+    },
     async responses() {
       return (await readFile(responsePath, "utf8").catch(() => ""))
         .trim()
@@ -474,6 +493,20 @@ async function createHarness(
 }
 
 describe("ACP driver backend lifecycle", () => {
+  test("uses OpenCode native instructions without a hidden bootstrap prompt", async () => {
+    const harness = await createHarness({ openCodeInstructions: true });
+
+    try {
+      expect(await harness.methods()).not.toContain("session/prompt");
+      const config = await harness.openCodeConfig();
+      expect(config.instructions).toEqual([expect.any(String)]);
+      const [instructionPath] = config.instructions as [string];
+      expect(await readFile(instructionPath, "utf8")).toContain("Always answer concisely.");
+    } finally {
+      await harness.destroy();
+    }
+  });
+
   test("buffers an update sent before the new-session response", async () => {
     const harness = await createHarness({ updateBeforeSessionResponse: true });
 


### PR DESCRIPTION
## Summary

- stop OpenAI initialization from notifying after shutdown starts
- preserve OpenCode native instruction delivery through `OPENCODE_CONFIG_CONTENT`
- cover both compatibility paths with focused tests

## V1 compatibility audit

Compared all 13 commits unique to `fix-event-delivery-timeout-v1-driver` against V2 `main`. Eleven are already present or superseded in V2. These two semantic fixes were missing and are ported here. Native SubAgent lifecycle isolation is already on V2 in #113.

## Verification

- `bun run tc`
- `bun run build`
- focused OpenCode native-instruction, OpenAI startup/shutdown, backpressure, and parallel-child lifecycle tests
- `bun run check`: 1218 pass, 61 skip, 12 fail, 1 error on macOS; failures are existing process-tree watchdog/timing cases and need Linux CI confirmation

No protocol shape changes and no V1 scheduler/backcompat layer are introduced.