### PR TITLE
fix(acp): complete empty end turns

### DIFF
--- a/src/runtimes/acp/acp-assistant-transcript-state.ts
+++ b/src/runtimes/acp/acp-assistant-transcript-state.ts
@@ -134,10 +134,6 @@ export class AcpAssistantTranscriptState {
     }
 
     const finalMessage = this.#lastCompletedAssistantMessage;
-    const emptyTurn =
-      stopReason === "end_turn" &&
-      (finalMessage === null || finalMessage.text.trim().length === 0) &&
-      !this.#tools.hasActivity();
 
     if (stopReason === "cancelled") {
       events.push({
@@ -145,19 +141,6 @@ export class AcpAssistantTranscriptState {
         payload: {
           requestedBy: "user",
           stopReason: "cancelled",
-        },
-        runId,
-      });
-    } else if (emptyTurn) {
-      events.push({
-        kind: "run.failed",
-        payload: {
-          error: {
-            code: "acp.empty_turn",
-            message: "ACP prompt ended without assistant output or tool activity.",
-          },
-          recoverable: true,
-          stopReason,
         },
         runId,
       });

--- a/tests/acp-event-translator-lifecycle.test.ts
+++ b/tests/acp-event-translator-lifecycle.test.ts
@@ -149,7 +149,7 @@ describe("ACP runtime event translation", () => {
     );
   });
 
-  test("uses a later identified final after anonymous progress, but fails closed for an anonymous final", () => {
+  test("uses a later identified final and preserves anonymous message boundaries", () => {
     const state = new AcpTurnEventState();
 
     state.begin({
@@ -219,7 +219,7 @@ describe("ACP runtime event translation", () => {
       }),
       ...anonymousFinalState.completePrompt("end_turn", null),
     ];
-    const anonymousFailed = requireEvent(anonymousFinalEvents, "run.failed");
+    const anonymousCompleted = requireEvent(anonymousFinalEvents, "run.completed");
     const firstAnonymousDelta = requireEvent(
       anonymousFinalEvents.filter(
         (event) =>
@@ -240,11 +240,7 @@ describe("ACP runtime event translation", () => {
     expect(eventPayloadString(firstAnonymousDelta, "messageId")).not.toBe(
       eventPayloadString(finalAnonymousDelta, "messageId"),
     );
-    expect(eventPayload(anonymousFailed)).toMatchObject({
-      error: {
-        code: "acp.empty_turn",
-      },
-      recoverable: true,
+    expect(eventPayload(anonymousCompleted)).toMatchObject({
       stopReason: "end_turn",
     });
   });

--- a/tests/acp-event-translator-session-update.test.ts
+++ b/tests/acp-event-translator-session-update.test.ts
@@ -144,30 +144,14 @@ describe("ACP runtime event translation", () => {
     });
   });
 
-  test("fails an empty end turn instead of reporting a blank completed run", () => {
+  test("completes an empty end turn", () => {
     const state = new AcpTurnEventState();
+    state.begin({ messageId: "message-1", runId: RUN_ID, sessionId: "session-1" });
 
-    state.begin({
-      messageId: "message-1",
-      runId: RUN_ID,
-      sessionId: "session-1",
-    });
+    const events = state.completePrompt("end_turn", null);
 
-    const events = state.completePrompt("end_turn", {
-      inputTokens: 0,
-      outputTokens: 0,
-      totalTokens: 0,
-    });
-
-    expect(eventKinds(events)).toEqual(["usage.updated", "run.failed"]);
-    expect(eventPayload(events[1]!)).toMatchObject({
-      error: {
-        code: "acp.empty_turn",
-        message: "ACP prompt ended without assistant output or tool activity.",
-      },
-      recoverable: true,
-      stopReason: "end_turn",
-    });
+    expect(eventKinds(events)).toEqual(["run.completed"]);
+    expect(eventPayload(events[0]!)).toMatchObject({ stopReason: "end_turn" });
   });
 
   test("ignores ACP user message echo chunks because driver input is the source of truth", () => {
@@ -301,7 +285,7 @@ describe("ACP runtime event translation", () => {
     expect(eventPayloadString(completed, "finalMessageText")).not.toContain(progressText);
   });
 
-  test("fails closed when an anonymous thought follows identified progress", () => {
+  test("completes end_turn when an anonymous thought follows identified progress", () => {
     const state = new AcpTurnEventState();
 
     state.begin({
@@ -326,7 +310,7 @@ describe("ACP runtime event translation", () => {
       }),
       ...state.completePrompt("end_turn", null),
     ];
-    const failed = requireEvent(events, "run.failed");
+    const completed = requireEvent(events, "run.completed");
 
     expect(eventKinds(events)).toEqual([
       "message.started",
@@ -335,13 +319,9 @@ describe("ACP runtime event translation", () => {
       "thought.started",
       "thought.delta",
       "thought.completed",
-      "run.failed",
+      "run.completed",
     ]);
-    expect(eventPayload(failed)).toMatchObject({
-      error: {
-        code: "acp.empty_turn",
-      },
-      recoverable: true,
+    expect(eventPayload(completed)).toMatchObject({
       stopReason: "end_turn",
     });
   });

--- a/tests/fixtures/providers/acp/cases/thought-and-unknown-update.json
+++ b/tests/fixtures/providers/acp/cases/thought-and-unknown-update.json
@@ -70,13 +70,8 @@
       "runId": "run-1"
     },
     {
-      "kind": "run.failed",
+      "kind": "run.completed",
       "payload": {
-        "error": {
-          "code": "acp.empty_turn",
-          "message": "ACP prompt ended without assistant output or tool activity."
-        },
-        "recoverable": true,
         "stopReason": "end_turn"
       },
       "runId": "run-1"


### PR DESCRIPTION
## Summary

- treat an empty ACP `end_turn` as a successful `run.completed`
- preserve ACP 1.2.1 semantics for `max_tokens`, `max_turn_requests`, `refusal`, and `cancelled`
- keep protocol and process exceptions on the existing failure path

## Verification

- `bun test tests/acp-event-translator-session-update.test.ts tests/acp-event-translator-lifecycle.test.ts tests/acp-provider-fixtures.test.ts tests/acp-driver-backend.test.ts` — 51 passed
- `bun test tests/acp-v1-contract-adapter-mapping.test.ts` — 12 passed, including request-limit finish semantics
- `bun run tc` — passed
- `bun run build` — passed
- `git diff --check` — passed
