### PR TITLE
fix(protocol): preserve V1 attachment input compatibility

### DIFF
--- a/src/runtime-command/index.ts
+++ b/src/runtime-command/index.ts
@@ -184,9 +184,14 @@ function readOptionalString(record: Record<string, unknown>, field: string): str
 
 function readRuntimeCommandInput(value: unknown): RuntimeCommandInput {
   const record = readRecord(value, "input");
+  const attachmentIds = record["attachmentIds"];
 
-  if ("attachmentIds" in record) {
-    throw new TypeError("input.attachmentIds is unsupported.");
+  if (
+    attachmentIds !== undefined &&
+    (!Array.isArray(attachmentIds) ||
+      attachmentIds.some((id) => typeof id !== "string" || id.length === 0))
+  ) {
+    throw new TypeError("input.attachmentIds must be an array of non-empty strings.");
   }
 
   return {

--- a/tests/driver-golden-fixtures.test.ts
+++ b/tests/driver-golden-fixtures.test.ts
@@ -47,7 +47,20 @@ describe("Driver golden fixtures", () => {
     expect(parseRuntimeCommand(fixture)).toEqual(fixture);
   });
 
-  test("rejects unsupported input attachments", () => {
+  test("preserves v1 compatibility for API-materialized input attachments", () => {
+    const fixture = readJsonFixture("./fixtures/driver/commands/input-start.json") as {
+      readonly input: Record<string, unknown>;
+    };
+
+    expect(
+      parseRuntimeCommand({
+        ...fixture,
+        input: { ...fixture.input, attachmentIds: ["file-1"] },
+      }),
+    ).toEqual(fixture);
+  });
+
+  test("rejects malformed input attachment IDs", () => {
     const fixture = readJsonFixture("./fixtures/driver/commands/input-start.json") as {
       readonly input: Record<string, unknown>;
     };
@@ -55,9 +68,9 @@ describe("Driver golden fixtures", () => {
     expect(() =>
       parseRuntimeCommand({
         ...fixture,
-        input: { ...fixture.input, attachmentIds: [] },
+        input: { ...fixture.input, attachmentIds: [""] },
       }),
-    ).toThrow("input.attachmentIds is unsupported.");
+    ).toThrow("input.attachmentIds must be an array of non-empty strings.");
   });
 
   test.each(runtimeEventFixtures)("ingests runtime event fixture %s", (name) => {


### PR DESCRIPTION
## Why
The API materializes attached files into the sandbox before `input.start`, but retains `input.attachmentIds` as durable provenance. V1 accepted this shape; V2 rejected the whole Run before the runtime saw the prompt.

## Change
Validate attachment IDs at the Driver trust boundary, then preserve V1 behavior by projecting the provider-neutral runtime input to text. No product-specific case is added.

## Verification
- `bun test tests/driver-golden-fixtures.test.ts` (13 passed)
- `bun run tc`
- `bun run build`
- `git diff --check`

## Production evidence
A Protocol V2 OpenAI Driver reached ready, then an attachment-backed OpenWiki Run failed with `input.attachmentIds is unsupported.`