### PR TITLE
fix(openai): preserve V1 additional-directory compatibility

### DIFF
--- a/src/runtimes/provider-registry.ts
+++ b/src/runtimes/provider-registry.ts
@@ -142,13 +142,6 @@ function resolveProviderForStartInput(
     throw new Error(`Runtime ${provider.runtime} does not support built-in tool restrictions.`);
   }
 
-  if (
-    provider.runtime === "openai-runtime" &&
-    input.execution.session.additionalDirectories.length > 0
-  ) {
-    throw new Error("Runtime openai-runtime does not support additional directories.");
-  }
-
   return provider;
 }
 

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -158,10 +158,10 @@ describe("provider registry", () => {
     ).toBe("claude-agent-sdk");
   });
 
-  test("rejects OpenAI additional directories", () => {
+  test("preserves v1 compatibility when OpenAI receives additional directories", () => {
     const input = startInputFor("openai-app-server");
 
-    expect(() =>
+    expect(
       AGENT_DRIVER_PROVIDER_REGISTRY.getByStartInput({
         ...input,
         execution: {
@@ -171,8 +171,8 @@ describe("provider registry", () => {
             additionalDirectories: ["/tmp/shared"],
           },
         },
-      }),
-    ).toThrow("Runtime openai-runtime does not support additional directories.");
+      }).runtime,
+    ).toBe("openai-runtime");
   });
 
   test.each(["claude-agent-sdk", "acp-fallback"] as const)(


### PR DESCRIPTION
## Why
Production V1 agents may carry `execution.session.additionalDirectories` even when using the Codex/OpenAI runtime. V1 ignored this field; V2 rejected the entire Driver before ready, breaking otherwise valid existing agents.

## Change
Keep the input contract intact and restore V1 behavior for OpenAI. Claude and ACP continue consuming supported additional directories; OpenAI continues using its session `cwd`. No OpenWiki-specific behavior is added.

## Verification
- `bun test tests/provider-registry.test.ts` (14 passed)
- `bun run tc`
- `bun run build`
- `git diff --check`

## Production evidence
V2 startup failed with: `Runtime openai-runtime does not support additional directories.` The same agent parameters work on V1.